### PR TITLE
feat: add an image-renderer deployment

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.6.12
+version: 5.7.0
 appVersion: 7.2.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -191,6 +191,20 @@ You have to add --force to your helm upgrade command as the labels of the chart 
 | `serviceMonitor.scrapeTimeout`            | Timeout after which the scrape is ended       | `30s`                                                   |
 | `serviceMonitor.relabelings`              | MetricRelabelConfigs to apply to samples before ingestion.  | `[]`                                      |
 | `revisionHistoryLimit`                    | Number of old ReplicaSets to retain           | `10`                                                    |
+| `imageRenderer.enabled`                    | Enable the image-renderer deployment & service                                     | `false`                          |
+| `imageRenderer.image.repository`           | image-renderer Image repository                                                    | `grafana/grafana-image-renderer` |
+| `imageRenderer.image.tag`                  | image-renderer Image tag                                                           | `latest`                         |
+| `imageRenderer.image.sha`                  | image-renderer Image sha (optional)                                                | `""`                             |
+| `imageRenderer.image.pullPolicy`           | image-renderer ImagePullPolicy                                                     | `Always`                         |
+| `imageRenderer.securityContext`            | image-renderer deployment securityContext                                          | `{}`                             |
+| `imageRenderer.hostAliases`                | image-renderer deployment Host Aliases                                             | `[]`                             |
+| `imageRenderer.priorityClassName`          | image-renderer deployment priority class                                           | `''`                             |
+| `imageRenderer.service.portName`           | image-renderer service port name                                                   | `'http'`                         |
+| `imageRenderer.service.port`               | image-renderer service port used by both service and deployment                    | `8081`                           |
+| `imageRenderer.podPortName`                | name of the image-renderer port on the pod                                         | `http`                           |
+| `imageRenderer.revisionHistoryLimit`       | number of image-renderer replica sets to keep                                      | `10`                             |
+| `imageRenderer.networkPolicy.limitIngress` | Enable a NetworkPolicy to limit inbound traffic from only the created grafana pods  | `true`                           |
+| `imageRenderer.networkPolicy.limitEgress`  | Enable a NetworkPolicy to limit outbound traffic to only the created grafana pods   | `false`                          |
 
 ### Example ingress with path
 
@@ -467,3 +481,16 @@ Include in the `extraSecretMounts` configuration flag:
      mountPath: /etc/secrets/auth_generic_oauth
      readOnly: true
 ```
+
+## Image Renderer Plug-In
+
+This chart supports enabling [remote image rendering](https://github.com/grafana/grafana-image-renderer/blob/master/docs/remote_rendering_using_docker.md)
+
+```yaml
+imageRenderer:
+  enabled: true
+```
+
+### Image Renderer NetworkPolicy
+
+By default the image-renderer pods will have a network policy which only allows ingress traffic from the created grafana instance

--- a/charts/grafana/templates/_helpers.tpl
+++ b/charts/grafana/templates/_helpers.tpl
@@ -80,3 +80,23 @@ Selector labels
 app.kubernetes.io/name: {{ include "grafana.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "grafana.imageRenderer.labels" -}}
+helm.sh/chart: {{ include "grafana.chart" . }}
+{{ include "grafana.imageRenderer.selectorLabels" . }}
+{{- if or .Chart.AppVersion .Values.image.tag }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels ImageRenderer
+*/}}
+{{- define "grafana.imageRenderer.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "grafana.name" . }}-image-renderer
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -324,6 +324,12 @@ containers:
             name: {{ .Values.smtp.existingSecret }}
             key: {{ .Values.smtp.passwordKey | default "password" }}
       {{- end }}
+      {{ if .Values.imageRenderer.enabled }}
+      - name: GF_RENDERING_SERVER_URL
+        value: http://{{ template "grafana.fullname" . }}-image-renderer.{{ template "grafana.namespace" . }}:{{ .Values.imageRenderer.service.port }}/render
+      - name: GF_RENDERING_CALLBACK_URL
+        value: http://{{ template "grafana.fullname" . }}.{{ template "grafana.namespace" . }}:{{ .Values.service.port }}/
+      {{ end }}
     {{- range $key, $value := .Values.envValueFrom }}
       - name: {{ $key | quote }}
         valueFrom:

--- a/charts/grafana/templates/image-renderer-deployment.yaml
+++ b/charts/grafana/templates/image-renderer-deployment.yaml
@@ -1,0 +1,104 @@
+{{ if .Values.imageRenderer.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "grafana.fullname" . }}-image-renderer
+  namespace: {{ template "grafana.namespace" . }}
+  labels:
+    {{- include "grafana.imageRenderer.labels" . | nindent 4 }}
+{{- if .Values.imageRenderer.labels }}
+{{ toYaml .Values.imageRenderer.labels | indent 4 }}
+{{- end }}
+{{- with .Values.imageRenderer.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  replicas: {{ .Values.imageRenderer.replicas }}
+  revisionHistoryLimit: {{ .Values.imageRenderer.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "grafana.imageRenderer.selectorLabels" . | nindent 6 }}
+{{- with .Values.imageRenderer.deploymentStrategy }}
+  strategy:
+{{ toYaml . | trim | indent 4 }}
+{{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "grafana.imageRenderer.selectorLabels" . | nindent 8 }}
+{{- with .Values.imageRenderer.podLabels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- with .Values.imageRenderer.podAnnotations }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+    spec:
+
+      {{- if .Values.imageRenderer.schedulerName }}
+      schedulerName: "{{ .Values.imageRenderer.schedulerName }}"
+      {{- end }}
+      {{- if .Values.imageRenderer.securityContext }}
+      securityContext:
+      {{ toYaml .Values.imageRenderer.securityContext | indent 2 }}
+      {{- end }}
+      {{- if .Values.imageRenderer.hostAliases }}
+      hostAliases:
+      {{ toYaml .Values.imageRenderer.hostAliases | indent 2 }}
+      {{- end }}
+      {{- if .Values.imageRenderer.priorityClassName }}
+      priorityClassName: {{ .Values.imageRenderer.priorityClassName }}
+      {{- end }}
+      {{- if .Values.imageRenderer.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imageRenderer.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end}}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}-image-renderer
+          {{- if .Values.imageRenderer.image.sha }}
+          image: "{{ .Values.imageRenderer.image.repository }}:{{ .Values.imageRenderer.image.tag }}@sha256:{{ .Values.imageRenderer.image.sha }}"
+          {{- else }}
+          image: "{{ .Values.imageRenderer.image.repository }}:{{ .Values.imageRenderer.image.tag }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.imageRenderer.image.pullPolicy }}
+        {{- if .Values.imageRenderer.command }}
+          command:
+          {{- range .Values.imageRenderer.command }}
+            - {{ . }}
+          {{- end }}
+        {{- end}}
+          ports:
+            - name: {{ .Values.imageRenderer.service.portName }}
+              containerPort: {{ .Values.imageRenderer.service.port }}
+              protocol: TCP
+          env:
+            - name: HTTP_PORT
+              value: {{ .Values.imageRenderer.service.port | quote }}
+              securityContext:
+                capabilities:
+                  drop: ['all']
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /tmp
+              name: image-renderer-tmpfs
+      {{- with .Values.imageRenderer.nodeSelector }}
+      nodeSelector:
+      {{ toYaml . | indent 2 }}
+      {{- end }}
+      {{- with .Values.imageRenderer.affinity }}
+      affinity:
+      {{ toYaml . | indent 2 }}
+      {{- end }}
+      {{- with .Values.imageRenderer.tolerations }}
+      tolerations:
+      {{ toYaml . | indent 2 }}
+      {{- end }}
+      volumes:
+        - name: image-renderer-tmpfs
+          emptyDir: {}
+{{- end }}

--- a/charts/grafana/templates/image-renderer-network-policy.yaml
+++ b/charts/grafana/templates/image-renderer-network-policy.yaml
@@ -1,0 +1,78 @@
+{{- if and (.Values.imageRenderer.enabled) (.Values.imageRenderer.networkPolicy.limitIngress) }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "grafana.fullname" . }}-image-renderer-ingress
+  namespace: {{ template "grafana.namespace" . }}
+  annotations:
+    comment: Limit image-renderer ingress traffic from grafana
+spec:
+  podSelector:
+    matchLabels:
+  labels:
+    {{- include "grafana.imageRenderer.labels" . | nindent 4 }}
+    {{- if .Values.imageRenderer.labels }}
+      {{ toYaml .Values.imageRenderer.labels | nindent 4 }}
+    {{- end }}
+
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: {{ .Values.imageRenderer.service.port }}
+          protocol: TCP
+      from:
+        - namespaceSelector:
+            matchLabels:
+              name: {{ template "grafana.namespace" . }}
+          podSelector:
+            matchLabels:
+              {{- include "grafana.labels" . | nindent 14 }}
+              {{- if .Values.labels }}
+                {{ toYaml .Values.labels | nindent 4 }}
+              {{- end }}
+{{ end }}
+
+{{- if and (.Values.imageRenderer.enabled) (.Values.imageRenderer.networkPolicy.limitEgress) }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "grafana.fullname" . }}-image-renderer-egress
+  namespace: {{ template "grafana.namespace" . }}
+  annotations:
+    comment: Limit image-renderer egress traffic to grafana
+spec:
+  podSelector:
+    matchLabels:
+  labels:
+    {{- include "grafana.imageRenderer.labels" . | nindent 4 }}
+    {{- if .Values.imageRenderer.labels }}
+      {{ toYaml .Values.imageRenderer.labels | nindent 4 }}
+    {{- end }}
+
+  policyTypes:
+    - Egress
+  egress:
+    # allow dns resolution
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # talk only to grafana
+    - ports:
+        - port: {{ .Values.service.port }}
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              name: {{ template "grafana.namespace" . }}
+          podSelector:
+            matchLabels:
+              {{- include "grafana.labels" . | nindent 14 }}
+              {{- if .Values.labels }}
+                {{ toYaml .Values.labels | nindent 4 }}
+              {{- end }}
+{{ end }}

--- a/charts/grafana/templates/image-renderer-service.yaml
+++ b/charts/grafana/templates/image-renderer-service.yaml
@@ -1,0 +1,28 @@
+{{ if .Values.imageRenderer.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "grafana.fullname" . }}-image-renderer
+  namespace: {{ template "grafana.namespace" . }}
+  labels:
+    {{- include "grafana.imageRenderer.labels" . | nindent 4 }}
+{{- if .Values.imageRenderer.service.labels }}
+{{ toYaml .Values.imageRenderer.service.labels | indent 4 }}
+{{- end }}
+{{- with .Values.imageRenderer.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  type: ClusterIP
+  {{- if .Values.imageRenderer.service.clusterIP }}
+  clusterIP: {{ .Values.imageRenderer.service.clusterIP }}
+  {{end}}
+  ports:
+    - name: {{ .Values.imageRenderer.service.portName }}
+      port: {{ .Values.imageRenderer.service.port }}
+      protocol: TCP
+      targetPort: {{ .Values.imageRenderer.service.targetPort }}
+  selector:
+    {{- include "grafana.imageRenderer.selectorLabels" . | nindent 4 }}
+{{ end }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -553,3 +553,37 @@ namespaceOverride: ""
 ## Number of old ReplicaSets to retain
 ##
 revisionHistoryLimit: 10
+
+## Add a seperate remote image renderer deployment/service
+imageRenderer:
+  # Enable the image-renderer deployment & service
+  enabled: false
+  image:
+    # image-renderer Image repository
+    repository: grafana/grafana-image-renderer
+    # image-renderer Image tag
+    tag: latest
+    # image-renderer Image sha (optional)
+    sha: ""
+    # image-renderer ImagePullPolicy
+    pullPolicy: Always
+  # image-renderer deployment securityContext
+  securityContext: {}
+  # image-renderer deployment Host Aliases
+  hostAliases: []
+  # image-renderer deployment priority class
+  priorityClassName: ''
+  service:
+    # image-renderer service port name
+    portName: 'http'
+    # image-renderer service port used by both service and deployment
+    port: 8081
+  # name of the image-renderer port on the pod
+  podPortName: http
+  # number of image-renderer replica sets to keep
+  revisionHistoryLimit: 10
+  networkPolicy:
+    # Enable a NetworkPolicy to limit inbound traffic to only the created grafana pods
+    limitIngress: true
+    # Enable a NetworkPolicy to limit outbound traffic to only the created grafana pods
+    limitEgress: false


### PR DESCRIPTION
Sets up a remote rendering service as per https://github.com/grafana/grafana-image-renderer/blob/master/docs/remote_rendering_using_docker.md