### PR TITLE
grafana chart: Add option foldersFromFilesStructure

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.6.3
+version: 5.6.4
 appVersion: 7.1.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -137,6 +137,7 @@ You have to add --force to your helm upgrade command as the labels of the chart 
 | `sidecar.dashboards.provider.disableDelete` | Activate to avoid the deletion of imported dashboards | `false`                                       |
 | `sidecar.dashboards.provider.allowUiUpdates` | Allow updating provisioned dashboards from the UI | `false`                                          |
 | `sidecar.dashboards.provider.type`        | Provider type                                 | `file`                                                  |
+| `sidecar.dashboards.provider.foldersFromFilesStructure`        | Allow Grafana to replicate dashboard structure from filesystem.                                 | `false`                                                  |
 | `sidecar.dashboards.watchMethod`          | Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds. | `WATCH` |
 | `sidecar.skipTlsVerify`                   | Set to true to skip tls verification for kube api calls | `nil`                                         |
 | `sidecar.dashboards.label`                | Label that config maps with dashboards should have to be added | `grafana_dashboard`                                |

--- a/charts/grafana/templates/configmap-dashboard-provider.yaml
+++ b/charts/grafana/templates/configmap-dashboard-provider.yaml
@@ -21,5 +21,6 @@ data:
       disableDeletion: {{ .Values.sidecar.dashboards.provider.disableDelete }}
       allowUiUpdates: {{ .Values.sidecar.dashboards.provider.allowUiUpdates }}
       options:
+        foldersFromFilesStructure: {{ .Values.sidecar.dashboards.provider.foldersFromFilesStructure }}
         path: {{ .Values.sidecar.dashboards.folder }}{{- with .Values.sidecar.dashboards.defaultFolderName }}/{{ . }}{{- end }}
 {{- end}}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -515,6 +515,8 @@ sidecar:
       disableDelete: false
       # allow updating provisioned dashboards from the UI
       allowUiUpdates: false
+      # allow Grafana to replicate dashboard structure from filesystem
+      foldersFromFilesStructure: false
   datasources:
     enabled: false
     # label that the configmaps with datasources are marked with


### PR DESCRIPTION
This adds a option `foldersFromFilesStructure`. It allows grafana to
replicate filesystem structure of json files in the dashboard.

More info about the feature:
https://grafana.com/docs/grafana/latest/administration/provisioning/#provision-folders-structure-from-filesystem-to-grafana

Fixes: #11 