### PR TITLE
bump appversion and image to 7.3.1

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.0.1
-appVersion: 7.2.1
+version: 6.1.0
+appVersion: 7.3.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -53,7 +53,7 @@ livenessProbe:
 
 image:
   repository: grafana/grafana
-  tag: 7.2.1
+  tag: 7.3.1
   sha: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
This PR bumps the app- and image version to grafana 7.3.1