### PR TITLE
add useExistingRole support.

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.7.10
+version: 5.8.10
 appVersion: 7.2.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -165,6 +165,7 @@ You have to add --force to your helm upgrade command as the labels of the chart 
 | `serviceAccount.nameTest`                 | Service account name to use for test, when empty will be set to created account if `serviceAccount.create` is set else to `default` | `nil` |
 | `rbac.create`                             | Create and use RBAC resources                 | `true`                                                  |
 | `rbac.namespaced`                         | Creates Role and Rolebinding instead of the default ClusterRole and ClusteRoleBindings for the grafana instance  | `false` |
+| `rbac.useExistingRole`                    | Set to a rolename to use existing role - skipping role creating - but still doing serviceaccount and rolebinding to the rolename set here. | `nil` |
 | `rbac.pspEnabled`                         | Create PodSecurityPolicy (with `rbac.create`, grant roles permissions as well) | `true`                 |
 | `rbac.pspUseAppArmor`                     | Enforce AppArmor in created PodSecurityPolicy (requires `rbac.pspEnabled`)  | `true`                    |
 | `rbac.extraRoleRules`                     | Additional rules to add to the Role           | []                                                      |

--- a/charts/grafana/templates/clusterrole.yaml
+++ b/charts/grafana/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create (not .Values.rbac.namespaced) }}
+{{- if and .Values.rbac.create (not .Values.rbac.namespaced) (not .Values.rbac.useExistingRole) }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/grafana/templates/clusterrolebinding.yaml
+++ b/charts/grafana/templates/clusterrolebinding.yaml
@@ -15,6 +15,10 @@ subjects:
     namespace: {{ template "grafana.namespace" . }}
 roleRef:
   kind: ClusterRole
+{{- if (not .Values.rbac.useExistingRole) }}
   name: {{ template "grafana.fullname" . }}-clusterrole
+{{- else }}
+  name: {{ .Values.rbac.useExistingRole }}
+{{- end }}
   apiGroup: rbac.authorization.k8s.io
 {{- end -}}

--- a/charts/grafana/templates/role.yaml
+++ b/charts/grafana/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if and .Values.rbac.create (not .Values.rbac.useExistingRole) -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:

--- a/charts/grafana/templates/rolebinding.yaml
+++ b/charts/grafana/templates/rolebinding.yaml
@@ -13,7 +13,11 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
+{{- if (not .Values.rbac.useExistingRole) }}
   name: {{ template "grafana.fullname" . }}
+{{- else }}
+  name: {{ .Values.rbac.useExistingRole }}
+{{- end }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "grafana.serviceAccountName" . }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1,5 +1,7 @@
 rbac:
   create: true
+  ## Use an existing ClusterRole/Role (depending on rbac.namespaced false/true)
+  # useExistingRole: name-of-some-(cluster)role
   pspEnabled: true
   pspUseAppArmor: true
   namespaced: false


### PR DESCRIPTION
What this PR does / why we need it:

This add useExistingRole option, which enables chart to skip role creation and instead bind to existing role - which is needed in f.ex. some RHEL openshift+jenkins setups, where "normal users" are not allowed to create role's (but can do the rolebinding and sa creation to the existing role).
Checklist

x DCO signed
x Chart Version bumped
x Variables are documented in the README.md

https://github.com/helm/charts/pull/23370 - reimplementation in new repo as requested.

Same option is in among others - Prometheus (upstreamed by me :)