### PR TITLE
Add runAsNonRoot to false for initChown

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.8.12
+version: 5.8.13
 appVersion: 7.2.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -27,6 +27,7 @@ initContainers:
     {{- end }}
     imagePullPolicy: {{ .Values.initChownData.image.pullPolicy }}
     securityContext:
+      runAsNonRoot: false
       runAsUser: 0
     command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsGroup }}", "/var/lib/grafana"]
     resources:


### PR DESCRIPTION
Specifically set runAsNonRoot to false for initChown container so that
it can always run as root. This is to avoid any pod.securityContext overriding
runAsNonRoot.