### PR TITLE
[grafana] updated grafana / sidecar image & repo

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.4.2
-appVersion: 7.4.1
+version: 6.4.3
+appVersion: 7.4.2
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -132,8 +132,8 @@ This version requires Helm >= 3.1.0.
 | `podAnnotations`                          | Pod annotations                               | `{}`                                                    |
 | `podLabels`                               | Pod labels                                    | `{}`                                                    |
 | `podPortName`                             | Name of the grafana port on the pod           | `grafana`                                               |
-| `sidecar.image.repository`                | Sidecar image repository                      | `kiwigrid/k8s-sidecar`                                  |
-| `sidecar.image.tag`                       | Sidecar image tag                             | `1.10.0`                                                 |
+| `sidecar.image.repository`                | Sidecar image repository                      | `quay.io/kiwigrid/k8s-sidecar`                          |
+| `sidecar.image.tag`                       | Sidecar image tag                             | `1.10.6`                                                |
 | `sidecar.image.sha`                       | Sidecar image sha (optional)                  | `""`                                                    |
 | `sidecar.imagePullPolicy`                 | Sidecar image pull policy                     | `IfNotPresent`                                          |
 | `sidecar.resources`                       | Sidecar resources                             | `{}`                                                    |

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -59,7 +59,7 @@ This version requires Helm >= 3.1.0.
 | `securityContext`                         | Deployment securityContext                    | `{"runAsUser": 472, "runAsGroup": 472, "fsGroup": 472}`  |
 | `priorityClassName`                       | Name of Priority Class to assign pods         | `nil`                                                   |
 | `image.repository`                        | Image repository                              | `grafana/grafana`                                       |
-| `image.tag`                               | Image tag (`Must be >= 5.0.0`)                | `7.0.3`                                                 |
+| `image.tag`                               | Image tag (`Must be >= 5.0.0`)                | `7.4.2`                                                 |
 | `image.sha`                               | Image sha (optional)                          | `17cbd08b9515fda889ca959e9d72ee6f3327c8f1844a3336dfd952134f38e2fe` |
 | `image.pullPolicy`                        | Image pull policy                             | `IfNotPresent`                                          |
 | `image.pullSecrets`                       | Image pull secrets                            | `{}`                                                    |

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -53,7 +53,7 @@ livenessProbe:
 
 image:
   repository: grafana/grafana
-  tag: 7.4.1
+  tag: 7.4.2
   sha: ""
   pullPolicy: IfNotPresent
 

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -561,8 +561,8 @@ smtp:
 ## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards
 sidecar:
   image:
-    repository: kiwigrid/k8s-sidecar
-    tag: 1.10.0
+    repository: quay.io/kiwigrid/k8s-sidecar
+    tag: 1.10.6
     sha: ""
   imagePullPolicy: IfNotPresent
   resources: {}


### PR DESCRIPTION
Signed-off-by: André Bauer <monotek23@gmail.com>

* updates grafana to 7.4.2
* updates k8s-sidcar image to 1.10.6 (fixes https://github.com/grafana/helm-charts/issues/233)
* changed sidcar repo to quay.io to prevent dockerhub limits errors
