### PR TITLE
[loki] Adding chown init container

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 2.3.0
+version: 2.3.1
 appVersion: v2.1.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki/templates/_pod.tpl
+++ b/charts/loki/templates/_pod.tpl
@@ -1,0 +1,26 @@
+{{- define "loki.initContainers" }}
+{{- if .Values.initContainers }}
+  {{- toYaml .Values.initContainers | nindent 8 }}
+{{- end }}
+{{- if ( and .Values.persistence.enabled .Values.initChownData.enabled ) }}
+- name: init-chown-data
+  {{- if .Values.initChownData.image.sha }}
+  image: "{{ .Values.initChownData.image.repository }}:{{ .Values.initChownData.image.tag }}@sha256:{{ .Values.initChownData.image.sha }}"
+  {{- else }}
+  image: "{{ .Values.initChownData.image.repository }}:{{ .Values.initChownData.image.tag }}"
+  {{- end }}
+  imagePullPolicy: {{ .Values.initChownData.image.pullPolicy }}
+  securityContext:
+    runAsNonRoot: false
+    runAsUser: 0
+  command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsGroup }}", "/data"]
+  resources:
+{{ toYaml .Values.initChownData.resources | indent 6 }}
+  volumeMounts:
+    - name: storage
+      mountPath: "/data"
+{{- if .Values.persistence.subPath }}
+      subPath: {{ .Values.persistence.subPath }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/loki/templates/statefulset.yaml
+++ b/charts/loki/templates/statefulset.yaml
@@ -42,7 +42,7 @@ spec:
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
       initContainers:
-        {{- toYaml .Values.initContainers | nindent 8 }}
+        {{- include "loki.initContainers" . | nindent 8 }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -147,6 +147,20 @@ persistence:
   # subPath: ""
   # existingClaim:
 
+initChownData:
+  ## If false, data ownership will not be reset at startup
+  ## This allows the prometheus-server to be run with an arbitrary user
+  ##
+  enabled: true
+
+  ## initChownData container image
+  ##
+  image:
+    repository: busybox
+    tag: "1.31.1"
+    sha: ""
+    pullPolicy: IfNotPresent
+
 ## Pod Labels
 podLabels: {}
 


### PR DESCRIPTION
Hello. Can we add init container for changing pvc data path owner like in grafana helm templates?