### PR TITLE
fixes output plugin name

### DIFF
--- a/charts/fluent-bit/templates/configmap.yaml
+++ b/charts/fluent-bit/templates/configmap.yaml
@@ -33,7 +33,7 @@ data:
         K8S-Logging.Exclude {{ .Values.config.k8sLoggingExclude }}
         K8S-Logging.Parser {{ .Values.config.k8sLoggingParser }}
     [Output]
-        Name grafana-loki
+        Name loki
         Match *
         {{- if and .Values.loki.user .Values.loki.password }}
         Url {{ .Values.loki.serviceScheme }}://{{ .Values.loki.user }}:{{ .Values.loki.password }}@{{ include "loki.serviceName" . }}:{{ .Values.loki.servicePort }}{{ .Values.loki.servicePath }}


### PR DESCRIPTION
after deploying the loki-stack helm chart into k8s using fluent-bit as the log exporter, the fluent-bit pod fails into a crash-loop because it can't find the `grafana-loki` output. Ideally this should be turned into a variable but for now this change should fix the problem.