### PR TITLE
[promtail] Disable initContainer by default

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.1.0
-version: 3.0.3
+version: 3.0.4
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 3.0.3](https://img.shields.io/badge/Version-3.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 3.0.4](https://img.shields.io/badge/Version-3.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 
@@ -86,7 +86,7 @@ The new release which will pick up again from the existing `positions.yaml`.
 | image.repository | string | `"grafana/promtail"` | Docker image repository |
 | image.tag | string | `nil` | Overrides the image tag whose default is the chart's appVersion |
 | imagePullSecrets | list | `[]` | Image pull secrets for Docker images |
-| initContainer.enabled | bool | `true` | Specifies whether the init container for setting inotify max user instances is to be enabled |
+| initContainer.enabled | bool | `false` | Specifies whether the init container for setting inotify max user instances is to be enabled |
 | initContainer.fsInotifyMaxUserInstances | int | `128` | The inotify max user instances to configure |
 | initContainer.image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy for the init container image |
 | initContainer.image.registry | string | `"docker.io"` | The Docker registry for the init container |

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -6,7 +6,7 @@ fullnameOverride: null
 
 initContainer:
   # -- Specifies whether the init container for setting inotify max user instances is to be enabled
-  enabled: true
+  enabled: false
   image:
     # -- The Docker registry for the init container
     registry: docker.io


### PR DESCRIPTION
The Promtail initContainer is enabled by default which sets the `fs.inotify.max_user_instances` sysctl to `128`.
This sysctl is not namespaced and it's value is applied to the node.
Also the default value of `128` is too low and can cause issues for other pods running on bigger nodes.
Therefore the sysctl must be disabled by default.