### PR TITLE
Make swartz-k a tempo codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,5 +9,5 @@
 /charts/grafana/ @maorfr @rtluckie @torstenwalter @Xtigyro @zanhsieh
 /charts/loki-distributed/ @unguiculus
 /charts/loki-canary/ @unguiculus
-/charts/tempo @joe-elliott @annanay25 @mdisibio @dgzlopes
-/charts/tempo-distributed @joe-elliott @annanay25 @mdisibio @dgzlopes
+/charts/tempo @swartz-k @joe-elliott @annanay25 @mdisibio @dgzlopes 
+/charts/tempo-distributed @swartz-k @joe-elliott @annanay25 @mdisibio @dgzlopes


### PR DESCRIPTION
@swartz-k is the original author of the tempo helm charts and wants to participate in maintaining them moving forward.