### PR TITLE
Add CODEOWNERS + add myself as maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# See https://github.com/scottrigby/prometheus-helm-charts/issues/12
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
+
+# The repo admins team will be the default owners for everything in the repo.
+# Unless a later match takes precedence, they will be requested for review when someone opens a pull request.
+* @prometheus-community/helm-charts-admins
+
+/charts/grafana/ @maorfr @rtluckie @torstenwalter @Xtigyro @zanhsieh

--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -1,0 +1,17 @@
+name: Check CODEOWNERS
+
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: install yq
+        run: |
+          sudo snap install yq
+      - name: generate CODEOWNERS
+        run: |
+          ./scripts/check-codeowners.sh > .github/CODEOWNERS
+      - name: check CODEOWNERS for modifications
+        run: |
+          git diff --exit-code

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.1.7
+version: 6.1.8
 appVersion: 7.3.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
@@ -17,5 +17,7 @@ maintainers:
     email: maor.friedman@redhat.com
   - name: Xtigyro
     email: miroslav.hadzhiev@gmail.com
+  - name: torstenwalter
+    email: mail@torstenwalter.de
 engine: gotpl
 type: application

--- a/scripts/check-codeowners.sh
+++ b/scripts/check-codeowners.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+cat <<EOF
+# See https://github.com/scottrigby/prometheus-helm-charts/issues/12
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
+
+# The repo admins team will be the default owners for everything in the repo.
+# Unless a later match takes precedence, they will be requested for review when someone opens a pull request.
+* @prometheus-community/helm-charts-admins
+
+EOF
+
+for DIR in $(ls -1 -d ./charts/*)
+do
+  FILE="$DIR/Chart.yaml"
+  DIR=$(echo $DIR | sed 's/^\.//')
+  MAINTAINERS=$(yq r $FILE 'maintainers.[*].name'| sed 's/^/@/' | sort --ignore-case)
+  echo $DIR/ $MAINTAINERS
+done


### PR DESCRIPTION
This adds a CODEOWNERS file as suggested in https://github.com/grafana/loki/issues/2593#issuecomment-718442894.
There is also a new workflow, which contains a check so that we cannot forget to reflect changes in chart maintainers also in that file.

@maorfr @rtluckie @Xtigyro @zanhsieh I also added myself as maintainer. Hope that's ok if not then I am happy to remove it.
So far I have hardly reviewed PRs and only added comments as I felt not entitled to do so. In the end I just helped with the chart migration ;-)