### PR TITLE
Add support for  Container Storage Interface (CSI) secret providers

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.0.0
+version: 6.0.1
 appVersion: 7.2.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -489,6 +489,24 @@ Include in the `extraSecretMounts` configuration flag:
      readOnly: true
 ```
 
+### extraSecretMounts using a Container Storage Interface (CSI) provider
+
+This example uses a CSI driver e.g. retrieving secrets using [Azure Key Vault Provider](https://github.com/Azure/secrets-store-csi-driver-provider-azure)
+
+```yaml
+- extraSecretMounts:
+  - name: secrets-store-inline
+    mountPath: /run/secrets
+    readOnly: true
+    csi:
+      driver: secrets-store.csi.k8s.io
+      readOnly: true
+      volumeAttributes:
+        secretProviderClass: "my-provider"
+      nodePublishSecretRef:
+        name: akv-creds
+```
+
 ## Image Renderer Plug-In
 
 This chart supports enabling [remote image rendering](https://github.com/grafana/grafana-image-renderer/blob/master/docs/remote_rendering_using_docker.md)

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -447,6 +447,9 @@ volumes:
 {{- else if .projected }}
   - name: {{ .name }}
     projected: {{- toYaml .projected | nindent 6 }}
+{{- else if .csi }}
+  - name: {{ .name }}
+    csi: {{- toYaml .csi | nindent 6 }}
 {{- end }}
 {{- end }}
 {{- range .Values.extraVolumeMounts }}

--- a/charts/grafana/templates/podsecuritypolicy.yaml
+++ b/charts/grafana/templates/podsecuritypolicy.yaml
@@ -34,6 +34,7 @@ spec:
     - 'configMap'
     - 'emptyDir'
     - 'projected'
+    - 'csi'
     - 'secret'
     - 'downwardAPI'
     - 'persistentVolumeClaim'

--- a/charts/grafana/templates/tests/test-podsecuritypolicy.yaml
+++ b/charts/grafana/templates/tests/test-podsecuritypolicy.yaml
@@ -25,5 +25,6 @@ spec:
   - downwardAPI
   - emptyDir
   - projected
+  - csi
   - secret
 {{- end }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -348,6 +348,19 @@ extraSecretMounts: []
   #           audience: sts.amazonaws.com
   #           expirationSeconds: 86400
   #           path: token
+  #
+  # for CSI e.g. Azure Key Vault use the following
+  # - name: secrets-store-inline
+  #  mountPath: /run/secrets
+  #  readOnly: true
+  #  csi:
+  #    driver: secrets-store.csi.k8s.io
+  #    readOnly: true
+  #    volumeAttributes:
+  #      secretProviderClass: "akv-grafana-spc"
+  #    nodePublishSecretRef:                       # Only required when using service principal mode
+  #       name: grafana-akv-creds                  # Only required when using service principal mode                  
+
 
 ## Additional grafana server volume mounts
 # Defines additional volume mounts.

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -359,8 +359,7 @@ extraSecretMounts: []
   #    volumeAttributes:
   #      secretProviderClass: "akv-grafana-spc"
   #    nodePublishSecretRef:                       # Only required when using service principal mode
-  #       name: grafana-akv-creds                  # Only required when using service principal mode                  
-
+  #       name: grafana-akv-creds                  # Only required when using service principal mode
 
 ## Additional grafana server volume mounts
 # Defines additional volume mounts.


### PR DESCRIPTION
Support for mounting secrets from a CSI provider 

**Background:**
I'm using Azure Key Vault (AKV) for the management of secrets.
Following [Microsoft guidelines](https://docs.microsoft.com/en-us/azure/key-vault/general/key-vault-integrate-kubernetes) the recommended integration of AKV is to use a CSI driver

This is not a breaking change - it adds new functionality `csi` under `extraSecretMounts` section

Signed-off-by: Maurycy Widera <mauryc@gmail.com>