### PR TITLE
add IngressClass support

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.1.1
+version: 6.1.2
 appVersion: 7.3.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/ingress.yaml
+++ b/charts/grafana/templates/ingress.yaml
@@ -24,6 +24,9 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end -}}
 {{- if .Values.ingress.tls }}
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -153,6 +153,9 @@ hostAliases: []
 
 ingress:
   enabled: false
+  # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+  # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+  # ingressClassName: nginx
   # Values can be templated
   annotations: {}
     # kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
Signed-off-by: Christian Niehoff <mail@christian-niehoff.com>

Resolves #77 

This pull request will add support for the new `ingressClassName` field.

See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress