### PR TITLE
Fix incorrect requirement on Helm version

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.1.14
+version: 6.1.15
 appVersion: 7.3.3
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -44,7 +44,7 @@ You have to add --force to your helm upgrade command as the labels of the chart 
 
 ### To 6.0.0
 
-This version requires Helm >= 3.4.0.
+This version requires Helm >= 3.1.0.
 
 ## Configuration
 


### PR DESCRIPTION
The README states that this chart requires Helm 3.4.0, which is not correct, as somebody found out in https://github.com/prometheus-community/helm-charts/pull/460#discussion_r537541527.