### PR TITLE
Revert "fluent-bit: Rename Fluent Bit plugin output name. (#2974)"

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: fluent-bit
-version: 2.1.0
+version: 2.1.1
 appVersion: v2.0.0
 kubeVersion: "^1.10.0-0"
 description: "Uses fluent-bit Loki go plugin for gathering logs and sending them to Loki"

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v1"
 name: fluent-bit
-version: 2.1.1
-appVersion: v2.0.0
+version: 2.2.1
+appVersion: v2.1.0
 kubeVersion: "^1.10.0-0"
 description: "Uses fluent-bit Loki go plugin for gathering logs and sending them to Loki"
 home: https://grafana.com/loki

--- a/charts/fluent-bit/templates/configmap.yaml
+++ b/charts/fluent-bit/templates/configmap.yaml
@@ -33,7 +33,7 @@ data:
         K8S-Logging.Exclude {{ .Values.config.k8sLoggingExclude }}
         K8S-Logging.Parser {{ .Values.config.k8sLoggingParser }}
     [Output]
-        Name grafana-loki
+        Name loki
         Match *
         {{- if and .Values.loki.user .Values.loki.password }}
         Url {{ .Values.loki.serviceScheme }}://{{ .Values.loki.user }}:{{ .Values.loki.password }}@{{ include "loki.serviceName" . }}:{{ .Values.loki.servicePort }}{{ .Values.loki.servicePath }}


### PR DESCRIPTION
This reverts commit 1b4e9853d02d46f10ac454b33701c26886ab48bd.

Signed-off-by: ohdearaugustin <j-reindl@live.at>

Closes  #131

As I could not find any configuration for the grafana-loki output plugin. Please revert this change to make the fluentbit chart usable again.