### PR TITLE
Remove argument from helm install command

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: grafana
-version: 6.1.8
+version: 6.1.9
 appVersion: 7.3.3
-kubeVersion: "^1.8.0-0"
+kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -16,7 +16,7 @@ _See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name my-release grafana/grafana
+helm install my-release grafana/grafana
 ```
 
 ## Uninstalling the Chart


### PR DESCRIPTION
Helm no longer accepts the `--name` argument, but rather want you to input the name directly.

```
$ helm version
version.BuildInfo{Version:"v3.4.1", GitCommit:"xxxx", GitTreeState:"dirty", GoVersion:"go1.15.4"}

$ helm install --name grafana --namespace infra  grafana/grafana
Error: unknown flag: --name

$ helm install grafana --namespace infra grafana/grafana
NAME: grafana
LAST DEPLOYED: Mon Nov 23 19:04:47 2020
NAMESPACE: infra
STATUS: deployed
```