### PR TITLE
Pin super-linter to specific version

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,9 +13,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Lint Code Base
-        uses: github/super-linter@v3
+        uses: docker://github/super-linter:v3.12.0
         env:
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_KUBERNETES_KUBEVAL: false
           VALIDATE_YAML: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I noticed that https://github.com/grafana/helm-charts/pull/47/checks?check_run_id=1225189051 fails.

Looks like https://github.com/github/super-linter/blob/master/action.yml does not use a fixed version.

The GitHub action refers to the v3 tag of the docker image:

```yaml
name: 'Super-Linter'
author: 'GitHub'
description: 'It is a simple combination of various linters, written in bash, to help validate your source code.'
runs:
  using: 'docker'
  image: 'docker://ghcr.io/github/super-linter:v3'
branding:
  icon: 'check-square'
  color: 'white'
```

It's a floating tag as one can check in https://hub.docker.com/r/github/super-linter/tags

Kubeval was added in https://github.com/github/super-linter/releases/tag/v3.11.0