### PR TITLE
[loki-stack] Update readme with grafana deployment name

### DIFF
--- a/charts/loki-stack/Chart.yaml
+++ b/charts/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 2.3.1
+version: 2.3.2
 appVersion: v2.1.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki-stack/README.md
+++ b/charts/loki-stack/README.md
@@ -47,13 +47,13 @@ The chart loki-stack contains a pre-configured Grafana, simply use `--set grafan
 To get the admin password for the Grafana pod, run the following command:
 
 ```bash
-kubectl get secret --namespace <YOUR-NAMESPACE> loki-grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo
+kubectl get secret --namespace <YOUR-NAMESPACE> loki-stack-grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo
 ```
 
 To access the Grafana UI, run the following command:
 
 ```bash
-kubectl port-forward --namespace <YOUR-NAMESPACE> service/loki-grafana 3000:80
+kubectl port-forward --namespace <YOUR-NAMESPACE> service/loki-stack-grafana 3000:80
 ```
 
 Navigate to <http://localhost:3000> and login with `admin` and the password output above.


### PR DESCRIPTION
grafana created by this chart is loki-stack-grafana instead loki-grafana, this change make commands in docs work again