### PR TITLE
Add example on how to use secrets in grafana.ini

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.6.4
+version: 5.6.5
 appVersion: 7.1.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -423,3 +423,42 @@ grafana.ini:
   server:
     root_url: http://localhost:3000/grafana # this host can be localhost
 ```
+
+## How to securely reference secrets in grafana.ini
+
+This example uses Grafana uses [file providers](https://grafana.com/docs/grafana/latest/administration/configuration/#file-provider) for secret values and the `extraSecretMounts` configuration flag (Additional grafana server secret mounts) to mount the secrets.
+
+In grafana.ini:
+
+```yaml
+grafana.ini:
+  [auth.generic_oauth]
+  enabled = true
+  client_id = $__file{/etc/secrets/auth_generic_oauth/client_id}
+  client_secret = $__file{/etc/secrets/auth_generic_oauth/client_secret}
+```
+
+Existing secret, or created along with helm:
+
+```yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: auth-generic-oauth-secret
+type: Opaque
+stringData:
+  client_id: <value>
+  client_secret: <value>
+```
+
+Include in the `extraSecretMounts` configuration flag:
+
+```yaml
+- extraSecretMounts:
+  - name: auth-generic-oauth-secret-mount
+     secretName: auth-generic-oauth-secret
+     defaultMode: 0440
+     mountPath: /etc/secrets/auth_generic_oauth
+     readOnly: true
+```


### PR DESCRIPTION
This PR adds an example on how to securely reference secrets in grafana.ini. Originally requested [here](https://github.com/helm/charts/issues/22473#issuecomment-662361020).

Adding to README to increase visibility.