### PR TITLE
grafana - set per-release PodDisruptionBudget name

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.6.1
+version: 5.6.3
 appVersion: 7.1.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,12 +1,7 @@
 apiVersion: v1
 name: grafana
-<<<<<<< HEAD
 version: 5.6.3
-appVersion: 7.1.1
-=======
-version: 5.6.2
 appVersion: 7.1.5
->>>>>>> upstream/main
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/charts/grafana/templates/poddisruptionbudget.yaml
+++ b/charts/grafana/templates/poddisruptionbudget.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ template "grafana.name" . }}
+  name: {{ template "grafana.fullname" . }}
   namespace: {{ template "grafana.namespace" . }}
   labels:
     {{- include "grafana.labels" . | nindent 4 }}


### PR DESCRIPTION

the default PodDisruptionBudget name is `grafana` . Attempting to install 2 grafana releases in the same namespace results in the following exception:
```
Error: rendered manifests contain a resource that already exists. Unable to continue with install: existing resource conflict: namespace: monitoring, name: grafana, existing_kind: policy/v1beta1, Kind=PodDisruptionBudget, new_kind: policy/v1beta1, Kind=PodDisruptionBudget
```
This change updates the name to `grafana-RELEASE`

Signed-off-by: S.Cavallo <smcavallo@hotmail.com>