### PR TITLE
Fix serviceMonitor selector matchLabels

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.1.0
+version: 6.1.1
 appVersion: 7.3.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/servicemonitor.yaml
+++ b/charts/grafana/templates/servicemonitor.yaml
@@ -28,8 +28,7 @@ spec:
   jobLabel: "{{ .Release.Name }}"
   selector:
     matchLabels:
-      app: {{ template "grafana.name" . }}
-      release: "{{ .Release.Name }}"
+      {{- include "grafana.selectorLabels" . | nindent 8 }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}


### PR DESCRIPTION
Signed-off-by: Cédric Menassa <cedric.menassa@gmail.com>

It seems  that the serviceMonitor `selector` `matchLabels` don't target correctly grafana pods.

Doesn't work:
```yaml 
  selector:
    matchLabels:
      app: {{ template "grafana.name" . }}
      release: "{{ .Release.Name }}"
```

Works:
```yaml
  selector:
    matchLabels:
      {{- include "grafana.selectorLabels" . | nindent 8 }}
```