### PR TITLE
(fluent-bit chart) allow labels to be optional

### DIFF
--- a/charts/fluent-bit/templates/configmap.yaml
+++ b/charts/fluent-bit/templates/configmap.yaml
@@ -43,7 +43,9 @@ data:
         TenantID {{ .Values.config.tenantID }}
         BatchWait {{ .Values.config.batchWait }}
         BatchSize {{ int .Values.config.batchSize }}
+        {{- if .Values.config.labels }}
         Labels {{ .Values.config.labels }}
+        {{- end }}
         RemoveKeys {{ include "helm-toolkit.utils.joinListWithComma" .Values.config.removeKeys }}
         AutoKubernetesLabels {{ .Values.config.autoKubernetesLabels }}
         LabelMapPath /fluent-bit/etc/labelmap.json


### PR DESCRIPTION
Sometimes you just don't want to use the labels field, however, the current helm chart doesn't allow it.