### PR TITLE
Fixing Github API URL

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.6.4
+version: 5.6.5
 appVersion: 7.1.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -437,7 +437,7 @@ grafana.ini:
  #    scopes: user:email,read:org
  #    auth_url: https://github.com/login/oauth/authorize
  #    token_url: https://github.com/login/oauth/access_token
- #    api_url: https://github.com/user
+ #    api_url: https://api.github.com/user
  #    team_ids:
  #    allowed_organizations:
  #    client_id:


### PR DESCRIPTION
https://grafana.com/docs/grafana/latest/auth/github/ has the correct URL, fixing it in the chart as OAurth will never work with the current URL.