### PR TITLE
[promtail] Add more customizations to values.yaml

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.1.0
-version: 3.0.4
+version: 3.0.5
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.1.0
-version: 3.0.5
+version: 3.1.0
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 3.0.4](https://img.shields.io/badge/Version-3.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 3.0.5](https://img.shields.io/badge/Version-3.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -71,8 +71,8 @@ The new release which will pick up again from the existing `positions.yaml`.
 | config.lokiAddress | string | `"http://loki-gateway/loki/api/v1/push"` | The Loki address to post logs to. Must be reference in `config.file` to configure `client.url`. See default config in `values.yaml` |
 | config.serverPort | int | `3101` | The port of the Promtail server Must be reference in `config.file` to configure `server.http_listen_port` See default config in `values.yaml` |
 | config.snippets | object | See `values.yaml` | A section of reusable snippets that can be reference in `config.file`. Custom snippets may be added in order to reduce redundancy. This is especially helpful when multiple `kubernetes_sd_configs` are use which usually have large parts in common. |
-| config.snippets.extraClientConfigs | object | empty | You can put here any keys that will be directly added to the config file's 'client' block. |
-| config.snippets.extraScrapeConfigs | object | empty | You can put here any additional scrape configs you want to add to the config file. |
+| config.snippets.extraClientConfigs | string | empty | You can put here any keys that will be directly added to the config file's 'client' block. |
+| config.snippets.extraScrapeConfigs | string | empty | You can put here any additional scrape configs you want to add to the config file. |
 | containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The security context for containers |
 | defaultVolumeMounts | list | See `values.yaml` | Default volume mounts. Corresponds to `volumes`. |
 | defaultVolumes | list | See `values.yaml` | Default volumes that are mounted into pods. In most cases, these should not be changed. Use `extraVolumes`/`extraVolumeMounts` for additional custom volumes. |
@@ -149,7 +149,7 @@ extraPorts:
 
 config:
   snippets:
-    extraScrapeConfigs:
+    extraScrapeConfigs: |
       # Add an additional scrape config for syslog
       - job_name: syslog
         syslog:
@@ -167,7 +167,7 @@ config:
 ```yaml
 config:
   snippets:
-    extraScrapeConfigs:
+    extraScrapeConfigs: |
       # Add an additional scrape config for syslog
       - job_name: journal
         journal:
@@ -238,7 +238,7 @@ header, you can use:
 ```yaml
 config:
   snippets:
-    extraClientConfigs:
+    extraClientConfigs: |
       basic_auth:
         username: loki
         password: secret

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 3.0.5](https://img.shields.io/badge/Version-3.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -75,13 +75,13 @@ The new release which will pick up again from the existing `positions.yaml`.
 | defaultVolumeMounts | list | See `values.yaml` | Default volume mounts. Corresponds to `volumes`. |
 | defaultVolumes | list | See `values.yaml` | Default volumes that are mounted into pods. In most cases, these should not be changed. Use `extraVolumes`/`extraVolumeMounts` for additional custom volumes. |
 | extraArgs | list | `[]` |  |
+| extraClientConfigs | object | empty | You can put here any keys that will be directly added to the config file's 'client' block. |
 | extraEnv | list | `[]` | Extra environment variables |
 | extraEnvFrom | list | `[]` | Extra environment variables from secrets or configmaps |
 | extraPorts | object | `{}` | Configure additional ports and services. For each configured port, a corresponding service is created. See values.yaml for details |
+| extraScrapeConfigs | object | empty | You can put here any additional scrape configs you want to add to the config file. |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
-| extra_client_configs | object | empty | You can put here any keys that will be directly added to the config file's 'client' block. |
-| extra_scrape_configs | object | empty | You can put here any additional scrape configs you want to add to the config file. |
 | fullnameOverride | string | `nil` | Overrides the chart's computed fullname |
 | image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | image.registry | string | `"docker.io"` | The Docker registry |

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -71,15 +71,15 @@ The new release which will pick up again from the existing `positions.yaml`.
 | config.lokiAddress | string | `"http://loki-gateway/loki/api/v1/push"` | The Loki address to post logs to. Must be reference in `config.file` to configure `client.url`. See default config in `values.yaml` |
 | config.serverPort | int | `3101` | The port of the Promtail server Must be reference in `config.file` to configure `server.http_listen_port` See default config in `values.yaml` |
 | config.snippets | object | See `values.yaml` | A section of reusable snippets that can be reference in `config.file`. Custom snippets may be added in order to reduce redundancy. This is especially helpful when multiple `kubernetes_sd_configs` are use which usually have large parts in common. |
+| config.snippets.extraClientConfigs | object | empty | You can put here any keys that will be directly added to the config file's 'client' block. |
+| config.snippets.extraScrapeConfigs | object | empty | You can put here any additional scrape configs you want to add to the config file. |
 | containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The security context for containers |
 | defaultVolumeMounts | list | See `values.yaml` | Default volume mounts. Corresponds to `volumes`. |
 | defaultVolumes | list | See `values.yaml` | Default volumes that are mounted into pods. In most cases, these should not be changed. Use `extraVolumes`/`extraVolumeMounts` for additional custom volumes. |
 | extraArgs | list | `[]` |  |
-| extraClientConfigs | object | empty | You can put here any keys that will be directly added to the config file's 'client' block. |
 | extraEnv | list | `[]` | Extra environment variables |
 | extraEnvFrom | list | `[]` | Extra environment variables from secrets or configmaps |
 | extraPorts | object | `{}` | Configure additional ports and services. For each configured port, a corresponding service is created. See values.yaml for details |
-| extraScrapeConfigs | object | empty | You can put here any additional scrape configs you want to add to the config file. |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `nil` | Overrides the chart's computed fullname |
@@ -148,20 +148,8 @@ extraPorts:
       loadBalancerIP: 123.234.123.234
 
 config:
-  file: |
-    server:
-      http_listen_port: {{ .Values.config.serverPort }}
-
-    client:
-      url: {{ .Values.config.lokiAddress }}
-
-    positions:
-      filename: /run/promtail/positions.yaml
-
-    scrape_configs:
-      # This reuses the existing default scrape configs
-      {{- tpl .Values.config.snippets.scrapeConfigs . | nindent 2 }}
-
+  snippets:
+    extraScrapeConfigs:
       # Add an additional scrape config for syslog
       - job_name: syslog
         syslog:
@@ -178,20 +166,8 @@ config:
 
 ```yaml
 config:
-  file: |
-    server:
-      http_listen_port: {{ .Values.config.serverPort }}
-
-    client:
-      url: {{ .Values.config.lokiAddress }}
-
-    positions:
-      filename: /run/promtail/positions.yaml
-
-    scrape_configs:
-      # This reuses the existing default scrape configs
-      {{- tpl .Values.config.snippets.scrapeConfigs . | nindent 2 }}
-
+  snippets:
+    extraScrapeConfigs:
       # Add an additional scrape config for syslog
       - job_name: journal
         journal:
@@ -251,4 +227,20 @@ config:
             grpc_listen_port: {{ .Values.extraPorts.grpcPush.containerPort }}
           labels:
             pushserver: push1
+```
+
+### Extra client config options
+
+If you want to add additional options to the `client` section of promtail's config, please use
+the `extraClientConfigs` section. For example, to enable HTTP basic auth and include OrgID
+header, you can use:
+
+```yaml
+config:
+  snippets:
+    extraClientConfigs:
+      basic_auth:
+        username: loki
+        password: secret
+      tenant_id: 1
 ```

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -80,6 +80,8 @@ The new release which will pick up again from the existing `positions.yaml`.
 | extraPorts | object | `{}` | Configure additional ports and services. For each configured port, a corresponding service is created. See values.yaml for details |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
+| extra_client_configs | object | empty | You can put here any keys that will be directly added to the config file's 'client' block. |
+| extra_scrape_configs | object | empty | You can put here any additional scrape configs you want to add to the config file. |
 | fullnameOverride | string | `nil` | Overrides the chart's computed fullname |
 | image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | image.registry | string | `"docker.io"` | The Docker registry |

--- a/charts/promtail/README.md.gotmpl
+++ b/charts/promtail/README.md.gotmpl
@@ -89,7 +89,7 @@ extraPorts:
 
 config:
   snippets:
-    extraScrapeConfigs:
+    extraScrapeConfigs: |
       # Add an additional scrape config for syslog
       - job_name: syslog
         syslog:
@@ -107,7 +107,7 @@ config:
 ```yaml
 config:
   snippets:
-    extraScrapeConfigs:
+    extraScrapeConfigs: |
       # Add an additional scrape config for syslog
       - job_name: journal
         journal:
@@ -178,7 +178,7 @@ header, you can use:
 ```yaml
 config:
   snippets:
-    extraClientConfigs:
+    extraClientConfigs: |
       basic_auth:
         username: loki
         password: secret

--- a/charts/promtail/README.md.gotmpl
+++ b/charts/promtail/README.md.gotmpl
@@ -88,20 +88,8 @@ extraPorts:
       loadBalancerIP: 123.234.123.234
 
 config:
-  file: |
-    server:
-      http_listen_port: {{"{{"}} .Values.config.serverPort {{"}}"}}
-
-    client:
-      url: {{"{{"}} .Values.config.lokiAddress {{"}}"}}
-
-    positions:
-      filename: /run/promtail/positions.yaml
-
-    scrape_configs:
-      # This reuses the existing default scrape configs
-      {{"{{"}}- tpl .Values.config.snippets.scrapeConfigs . | nindent 2 {{"}}"}}
-
+  snippets:
+    extraScrapeConfigs:
       # Add an additional scrape config for syslog
       - job_name: syslog
         syslog:
@@ -118,20 +106,8 @@ config:
 
 ```yaml
 config:
-  file: |
-    server:
-      http_listen_port: {{"{{"}} .Values.config.serverPort {{"}}"}}
-
-    client:
-      url: {{"{{"}} .Values.config.lokiAddress {{"}}"}}
-
-    positions:
-      filename: /run/promtail/positions.yaml
-
-    scrape_configs:
-      # This reuses the existing default scrape configs
-      {{"{{"}}- tpl .Values.config.snippets.scrapeConfigs . | nindent 2 {{"}}"}}
-
+  snippets:
+    extraScrapeConfigs:
       # Add an additional scrape config for syslog
       - job_name: journal
         journal:
@@ -191,4 +167,20 @@ config:
             grpc_listen_port: {{"{{"}} .Values.extraPorts.grpcPush.containerPort {{"}}"}}
           labels:
             pushserver: push1
+```
+
+### Extra client config options
+
+If you want to add additional options to the `client` section of promtail's config, please use
+the `extraClientConfigs` section. For example, to enable HTTP basic auth and include OrgID
+header, you can use:
+
+```yaml
+config:
+  snippets:
+    extraClientConfigs:
+      basic_auth:
+        username: loki
+        password: secret
+      tenant_id: 1
 ```

--- a/charts/promtail/ci/service-values.yaml
+++ b/charts/promtail/ci/service-values.yaml
@@ -13,19 +13,8 @@ extraPorts:
     containerPort: 3600
 
 config:
-  file: |
-    server:
-      http_listen_port: {{ .Values.config.serverPort }}
-
-    client:
-      url: {{ .Values.config.lokiAddress }}
-
-    positions:
-      filename: /run/promtail/positions.yaml
-
-    scrape_configs:
-      {{- tpl .Values.config.snippets.scrapeConfigs . | nindent 2 }}
-
+  snippets:
+    extraScrapeConfigs: |
       - job_name: syslog
         syslog:
           listen_address: 0.0.0.0:{{ .Values.extraPorts.syslog.containerPort }}

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -214,14 +214,6 @@ podSecurityPolicy:
   requiredDropCapabilities:
     - ALL
 
-# -- You can put here any keys that will be directly added to the config file's 'client' block.
-# @default -- empty
-extraClientConfigs: {}
-
-# -- You can put here any additional scrape configs you want to add to the config file.
-# @default -- empty
-extraScrapeConfigs: {}
-
 # -- Section for crafting Promtails config file. The only directly relevant value is `config.file`
 # which is a templated string that references the other values and snippets below this key.
 # @default -- See `values.yaml`
@@ -283,6 +275,14 @@ config:
     # If set to true, adds an additional label for the scrape job.
     # This helps debug the Promtail config.
     addScrapeJobLabel: false
+
+    # -- You can put here any keys that will be directly added to the config file's 'client' block.
+    # @default -- empty
+    extraClientConfigs: {}
+    
+    # -- You can put here any additional scrape configs you want to add to the config file.
+    # @default -- empty
+    extraScrapeConfigs: {}
 
     scrapeConfigs: |
       # See also https://github.com/grafana/loki/blob/master/production/ksonnet/promtail/scrape_config.libsonnet for reference

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -214,6 +214,14 @@ podSecurityPolicy:
   requiredDropCapabilities:
     - ALL
 
+# -- You can put here any keys that will be directly added to the config file's 'client' block.
+# @default -- empty
+extra_client_configs: {}
+
+# -- You can put here any additional scrape configs you want to add to the config file.
+# @default -- empty
+extra_scrape_configs: {}
+
 # -- Section for crafting Promtails config file. The only directly relevant value is `config.file`
 # which is a templated string that references the other values and snippets below this key.
 # @default -- See `values.yaml`
@@ -431,9 +439,11 @@ config:
 
     client:
       url: {{ .Values.config.lokiAddress }}
+      {{- toYaml .Values.extra_client_configs | nindent 2 }}
 
     positions:
       filename: /run/promtail/positions.yaml
 
     scrape_configs:
       {{- tpl .Values.config.snippets.scrapeConfigs $ | nindent 2 }}
+      {{- toYaml .Values.extra_scrape_configs | nindent 2 }}

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -216,11 +216,11 @@ podSecurityPolicy:
 
 # -- You can put here any keys that will be directly added to the config file's 'client' block.
 # @default -- empty
-extra_client_configs: {}
+extraClientConfigs: {}
 
 # -- You can put here any additional scrape configs you want to add to the config file.
 # @default -- empty
-extra_scrape_configs: {}
+extraScrapeConfigs: {}
 
 # -- Section for crafting Promtails config file. The only directly relevant value is `config.file`
 # which is a templated string that references the other values and snippets below this key.
@@ -439,11 +439,11 @@ config:
 
     client:
       url: {{ .Values.config.lokiAddress }}
-      {{- toYaml .Values.extra_client_configs | nindent 2 }}
+      {{- toYaml .Values.extraClientConfigs | nindent 2 }}
 
     positions:
       filename: /run/promtail/positions.yaml
 
     scrape_configs:
       {{- tpl .Values.config.snippets.scrapeConfigs $ | nindent 2 }}
-      {{- toYaml .Values.extra_scrape_configs | nindent 2 }}
+      {{- toYaml .Values.extraScrapeConfigs | nindent 2 }}

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -439,11 +439,11 @@ config:
 
     client:
       url: {{ .Values.config.lokiAddress }}
-      {{- toYaml .Values.extraClientConfigs | nindent 2 }}
+      {{- tpl .Values.config.snippets.extraClientConfigs . | nindent 2 }}
 
     positions:
       filename: /run/promtail/positions.yaml
 
     scrape_configs:
-      {{- tpl .Values.config.snippets.scrapeConfigs $ | nindent 2 }}
-      {{- toYaml .Values.extraScrapeConfigs | nindent 2 }}
+      {{- tpl .Values.config.snippets.scrapeConfigs . | nindent 2 }}
+      {{- tpl .Values.config.snippets.extraScrapeConfigs . | nindent 2 }}

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -278,11 +278,11 @@ config:
 
     # -- You can put here any keys that will be directly added to the config file's 'client' block.
     # @default -- empty
-    extraClientConfigs: {}
-    
+    extraClientConfigs: ""
+
     # -- You can put here any additional scrape configs you want to add to the config file.
     # @default -- empty
-    extraScrapeConfigs: {}
+    extraScrapeConfigs: ""
 
     scrapeConfigs: |
       # See also https://github.com/grafana/loki/blob/master/production/ksonnet/promtail/scrape_config.libsonnet for reference


### PR DESCRIPTION
This PR adds the following options, which were available previously:
- add custom keys to the `client` section of the config file
- add extra scrape configs directly (to allow for journal or static scrapping)