### PR TITLE
grafana - add support for prometheus serviceMonitor

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.6.1
+version: 5.6.4
 appVersion: 7.1.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -178,6 +178,13 @@ You have to add --force to your helm upgrade command as the labels of the chart 
 | `downloadDashboardsImage.sha`             | Curl docker image sha (optional)              | `""`                                                    |
 | `downloadDashboardsImage.pullPolicy`      | Curl docker image pull policy                 | `IfNotPresent`                                          |
 | `namespaceOverride`                       | Override the deployment namespace             | `""` (`Release.Namespace`)                              |
+| `serviceMonitor.enabled`                  | Use servicemonitor from prometheus operator   | `false`                                                 |
+| `serviceMonitor.namespace`                | Namespace this servicemonitor is installed in |                                                         |
+| `serviceMonitor.interval`                 | How frequently Prometheus should scrape       | `1m`                                                    |
+| `serviceMonitor.path`                     | Path to scrape                                | `/metrics`                                              |
+| `serviceMonitor.labels`                   | Labels for the servicemonitor passed to Prometheus Operator      |  `{}`                                |
+| `serviceMonitor.scrapeTimeout`            | Timeout after which the scrape is ended       | `30s`                                                   |
+| `serviceMonitor.relabelings`              | MetricRelabelConfigs to apply to samples before ingestion.  | `[]`                                      |
 
 ### Example ingress with path
 

--- a/charts/grafana/templates/servicemonitor.yaml
+++ b/charts/grafana/templates/servicemonitor.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "grafana.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- include "grafana.labels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.labels }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+  - interval: {{ .Values.serviceMonitor.interval }}
+    {{- if .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    honorLabels: true
+    port: {{ .Values.service.portName }}
+    path: {{ .Values.serviceMonitor.path }}
+    scheme: {{ .Values.serviceMonitor.scheme }}
+    {{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
+  jobLabel: "{{ .Release.Name }}"
+  selector:
+    matchLabels:
+      app: {{ template "grafana.name" . }}
+      release: "{{ .Release.Name }}"
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/grafana/templates/servicemonitor.yaml
+++ b/charts/grafana/templates/servicemonitor.yaml
@@ -21,7 +21,6 @@ spec:
     honorLabels: true
     port: {{ .Values.service.portName }}
     path: {{ .Values.serviceMonitor.path }}
-    scheme: {{ .Values.serviceMonitor.scheme }}
     {{- if .Values.serviceMonitor.relabelings }}
     relabelings:
     {{- toYaml .Values.serviceMonitor.relabelings | nindent 4 }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -124,6 +124,19 @@ service:
   labels: {}
   portName: service
 
+serviceMonitor:
+  ## If true, a ServiceMonitor CRD is created for a prometheus operator
+  ## https://github.com/coreos/prometheus-operator
+  ##
+  enabled: false
+  path: /metrics
+  #  namespace: monitoring
+  labels: {}
+  interval: 5m
+  scrapeTimeout: 30s
+  scheme: http
+  relabelings: []
+
 extraExposePorts: []
  # - name: keycloak
  #   port: 8080

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -130,7 +130,7 @@ serviceMonitor:
   ##
   enabled: false
   path: /metrics
-  #  namespace: monitoring
+  #  namespace: monitoring  (defaults to use the namespace this chart is deployed to)
   labels: {}
   interval: 1m
   scrapeTimeout: 30s

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -132,9 +132,8 @@ serviceMonitor:
   path: /metrics
   #  namespace: monitoring
   labels: {}
-  interval: 5m
+  interval: 1m
   scrapeTimeout: 30s
-  scheme: http
   relabelings: []
 
 extraExposePorts: []


### PR DESCRIPTION
add support for optional prometheus serviceMonitor

This is a pattern that is pretty standard across helm charts.  Some examples:
https://github.com/helm/charts/blob/master/stable/prometheus-redis-exporter/templates/servicemonitor.yaml
https://github.com/helm/charts/blob/master/stable/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
https://github.com/helm/charts/blob/master/stable/coredns/templates/servicemonitor.yaml
It would be helpful to have this built into the grafana helm chart as well for ease of monitoring.

Signed-off-by: S.Cavallo <smcavallo@hotmail.com>