### PR TITLE
[grafana] Add support for overriding container securityContext

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.1.16
+version: 6.1.17
 appVersion: 7.3.5
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -203,6 +203,10 @@ containers:
       - {{ . }}
     {{- end }}
   {{- end}}
+{{- if .Values.containerSecurityContext }}
+    securityContext:
+{{- toYaml .Values.containerSecurityContext | nindent 6 }}
+{{- end }}
     volumeMounts:
       - name: config
         mountPath: "/etc/grafana/grafana.ini"

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -76,7 +76,7 @@ securityContext:
   runAsGroup: 472
   fsGroup: 472
 
-securityContext:
+containerSecurityContext:
   {}
 
 extraConfigmapMounts: []

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -76,6 +76,8 @@ securityContext:
   runAsGroup: 472
   fsGroup: 472
 
+securityContext:
+  {}
 
 extraConfigmapMounts: []
   # - name: certs-configmap


### PR DESCRIPTION
Need to align with company security requirements, and current psp of Grafana is too wide.
Being able to override default containerSecurityContext settings will help us to cover security related aspects.