### PR TITLE
[promtail] fix: PSP reference in role was wrong and PSP needs to allow privileged

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.1.0
-version: 3.0.2
+version: 3.0.3
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 3.0.2](https://img.shields.io/badge/Version-3.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 3.0.3](https://img.shields.io/badge/Version-3.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/templates/role.yaml
+++ b/charts/promtail/templates/role.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "promtail.labels" . | nindent 4 }}
 rules:
   - apiGroups:
-      - extensions
+      - policy
     resources:
       - podsecuritypolicies
     verbs:

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -193,8 +193,8 @@ extraPorts: {}
 # -- PodSecurityPolicy configuration.
 # @default -- See `values.yaml`
 podSecurityPolicy:
-  privileged: false
-  allowPrivilegeEscalation: false
+  privileged: true
+  allowPrivilegeEscalation: true
   volumes:
     - 'secret'
     - 'hostPath'


### PR DESCRIPTION
There are 2 issues when you try to run promtail on a cluster that enforces PSPs
(and you have in the config:
```yaml
rbac:
  create: true
  pspEnabled: true
```

* API group reference in role is wrong (must be `policy`
* the PSP doesn't allow for `privileged`, but must run as user 0

Credits: @glitchcrab

Signed-off-by: Łukasz Piątkowski <piontec@gmail.com>