### PR TITLE
[loki] Fix bug when rbac.pspEnabled=false and when securityContext=false

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 2.5.0
+version: 2.5.1
 appVersion: v2.2.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki/templates/role.yaml
+++ b/charts/loki/templates/role.yaml
@@ -15,6 +15,7 @@ rules:
   resources:      ['podsecuritypolicies']
   verbs:          ['use']
   resourceNames:  [{{ template "loki.fullname" . }}]
+{{- else }}
+rules: []
 {{- end }}
 {{- end }}
-

--- a/charts/loki/templates/statefulset.yaml
+++ b/charts/loki/templates/statefulset.yaml
@@ -39,8 +39,10 @@ spec:
     {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
     {{- end }}
+      {{- if .Values.securityContext }}
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
+      {{- end }}
       initContainers:
         {{- toYaml .Values.initContainers | nindent 8 }}
       {{- if .Values.image.pullSecrets }}


### PR DESCRIPTION
### Problem 1

When installing the loki charts with rbac.pspEnabled=false, the resulting Role object is rendered without `rules`:

```
$ helm template --set rbac.pspEnabled=false .
...
---
# Source: loki/templates/role.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: RELEASE-NAME-loki
  namespace: operations-cluster
  labels:
    app: loki
    chart: loki-2.3.0
    heritage: Helm
    release: RELEASE-NAME
---
...
```

Since `rules` is required, trying to install this Role object will fail validation:

```
$ helm install --set rbac.pspEnabled=false myloki .
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Role): missing required field "rules" in io.k8s.api.rbac.v1.Role
```

For context, my use-case is that the administrators of the Kubernetes cluster I'm using have disabled access to PodSecurityPolicies:

```
User "machaffe" cannot get podsecuritypolicies.policy at the cluster scope: no RBAC policy matched
```

This PR will make it so that rbac.pspEnabled=false will still render the required `rules: []` field.

```
$ helm template --set rbac.pspEnabled=false . | grep rules
rules: []
```

### Problem 2
When installing the loki chart in OpenShift, my cluster is configured to provide the securityContext via an admission controller (I think) so I need to disable the default securityContext. You can do this in e.g. the grafana helm chart by setting `securityContext=false`, but this won't work in the loki helm chart:

```
Error: UPGRADE FAILED: error validating "": error validating data: ValidationError(StatefulSet.spec.template.spec.securityContext): invalid type for io.k8s.api.core.v1.PodSecurityContext: got "boolean", expected "map"
``` 

So I changed the loki chart to allow disabling the securityContext all together similar to the grafana chart. Might be related to https://github.com/grafana/loki/issues/1458