### PR TITLE
fix: Fix network communication with ImageRenderer so it works with the

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.1.11
+version: 6.1.12
 appVersion: 7.3.3
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -633,7 +633,8 @@ imageRenderer:
     # image-renderer ImagePullPolicy
     pullPolicy: Always
   # extra environment variables
-  env: {}
+  env:
+    HTTP_HOST: "0.0.0.0"
     # RENDERING_ARGS: --disable-gpu,--window-size=1280x758
     # RENDERING_MODE: clustered
   # image-renderer deployment securityContext
@@ -647,7 +648,7 @@ imageRenderer:
     portName: 'http'
     # image-renderer service port used by both service and deployment
     port: 8081
-    targetPort: 3001
+    targetPort: 8081
   # name of the image-renderer port on the pod
   podPortName: http
   # number of image-renderer replica sets to keep


### PR DESCRIPTION
Hello 👋 

I was using your HelmChart today to install the ImageRenderer plugin and experienced some confusion when my Grafana instance couldn't talk to the imageRenderer.

It seems the default values.yaml Values don't provide a working setup, I've tweaked them to fix that.


Thanks!