### PR TITLE
Update PSP to allow runtime/default

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.8.10
+version: 5.8.12
 appVersion: 7.2.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/podsecuritypolicy.yaml
+++ b/charts/grafana/templates/podsecuritypolicy.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
   annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
     {{- if .Values.rbac.pspUseAppArmor }}
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'


### PR DESCRIPTION
With K8S 1.19 this is required, closes https://github.com/grafana/helm-charts/issues/59