### PR TITLE
[loki-distributed]  Add `extraVolumes` and `extraVolumeMounts` in global

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.0.0
-version: 0.20.1
+version: 0.20.2
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -87,6 +87,8 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | gateway.tolerations | list | `[]` | Tolerations for gateway pods |
 | global.image.registry | string | `nil` | Overrides the Docker registry globally for all images |
 | global.priorityClassName | string | `nil` | Overrides the priorityClassName for all pods |
+| global.extraVolumeMounts | list | `[]` | Extra volumeMounts definition in all deployment/statefulset |
+| global.extraVolumes | list | `[]` | Extra volumes definition in all deployment/statefulset |
 | imagePullSecrets | list | `[]` | Image pull secrets for Docker images |
 | ingester.affinity | string | Hard node and soft zone anti-affinity | Affinity for ingester pods. Passed through `tpl` and, thus, to be configured as string |
 | ingester.extraArgs | list | `[]` | Additional CLI args for the ingester |

--- a/charts/loki-distributed/templates/compactor/deployment-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/deployment-compactor.yaml
@@ -67,6 +67,9 @@ spec:
             initialDelaySeconds: 15
             timeoutSeconds: 1
           volumeMounts:
+          {{- if .Values.global.extraVolumeMounts }}
+            {{ toYaml .Values.global.extraVolumeMounts | nindent 12}}
+          {{- end }}
             - name: config
               mountPath: /etc/loki/config
             - name: data
@@ -82,6 +85,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+      {{- if .Values.global.extraVolumes }}
+        {{ toYaml .Values.global.extraVolumes | nindent 8}}
+      {{- end }}
         - name: config
           configMap:
             name: {{ include "loki.fullname" . }}

--- a/charts/loki-distributed/templates/distributor/deployment-distributor.yaml
+++ b/charts/loki-distributed/templates/distributor/deployment-distributor.yaml
@@ -75,6 +75,9 @@ spec:
             initialDelaySeconds: 15
             timeoutSeconds: 1
           volumeMounts:
+          {{- if .Values.global.extraVolumeMounts }}
+            {{ toYaml .Values.global.extraVolumeMounts | nindent 12}}
+          {{- end }}
             - name: config
               mountPath: /etc/loki/config
           resources:
@@ -92,6 +95,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+      {{- if .Values.global.extraVolumes }}
+        {{ toYaml .Values.global.extraVolumes | nindent 8}}
+      {{- end }}
         - name: config
           configMap:
             name: {{ include "loki.fullname" . }}

--- a/charts/loki-distributed/templates/gateway/deployment-gateway.yaml
+++ b/charts/loki-distributed/templates/gateway/deployment-gateway.yaml
@@ -61,6 +61,9 @@ spec:
           securityContext:
             {{- toYaml .Values.gateway.containerSecurityContext | nindent 12 }}
           volumeMounts:
+          {{- if .Values.global.extraVolumeMounts }}
+            {{ toYaml .Values.global.extraVolumeMounts | nindent 12}}
+          {{- end }}
             - name: config
               mountPath: /etc/nginx
             {{- if .Values.gateway.basicAuth.enabled }}
@@ -86,6 +89,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+      {{- if .Values.global.extraVolumes }}
+        {{ toYaml .Values.global.extraVolumes | nindent 8}}
+      {{- end }}
         - name: config
           configMap:
             name: {{ include "loki.gatewayFullname" . }}

--- a/charts/loki-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/statefulset-ingester.yaml
@@ -75,6 +75,9 @@ spec:
             initialDelaySeconds: 30
             timeoutSeconds: 1
           volumeMounts:
+          {{- if .Values.global.extraVolumeMounts }}
+            {{ toYaml .Values.global.extraVolumeMounts | nindent 12}}
+          {{- end }}
             - name: config
               mountPath: /etc/loki/config
             - name: data
@@ -94,6 +97,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+      {{- if .Values.global.extraVolumes }}
+        {{ toYaml .Values.global.extraVolumes | nindent 8}}
+      {{- end }}
         - name: config
           configMap:
             name: {{ include "loki.fullname" . }}

--- a/charts/loki-distributed/templates/querier/statefulset-querier.yaml
+++ b/charts/loki-distributed/templates/querier/statefulset-querier.yaml
@@ -75,6 +75,9 @@ spec:
             initialDelaySeconds: 15
             timeoutSeconds: 1
           volumeMounts:
+          {{- if .Values.global.extraVolumeMounts }}
+            {{ toYaml .Values.global.extraVolumeMounts | nindent 12}}
+          {{- end }}
             - name: config
               mountPath: /etc/loki/config
             - name: data
@@ -94,6 +97,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+      {{- if .Values.global.extraVolumes }}
+        {{ toYaml .Values.global.extraVolumes | nindent 8}}
+      {{- end }}
         - name: config
           configMap:
             name: {{ include "loki.fullname" . }}

--- a/charts/loki-distributed/templates/query-frontend/deployment-query-frontend.yaml
+++ b/charts/loki-distributed/templates/query-frontend/deployment-query-frontend.yaml
@@ -64,6 +64,9 @@ spec:
           securityContext:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
           volumeMounts:
+          {{- if .Values.global.extraVolumeMounts }}
+            {{ toYaml .Values.global.extraVolumeMounts | nindent 12}}
+          {{- end }}
             - name: config
               mountPath: /etc/loki/config
           resources:
@@ -81,6 +84,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+      {{- if .Values.global.extraVolumes }}
+        {{ toYaml .Values.global.extraVolumes | nindent 8}}
+      {{- end }}
         - name: config
           configMap:
             name: {{ include "loki.fullname" . }}

--- a/charts/loki-distributed/templates/ruler/deployment-ruler.yaml
+++ b/charts/loki-distributed/templates/ruler/deployment-ruler.yaml
@@ -73,6 +73,9 @@ spec:
             initialDelaySeconds: 15
             timeoutSeconds: 1
           volumeMounts:
+          {{- if .Values.global.extraVolumeMounts }}
+            {{ toYaml .Values.global.extraVolumeMounts | nindent 12}}
+          {{- end }}
             - name: config
               mountPath: /etc/loki/config
             - name: data
@@ -98,6 +101,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+      {{- if .Values.global.extraVolumes }}
+        {{ toYaml .Values.global.extraVolumes | nindent 8}}
+      {{- end }}
         - name: config
           configMap:
             name: {{ include "loki.fullname" . }}

--- a/charts/loki-distributed/templates/table-manager/deployment-table-manager.yaml
+++ b/charts/loki-distributed/templates/table-manager/deployment-table-manager.yaml
@@ -67,6 +67,9 @@ spec:
             initialDelaySeconds: 15
             timeoutSeconds: 1
           volumeMounts:
+          {{- if .Values.global.extraVolumeMounts }}
+            {{ toYaml .Values.global.extraVolumeMounts | nindent 12}}
+          {{- end }}
             - name: config
               mountPath: /etc/loki/config
           resources:
@@ -84,6 +87,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+      {{- if .Values.global.extraVolumes }}
+        {{ toYaml .Values.global.extraVolumes | nindent 8}}
+      {{- end }}
         - name: config
           configMap:
             name: {{ include "loki.fullname" . }}

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -5,6 +5,12 @@ global:
   # -- Overrides the priorityClassName for all pods
   priorityClassName: null
 
+  # -- Extra Volumes definition in all deployment/statefulset
+  extraVolumes: []
+
+  # -- Extra Volume Mount definition in all deployment/statefulset
+  extraVolumeMounts: []
+
 # -- Overrides the chart's name
 nameOverride: null
 

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -5,10 +5,10 @@ global:
   # -- Overrides the priorityClassName for all pods
   priorityClassName: null
 
-  # -- Extra Volumes definition in all deployment/statefulset
+  # -- Extra volumes definition in all deployment/statefulset
   extraVolumes: []
 
-  # -- Extra Volume Mount definition in all deployment/statefulset
+  # -- Extra volumeMounts definition in all deployment/statefulset
   extraVolumeMounts: []
 
 # -- Overrides the chart's name


### PR DESCRIPTION
This PR proposes to add new 2 fields in `global`:
- `extraVolumes`
- `extraVolumeMounts`.

Adding those 2 fields so that I can inject new volume (and mount it) to the all containers. In my use case, I need them so I can deploy loki with GCS storage, where it needs GCP Service Account secret file.

The way I use is like this:
```
global:
  extraVolumes:
  - name: secret # to hold the Loki GCP service account to access gcs bucket
    secret:
      secretName: ${gcp_sa_secret_name}

  extraVolumeMounts:
  - name: secret
    mountPath: /secret/loki/

```

Then for each loki component, I add `extraEnvs`:
```
...
  extraEnv:
  - name: GOOGLE_APPLICATION_CREDENTIALS 
    value: /secret/loki/credentials.json
...
```

Please help review. 
Thanks in advance.