### PR TITLE
[promtail] Fix scrape configs

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.1.0
-version: 3.0.1
+version: 3.0.2
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 3.0.1](https://img.shields.io/badge/Version-3.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 3.0.2](https://img.shields.io/badge/Version-3.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -264,6 +264,11 @@ config:
           - __meta_kubernetes_pod_uid
           - __meta_kubernetes_pod_container_name
         target_label: __path__
+
+    # If set to true, adds an additional label for the scrape job.
+    # This helps debug the Promtail config.
+    addScrapeJobLabel: false
+
     scrapeConfigs: |
       # See also https://github.com/grafana/loki/blob/master/production/ksonnet/promtail/scrape_config.libsonnet for reference
 
@@ -278,10 +283,19 @@ config:
             source_labels:
               - __meta_kubernetes_pod_label_app_kubernetes_io_name
             target_label: app
+          - action: drop
+            regex: ''
+            source_labels:
+              - app
           - action: replace
             source_labels:
               - __meta_kubernetes_pod_label_app_kubernetes_io_component
             target_label: component
+          {{- if .Values.config.snippets.addScrapeJobLabel }}
+          - action: replace
+            replacement: kubernetes-pods-app-kubernetes-io-name
+            target_label: scrape_job
+          {{- end }}
           {{- toYaml .Values.config.snippets.common | nindent 4 }}
 
       # Pods with a label 'app'
@@ -300,10 +314,19 @@ config:
             source_labels:
               - __meta_kubernetes_pod_label_app
             target_label: app
+          - action: drop
+            regex: ''
+            source_labels:
+              - app
           - action: replace
             source_labels:
               - __meta_kubernetes_pod_label_component
             target_label: component
+          {{- if .Values.config.snippets.addScrapeJobLabel }}
+          - action: replace
+            replacement: kubernetes-pods-app
+            target_label: scrape_job
+          {{- end }}
           {{- toYaml .Values.config.snippets.common | nindent 4 }}
 
       # Pods with direct controllers, such as StatefulSet
@@ -328,6 +351,11 @@ config:
             source_labels:
               - __meta_kubernetes_pod_controller_name
             target_label: app
+          {{- if .Values.config.snippets.addScrapeJobLabel }}
+          - action: replace
+            replacement: kubernetes-pods-direct-controllers
+            target_label: scrape_job
+          {{- end }}
           {{- toYaml .Values.config.snippets.common | nindent 4 }}
 
       # Pods with indirect controllers, such as Deployment
@@ -353,8 +381,12 @@ config:
             source_labels:
               - __meta_kubernetes_pod_controller_name
             target_label: app
+          {{- if .Values.config.snippets.addScrapeJobLabel }}
+          - action: replace
+            replacement: kubernetes-pods-indirect-controller
+            target_label: scrape_job
+          {{- end }}
           {{- toYaml .Values.config.snippets.common | nindent 4 }}
-
       # All remaining pods not yet covered
       - job_name: kubernetes-other
         pipeline_stages:
@@ -369,11 +401,23 @@ config:
             source_labels:
               - __meta_kubernetes_pod_label_app_kubernetes_io_name
               - __meta_kubernetes_pod_label_app
+          - action: drop
+            regex: .+
+            source_labels:
               - __meta_kubernetes_pod_controller_name
+          - action: replace
+            source_labels:
+              - __meta_kubernetes_pod_name
+            target_label: app
           - action: replace
             source_labels:
               - __meta_kubernetes_pod_label_component
             target_label: component
+          {{- if .Values.config.snippets.addScrapeJobLabel }}
+          - action: replace
+            replacement: kubernetes-other
+            target_label: scrape_job
+          {{- end }}
           {{- toYaml .Values.config.snippets.common | nindent 4 }}
 
   # -- Config file contents for Promtail.


### PR DESCRIPTION
The default config was missing a few drop actions. This had caused logs
to be added twice, once the correct way and once with an incorrect job
label.

In order to help debug the config, the flag
`config.snippets.addScrapeJobLabel` is introduced. If enabled, an
additional label `scrape_job` is added which identifies the scrape job
that picked up the log message.
