### PR TITLE
[grafana] Support in-memory for non-persistent local storage

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.3.0
+version: 6.4.0
 appVersion: 7.4.0
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -100,6 +100,8 @@ This version requires Helm >= 3.1.0.
 | `persistence.annotations`                 | PersistentVolumeClaim annotations             | `{}`                                                    |
 | `persistence.finalizers`                  | PersistentVolumeClaim finalizers              | `[ "kubernetes.io/pvc-protection" ]`                    |
 | `persistence.subPath`                     | Mount a sub dir of the persistent volume      | `nil`                                                   |
+| `persistence.inMemory.enabled`            | If persistence is not enabled, whether to mount the local storage in-memory to improve performance | `false`                                                   |
+| `persistence.inMemory.sizeLimit`          | SizeLimit for the in-memory local storage     | `nil`                                                   |
 | `initChownData.enabled`                   | If false, don't reset data ownership at startup | true                                                  |
 | `initChownData.image.repository`          | init-chown-data container image repository    | `busybox`                                               |
 | `initChownData.image.tag`                 | init-chown-data container image tag           | `1.31.1`                                                |

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -431,7 +431,15 @@ volumes:
 # nothing
 {{- else }}
   - name: storage
+{{- if .Values.persistence.inMemory.enabled }}
+    emptyDir:
+      medium: Memory
+{{- if .Values.persistence.inMemory.sizeLimit }}
+      sizeLimit: {{ .Values.persistence.inMemory.sizeLimit }}
+{{- end -}}
+{{- else }}
     emptyDir: {}
+{{- end -}}
 {{- end -}}
 {{- if .Values.sidecar.dashboards.enabled }}
   - name: sc-dashboard-volume

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -246,6 +246,17 @@ persistence:
   # subPath: ""
   # existingClaim:
 
+  ## If persistence is not enabled, this allows to mount the
+  ## local storage in-memory to improve performance
+  ##
+  inMemory:
+    enabled: false
+    ## The maximum usage on memory medium EmptyDir would be
+    ## the minimum value between the SizeLimit specified
+    ## here and the sum of memory limits of all containers in a pod
+    ##
+    # sizeLimit: 300Mi
+
 initChownData:
   ## If false, data ownership will not be reset at startup
   ## This allows the prometheus-server to be run with an arbitrary user


### PR DESCRIPTION
This PR adds support for mounting the Grafana non-persistent local storage in-memory (tmpfs).
That allows to get better performance when you don't need persistence and when the load on Grafana is high enough to create a lot of "locked db" issues, but not enough to warrant a dedicated external RDBMS.