### PR TITLE
Add missing default value for `imageRenderer.service.targetPort`

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.1.10
+version: 6.1.11
 appVersion: 7.3.3
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -647,6 +647,7 @@ imageRenderer:
     portName: 'http'
     # image-renderer service port used by both service and deployment
     port: 8081
+    targetPort: 3001
   # name of the image-renderer port on the pod
   podPortName: http
   # number of image-renderer replica sets to keep


### PR DESCRIPTION
This PR fixes https://github.com/grafana/helm-charts/issues/95 for Helm v3.1.3.