### PR TITLE
Add workflow for pull request validation

### DIFF
--- a/.github/workflows/validate-pr.yaml
+++ b/.github/workflows/validate-pr.yaml
@@ -1,0 +1,26 @@
+name: Validate Pull Request
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+
+      - name: Validate PR
+        run: scripts/validate-pr.sh
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}

--- a/scripts/validate-pr.sh
+++ b/scripts/validate-pr.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+: "${PR_TITLE:?Environment variable must be set}"
+
+main() {
+    local repo_root
+    repo_root=$(git rev-parse --show-toplevel)
+
+    local changed
+    changed=$(ct list-changed --config "$repo_root/ct.yaml")
+
+    if [[ -z "$changed" ]]; then
+        exit 0
+    fi
+
+    local num_changed
+    num_changed=$(wc -l <<< "$changed")
+
+    if ((num_changed > 1)); then
+        echo "This PR has changes to multiple charts. Please create individual PRs per chart." >&2
+        exit 1
+    fi
+
+    # Strip charts directory
+    changed="${changed##*/}"
+
+    if [[ "$PR_TITLE" != "[$changed] "* ]]; then
+        echo "PR title must start with '[$changed] '." >&2
+        exit 1
+    fi
+}
+
+main


### PR DESCRIPTION
Now that we have multiple charts in the repo, it makes sense to enforce
that a pull request title starts with a prefix that contains the chart
name. Additionally, this will require that a single pull request cannot
make changes to multiple charts.
