### PR TITLE
[loki] Allow to define existing secret for Loki configuration

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 2.5.0
+version: 2.6.0
 appVersion: v2.2.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki/templates/secret.yaml
+++ b/charts/loki/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.config.existingSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,3 +11,4 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   loki.yaml: {{ tpl (toYaml .Values.config) . | b64enc}}
+{{- end -}}

--- a/charts/loki/templates/statefulset.yaml
+++ b/charts/loki/templates/statefulset.yaml
@@ -30,7 +30,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
+      {{- if not .Values.config.existingSecret }}
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -113,7 +115,11 @@ spec:
         {{- end }}
         - name: config
           secret:
+          {{- if .Values.config.existingSecret }}
+            secretName: {{ .Values.config.existingSecret }}
+          {{- else }}
             secretName: {{ template "loki.fullname" . }}
+          {{- end }}
 {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 8}}
 {{- end }}

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -44,6 +44,8 @@ tracing:
   jaegerAgentHost:
 
 config:
+  ## Name of the existing secret containing loki.yaml key and the configuration as value
+  # existingSecret:
   auth_enabled: false
   ingester:
     chunk_idle_period: 3m


### PR DESCRIPTION
**What this PR does / why we need it**:
Add alternative solution to let users provide secrets which holds Loki configuration.
**Which issue(s) this PR fixes**:
Fixes #158

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>
