### PR TITLE
Fix deprecated APIs

### DIFF
--- a/charts/grafana/templates/role.yaml
+++ b/charts/grafana/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "grafana.fullname" . }}

--- a/charts/grafana/templates/rolebinding.yaml
+++ b/charts/grafana/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "grafana.fullname" . }}


### PR DESCRIPTION
Fixed this linting errors:
```
$ helm lint charts/grafana/ --values charts/grafana/values.yaml 
==> Linting charts/grafana/
[ERROR] templates/role.yaml: the kind "rbac.authorization.k8s.io/v1beta1 Role" is deprecated in favor of "rbac.authorization.k8s.io/v1 Role"
[ERROR] templates/rolebinding.yaml: the kind "rbac.authorization.k8s.io/v1beta1 RoleBinding" is deprecated in favor of "rbac.authorization.k8s.io/v1 RoleBinding"

Error: 1 chart(s) linted, 1 chart(s) failed
```