### PR TITLE
[grafana] Added support for auth tokens for local dashboards

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.4.3
+version: 6.4.4
 appVersion: 7.4.2
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/configmap.yaml
+++ b/charts/grafana/templates/configmap.yaml
@@ -59,6 +59,9 @@ data:
     --max-time 60 \
       {{- if not $value.b64content }}
     -H "Accept: application/json" \
+        {{- if $value.token }}
+    -H "Authorization: token {{ $value.token }}" \
+        {{- end }}
     -H "Content-Type: application/json;charset=UTF-8" \
       {{ end }}
     {{- if $value.url -}}"{{ $value.url }}"{{- else -}}"https://grafana.com/api/dashboards/{{ $value.gnetId }}/revisions/{{- if $value.revision -}}{{ $value.revision }}{{- else -}}1{{- end -}}/download"{{- end -}}{{ if $value.datasource }} | sed '/-- .* --/! s/"datasource":.*,/"datasource": "{{ $value.datasource }}",/g'{{ end }}{{- if $value.b64content -}} | base64 -d {{- end -}} \

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -470,8 +470,10 @@ dashboards: {}
   #     datasource: Prometheus
   #   local-dashboard:
   #     url: https://example.com/repository/test.json
+  #     token: ''
   #   local-dashboard-base64:
   #     url: https://example.com/repository/test-b64.json
+  #     token: ''
   #     b64content: true
 
 ## Reference to external ConfigMap per provider. Use provider name as key and ConfigMap name as value.


### PR DESCRIPTION
Signed-off-by: dkusidlo <dennis.kusidlo@gmail.com>

When using GitHub Enterprise for local dashboards the raw token expires after 14 days and tokenless curl is not supported.
Personal access tokens do not expire and would fix this problem, but do not work when provided in the URL with `?token=`. There we would need support for an optional `Authorization` header in the curl command of the download_dashboards.sh.

