### PR TITLE
Loki-stack: fix values for logstash and filebeat

### DIFF
--- a/charts/loki-stack/values.yaml
+++ b/charts/loki-stack/values.yaml
@@ -34,19 +34,31 @@ filebeat:
             - logs_path:
                 logs_path: "/var/log/containers/"
       output.logstash:
-        hosts: ["logstash-loki:5044"]
+        hosts: ["loki-logstash-headless:5044"] # {{name_of_release}}-logstash-headless:5044
 
 logstash:
   enabled: false
   image: grafana/logstash-output-loki
   imageTag: 1.0.1
-  filters:
-    main: |-
+
+  logstashConfig:
+    logstash.yml: |
+      http.host: 0.0.0.0
+      xpack.monitoring.enabled: false
+
+  logstashPipeline:
+    logstash.conf: |
+      input {
+        beats {
+          port => 5044
+        }
+      }
+
       filter {
         if [kubernetes] {
           mutate {
             add_field => {
-              "container_name" => "%{[kubernetes][container][name]}"
+              "container" => "%{[kubernetes][container][name]}"
               "namespace" => "%{[kubernetes][namespace]}"
               "pod" => "%{[kubernetes][pod][name]}"
             }
@@ -57,13 +69,10 @@ logstash:
           remove_field => ["tags"]
         }
       }
-  outputs:
-    main: |-
+
       output {
         loki {
           url => "http://loki:3100/loki/api/v1/push"
-          #username => "test"
-          #password => "test"
         }
         # stdout { codec => rubydebug }
       }


### PR DESCRIPTION
Exemplary values in Loki-stack/values.yaml use probably some old version of logstash subchart and doesn't work.
Fixes #136 