### PR TITLE
add envFromSecret parameter for datasources sidecar

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.6.8
+version: 5.6.9
 appVersion: 7.2.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -147,6 +147,7 @@ You have to add --force to your helm upgrade command as the labels of the chart 
 | `sidecar.datasources.enabled`             | Enables the cluster wide search for datasources and adds/updates/deletes them in grafana |`false`       |
 | `sidecar.datasources.label`               | Label that config maps with datasources should have to be added | `grafana_datasource`                               |
 | `sidecar.datasources.searchNamespace`     | If specified, the sidecar will search for datasources config-maps inside this namespace. Otherwise the namespace in which the sidecar is running will be used. It's also possible to specify ALL to search in all namespaces | `nil`                               |
+| `sidecar.datasources.envFromSecret`       | Name of a Kubernetes secret (must be manually created in the same namespace) containing values to be added to the environment. Can be templated | `""` |
 | `sidecar.notifiers.enabled`               | Enables the cluster wide search for notifiers and adds/updates/deletes them in grafana |`false`       |
 | `sidecar.notifiers.label`                 | Label that config maps with notifiers should have to be added | `grafana_notifier`                               |
 | `sidecar.notifiers.searchNamespace`       | If specified, the sidecar will search for notifiers config-maps (or secrets) inside this namespace. Otherwise the namespace in which the sidecar is running will be used. It's also possible to specify ALL to search in all namespaces | `nil`                               |

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -78,6 +78,11 @@ initContainers:
     image: "{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}"
     {{- end }}
     imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+    {{- if .Values.sidecar.datasources.envFromSecret }}
+    envFrom:
+      - secretRef:
+          name: {{ tpl .Values.sidecar.datasources.envFromSecret . }}
+    {{- end }}
     env:
       - name: METHOD
         value: LIST

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -537,6 +537,10 @@ sidecar:
     # Otherwise the namespace in which the sidecar is running will be used.
     # It's also possible to specify ALL to search in all namespaces
     searchNamespace: null
+
+    ## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
+    ## This can be useful for database passwords, etc. Value is templated.
+    envFromSecret: ""
   notifiers:
     enabled: false
     # label that the configmaps with notifiers are marked with


### PR DESCRIPTION
Grafana config files [allow the use of environment variables](https://grafana.com/docs/grafana/latest/administration/provisioning/#using-environment-variables). This change allows a secret to be specified for the datasources sidecar. Its defined keys will then be made available to the sidecar via environment variables.