### PR TITLE
Allow specifying pvc selectors in the chart

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.1.12
+version: 6.1.13
 appVersion: 7.3.3
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/pvc.yaml
+++ b/charts/grafana/templates/pvc.yaml
@@ -25,4 +25,9 @@ spec:
   {{- if .Values.persistence.storageClassName }}
   storageClassName: {{ .Values.persistence.storageClassName }}
   {{- end -}}
+  {{- with .Values.persistence.selectorLabels }}
+  selector:
+    matchLabels:
+{{ toYaml . | indent 6 }}
+  {{- end }}
 {{- end -}}

--- a/charts/grafana/templates/statefulset.yaml
+++ b/charts/grafana/templates/statefulset.yaml
@@ -43,5 +43,10 @@ spec:
       storageClassName: {{ .Values.persistence.storageClassName }}
       resources:
         requests:
-          storage: {{ .Values.persistence.size }} 
+          storage: {{ .Values.persistence.size }}
+      {{- with .Values.persistence.selectorLabels }}
+      selector:
+        matchLabels:
+{{ toYaml . | indent 10 }}
+      {{- end }}
 {{- end }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -240,6 +240,7 @@ persistence:
   # annotations: {}
   finalizers:
     - kubernetes.io/pvc-protection
+  # selectorLabels: {}
   # subPath: ""
   # existingClaim:
 


### PR DESCRIPTION
In some on prem datacenter deployments you have static PVs where you match pre-created PVCs/VolumeClaimTemplates to a fixed PV. This allows use of this by optionally allowing users to specify a `labelSelector` for their persistence.

Currently the only real option is to have a single instance where you pass in a pre-created PVC - whilst this is an option for a single instance of grafana - it obviously doesn't work if you want to use a stateful set for multiple instances