### PR TITLE
AWS EKS support for cloudwatch with an example in values.yaml

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.7.7
+version: 5.7.8
 appVersion: 7.2.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.7.6
+version: 5.7.7
 appVersion: 7.2.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.7.4
+version: 5.7.6
 appVersion: 7.2.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -434,10 +434,15 @@ volumes:
     emptyDir: {}
 {{- end -}}
 {{- range .Values.extraSecretMounts }}
+{{- if .secretName }}
   - name: {{ .name }}
     secret:
       secretName: {{ .secretName }}
       defaultMode: {{ .defaultMode }}
+{{- else if .projected }}
+  - name: {{ .name }}
+    projected: {{- toYaml .projected | nindent 6 }}
+{{- end }}
 {{- end }}
 {{- range .Values.extraVolumeMounts }}
   - name: {{ .name }}

--- a/charts/grafana/templates/image-renderer-deployment.yaml
+++ b/charts/grafana/templates/image-renderer-deployment.yaml
@@ -86,20 +86,21 @@ spec:
           volumeMounts:
             - mountPath: /tmp
               name: image-renderer-tmpfs
+      {{- with .Values.imageRenderer.resources }}
           resources:
-            {{ toYaml .Values.imageRenderer.resources | nindent 12 }}
-
+{{ toYaml . | indent 12 }}
+      {{- end }}
       {{- with .Values.imageRenderer.nodeSelector }}
       nodeSelector:
-      {{ toYaml . | indent 2 }}
+{{ toYaml . | indent 8 }}
       {{- end }}
       {{- with .Values.imageRenderer.affinity }}
       affinity:
-      {{ toYaml . | indent 2 }}
+{{ toYaml . | indent 8 }}
       {{- end }}
       {{- with .Values.imageRenderer.tolerations }}
       tolerations:
-      {{ toYaml . | indent 2 }}
+{{ toYaml . | indent 8 }}
       {{- end }}
       volumes:
         - name: image-renderer-tmpfs

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -297,7 +297,7 @@ admin:
 ##   AWS_ROLE_ARN: arn:aws:iam::123456789000:role/iam-role-name-here
 ##   AWS_WEB_IDENTITY_TOKEN_FILE: /var/run/secrets/eks.amazonaws.com/serviceaccount/token
 ##   AWS_REGION: us-east-1
-## 5. uncoment the EKS example in
+## 5. uncomment the EKS section in extraSecretMounts: below
 
 env: {}
 
@@ -329,7 +329,7 @@ extraSecretMounts: []
   #   subPath: ""
   #
   # for AWS EKS (cloudwatch) use the following (see also instruction in env: above)
-  #  - name: aws-iam-token
+  # - name: aws-iam-token
   #   mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
   #   readOnly: true
   #   projected:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -16,6 +16,7 @@ serviceAccount:
   name:
   nameTest:
 #  annotations:
+#    eks.amazonaws.com/role-arn: arn:aws:iam::123456789000:role/iam-role-name-here
 
 replicas: 1
 
@@ -286,18 +287,24 @@ admin:
 ## Extra environment variables that will be pass onto deployment pods
 ##
 ## to provide grafana with access to CloudWatch on AWS EKS:
-## 1. create an iam role of type "Web identity" with provider oidc.eks.*
-## 2. edit the "Trust relationships" of the role to include inside the StringEquals clause
+## 1. create an iam role of type "Web identity" with provider oidc.eks.* (note the provider for later)
+## 2. edit the "Trust relationships" of the role, add a line inside the StringEquals clause using the
+## same oidc eks provider as noted before (same as the existing line)
+## also, replace NAMESPACE and prometheus-operator-grafana with the service account namespace and name
+##
 ##  "oidc.eks.us-east-1.amazonaws.com/id/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:sub": "system:serviceaccount:NAMESPACE:prometheus-operator-grafana",
-## replace NAMESPACE and prometheus-operator-grafana with the service account namespace and name
-## you can find it using: kubectl get serviceaccount -A
-## 3. attach a policy to the role i.e. CloudWatchReadOnlyAccess
+##
+## 3. attach a policy to the role, you can use a built in policy called CloudWatchReadOnlyAccess
 ## 4. use the following env: (replace 123456789000 and iam-role-name-here with your aws account number and role name)
+##
 ## env:
 ##   AWS_ROLE_ARN: arn:aws:iam::123456789000:role/iam-role-name-here
 ##   AWS_WEB_IDENTITY_TOKEN_FILE: /var/run/secrets/eks.amazonaws.com/serviceaccount/token
 ##   AWS_REGION: us-east-1
+##
 ## 5. uncomment the EKS section in extraSecretMounts: below
+## 6. uncomment the annotation section in the serviceAccount: above
+## make sure to replace arn:aws:iam::123456789000:role/iam-role-name-here with your role arn
 
 env: {}
 

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -487,7 +487,7 @@ smtp:
 sidecar:
   image:
     repository: kiwigrid/k8s-sidecar
-    tag: 0.1.151
+    tag: 0.1.209
     sha: ""
   imagePullPolicy: IfNotPresent
   resources: {}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -284,6 +284,21 @@ admin:
 # schedulerName:
 
 ## Extra environment variables that will be pass onto deployment pods
+##
+## to provide grafana with access to CloudWatch on AWS EKS:
+## 1. create an iam role of type "Web identity" with provider oidc.eks.*
+## 2. edit the "Trust relationships" of the role to include inside the StringEquals clause
+##  "oidc.eks.us-east-1.amazonaws.com/id/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:sub": "system:serviceaccount:NAMESPACE:prometheus-operator-grafana",
+## replace NAMESPACE and prometheus-operator-grafana with the service account namespace and name
+## you can find it using: kubectl get serviceaccount -A
+## 3. attach a policy to the role i.e. CloudWatchReadOnlyAccess
+## 4. use the following env: (replace 123456789000 and iam-role-name-here with your aws account number and role name)
+## env:
+##   AWS_ROLE_ARN: arn:aws:iam::123456789000:role/iam-role-name-here
+##   AWS_WEB_IDENTITY_TOKEN_FILE: /var/run/secrets/eks.amazonaws.com/serviceaccount/token
+##   AWS_REGION: us-east-1
+## 5. uncoment the EKS example in
+
 env: {}
 
 ## "valueFrom" environment variable references that will be added to deployment pods
@@ -312,6 +327,18 @@ extraSecretMounts: []
   #   secretName: grafana-secret-files
   #   readOnly: true
   #   subPath: ""
+  #
+  # for AWS EKS (cloudwatch) use the following (see also instruction in env: above)
+  #  - name: aws-iam-token
+  #   mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
+  #   readOnly: true
+  #   projected:
+  #     defaultMode: 420
+  #     sources:
+  #       - serviceAccountToken:
+  #           audience: sts.amazonaws.com
+  #           expirationSeconds: 86400
+  #           path: token
 
 ## Additional grafana server volume mounts
 # Defines additional volume mounts.
@@ -339,6 +366,14 @@ datasources: {}
 #      url: http://prometheus-prometheus-server
 #      access: proxy
 #      isDefault: true
+#    - name: CloudWatch
+#        type: cloudwatch
+#        access: proxy
+#        uid: cloudwatch
+#        editable: false
+#        jsonData:
+#          authType: credentials
+#          defaultRegion: us-east-1
 
 ## Configure notifiers
 ## ref: http://docs.grafana.org/administration/provisioning/#alert-notification-channels


### PR DESCRIPTION
AWS EKS support for cloudwatch with an example in values.yaml

Background:

I'm using AWS EKS and CloudWatch for some of my metrics in kube-prometheus-stack (previously known as prometheus-operator)

This is my minimal patch and example configuration with a howto guide on using EKS iam roles for service accounts to gain access to cloudwatch metrics.

If this patch is merged it will save me some effort next time i need to upgrade

This is not a breaking change although it adds new functionality in form of the projected field.