### PR TITLE
Support templating in `ldap-toml` values

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.1.4
+version: 6.1.5
 appVersion: 7.3.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/secret.yaml
+++ b/charts/grafana/templates/secret.yaml
@@ -17,6 +17,6 @@ data:
   {{- end }}
   {{- end }}
   {{- if not .Values.ldap.existingSecret }}
-  ldap-toml: {{ .Values.ldap.config | b64enc | quote }}
+  ldap-toml: {{ tpl .Values.ldap.config $ | b64enc | quote }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Hi,

I want to provide a blueprint in our company. Currently I'm using the `existingSecret` to provide a ldap.toml. But if ldap.toml has been changed, grafana will not do a reload or restart and needs a manual restart.

If I could embed the ldap.config inside the values.yaml, the restart annotation should work as expected.