### PR TITLE
[grafana] Prevent admin password from changing every upgrade

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.9.2
+version: 6.9.3
 appVersion: 7.5.5
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_helpers.tpl
+++ b/charts/grafana/templates/_helpers.tpl
@@ -114,3 +114,16 @@ Return the appropriate apiVersion for rbac.
 {{- print "rbac.authorization.k8s.io/v1beta1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Looks if there's an existing secret and reuse its password. If not it generates
+new password and use it.
+*/}}
+{{- define "grafana.password" -}}
+{{- $secret := (lookup "v1" "Secret" (include "grafana.namespace" .) (include "grafana.fullname" .) ) -}}
+  {{- if $secret -}}
+    {{-  index $secret "data" "admin-password" -}}
+  {{- else -}}
+    {{- (randAlphaNum 40) | b64enc | quote -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/grafana/templates/secret.yaml
+++ b/charts/grafana/templates/secret.yaml
@@ -17,7 +17,7 @@ data:
   {{- if .Values.adminPassword }}
   admin-password: {{ .Values.adminPassword | b64enc | quote }}
   {{- else }}
-  admin-password: {{ randAlphaNum 40 | b64enc | quote }}
+  admin-password: {{ template "grafana.password" . }}
   {{- end }}
   {{- end }}
   {{- if not .Values.ldap.existingSecret }}


### PR DESCRIPTION
Solving #10 
Using a lookup function to check if the password secret exists or not before generating new one, If It's indeed exit It'll be reused. 

Lookup functions are [first introduced in helm3](https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-lookup-function) so By introducing a new lookup function this chart is pretty much incompatible with Helm2 But at this point of time, I'm not really sure that this is a problem cause 
[On November 13, 2020, Helm v2 support will formally end](https://github.com/helm/charts#status-of-the-project)