### PR TITLE
[tempo-distributed] Add options for LoadBalancer Distributor.

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.7.0
+version: 0.7.1
 appVersion: 0.6.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.7.1
+version: 0.8.0
 appVersion: 0.6.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
+![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -58,7 +58,9 @@ The memcached default args are removed and should be provided manually. The sett
 | distributor.replicas | int | `1` | Number of replicas for the distributor |
 | distributor.resources | object | `{}` | Resource requests and limits for the distributor |
 | distributor.service.annotations | object | `{}` | Annotations for distributor service |
-| distributor.service.type | string | `"ClusterIP"` |  |
+| distributor.service.loadBalancerIP | string | `""` | If type is LoadBalancer you can assign the IP to the LoadBalancer |
+| distributor.service.loadBalancerSourceRanges | list | `[]` | If type is LoadBalancer limit incoming traffic from IPs. |
+| distributor.service.type | string | `"ClusterIP"` | Type of service for the distributor |
 | distributor.terminationGracePeriodSeconds | int | `30` | Grace period to allow the distributor to shutdown before it is killed |
 | distributor.tolerations | list | `[]` | Tolerations for distributor pods |
 | global.image.registry | string | `nil` | Overrides the Docker registry globally for all images |
@@ -139,6 +141,7 @@ The memcached default args are removed and should be provided manually. The sett
 | queryFrontend.query.resources | object | `{}` | Resource requests and limits for the query |
 | queryFrontend.replicas | int | `1` | Number of replicas for the query-frontend |
 | queryFrontend.resources | object | `{}` | Resource requests and limits for the query-frontend |
+| queryFrontend.service.annotations | object | `{}` | Annotations for queryFrontend service |
 | queryFrontend.terminationGracePeriodSeconds | int | `30` | Grace period to allow the query-frontend to shutdown before it is killed |
 | queryFrontend.tolerations | list | `[]` | Tolerations for query-frontend pods |
 | serviceAccount.annotations | object | `{}` | Annotations for the service account |

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -28,7 +28,6 @@ For example to enable Jaeger grpc thrift http and zipkin protocols:
 ```yaml
 traces:
   jaeger:
-    enabled: true
     grpc: true
     thriftHttp: true
   zipkin: true

--- a/charts/tempo-distributed/README.md.gotmpl
+++ b/charts/tempo-distributed/README.md.gotmpl
@@ -20,6 +20,20 @@ helm repo add grafana https://grafana.github.io/helm-charts
 
 A major chart version change indicates that there is an incompatible breaking change needing manual actions.
 
+### From Chart versions < 0.8.0
+
+By default all tracing protocols are disabled and you need to specify which protocols to enable for ingestion.
+
+For example to enable Jaeger grpc thrift http and zipkin protocols:
+```yaml
+traces:
+  jaeger:
+    enabled: true
+    grpc: true
+    thriftHttp: true
+  zipkin: true
+```
+
 ### From Chart Versions < 0.7.0
 
 The memcached default args are removed and should be provided manually. The settings for the `memcached.exporter` moved to `memcachedExporter`

--- a/charts/tempo-distributed/README.md.gotmpl
+++ b/charts/tempo-distributed/README.md.gotmpl
@@ -34,6 +34,8 @@ traces:
   zipkin: true
 ```
 
+The distributor service is now called {{"{{"}}tempo.fullname{{"}}"}}-distributor. That could impact your ingestion towards this service.
+
 ### From Chart Versions < 0.7.0
 
 The memcached default args are removed and should be provided manually. The settings for the `memcached.exporter` moved to `memcachedExporter`

--- a/charts/tempo-distributed/README.md.gotmpl
+++ b/charts/tempo-distributed/README.md.gotmpl
@@ -28,7 +28,6 @@ For example to enable Jaeger grpc thrift http and zipkin protocols:
 ```yaml
 traces:
   jaeger:
-    enabled: true
     grpc: true
     thriftHttp: true
   zipkin: true

--- a/charts/tempo-distributed/templates/distributor/deployment-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/deployment-distributor.yaml
@@ -64,7 +64,7 @@ spec:
               name: zipkin
               protocol: TCP
             {{- end }}
-            {{- if .Values.traces.otlp }}
+            {{- if or (.Values.traces.otlp.http) (.Values.traces.otlp.grpc) }}
             - containerPort: 55680
               name: otlp
               protocol: TCP

--- a/charts/tempo-distributed/templates/distributor/deployment-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/deployment-distributor.yaml
@@ -1,8 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: distributor
-  name: {{ template "tempo.fullname" . }}
+  name: {{ template "tempo.fullname" . }}-distributor
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "tempo.distributorLabels" . | nindent 4 }}
@@ -40,10 +39,41 @@ spec:
               protocol: TCP
             - containerPort: 3100
               name: http
+            {{- if .Values.traces.jaeger.thriftCompact }}
+            - containerPort: 6831
+              name: jaeger-thrift-compact
+              protocol: UDP
+            {{- end }}
+            {{- if .Values.traces.jaeger.thriftBinary }}
+            - containerPort: 6832
+              name: jaeger-thrift-binary
+              protocol: UDP
+            {{- end }}
+            {{- if .Values.traces.jaeger.thriftHttp }}
+            - containerPort: 14268
+              name: jaeger-thrift-http
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.traces.jaeger.grpc }}
+            - containerPort: 14250
+              name: jaeger-grpc
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.traces.zipkin }}
+            - containerPort: 9411
+              name: zipkin
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.traces.otlp }}
+            - containerPort: 55680
+              name: otlp
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.traces.opencensus }}
             - containerPort: 55678
               name: opencensus
-            - containerPort: 14268
-              name: jaeger-http
+              protocol: TCP
+            {{- end }}
           {{- with .Values.distributor.extraEnv }}
           env:
             {{- toYaml . | nindent 12 }}

--- a/charts/tempo-distributed/templates/distributor/deployment-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/deployment-distributor.yaml
@@ -41,17 +41,17 @@ spec:
               name: http
             {{- if .Values.traces.jaeger.thriftCompact }}
             - containerPort: 6831
-              name: jaeger-thrift-compact
+              name: jaeger-compact
               protocol: UDP
             {{- end }}
             {{- if .Values.traces.jaeger.thriftBinary }}
             - containerPort: 6832
-              name: jaeger-thrift-binary
+              name: jaeger-binary
               protocol: UDP
             {{- end }}
             {{- if .Values.traces.jaeger.thriftHttp }}
             - containerPort: 14268
-              name: jaeger-thrift-http
+              name: jaeger-http
               protocol: TCP
             {{- end }}
             {{- if .Values.traces.jaeger.grpc }}

--- a/charts/tempo-distributed/templates/distributor/service-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/service-distributor.yaml
@@ -1,4 +1,4 @@
-  apiVersion: v1
+apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "tempo.fullname" . }}

--- a/charts/tempo-distributed/templates/distributor/service-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/service-distributor.yaml
@@ -15,6 +15,10 @@ spec:
     - name: http
       port: 3100
       targetPort: http
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: 9095
     {{- if .Values.traces.jaeger.thriftCompact }}
     - name: distributor-jaeger-thrift-compact
       port: 6831
@@ -45,7 +49,7 @@ spec:
       protocol: TCP
       targetPort: zipkin
     {{- end }}
-    {{- if .Values.traces.otlp }}
+    {{- if or (.Values.traces.otlp.http) (.Values.traces.otlp.grpc) }}
     - name: distributor-otlp
       port: 55680
       protocol: TCP

--- a/charts/tempo-distributed/templates/distributor/service-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/service-distributor.yaml
@@ -23,19 +23,19 @@ spec:
     - name: distributor-jaeger-thrift-compact
       port: 6831
       protocol: UDP
-      targetPort: jaeger-thrift-compact
+      targetPort: jaeger-compact
     {{- end }}
     {{- if .Values.traces.jaeger.thriftBinary }}
     - name: distributor-jaeger-thrift-binary
       port: 6832
       protocol: UDP
-      targetPort: jaeger-thrift-binary
+      targetPort: jaeger-binary
     {{- end }}
     {{- if .Values.traces.jaeger.thriftHttp }}
     - name: distributor-jaeger-thrift-http
       port: 14268
       protocol: TCP
-      targetPort: jaeger-thrift-http
+      targetPort: jaeger-http
     {{- end }}
     {{- if .Values.traces.jaeger.grpc }}
     - name: distributor-jaeger-grpc

--- a/charts/tempo-distributed/templates/distributor/service-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/service-distributor.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "tempo.fullname" . }}
+  name: {{ template "tempo.fullname" . }}-distributor
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.distributorLabels" . | nindent 4 }}
@@ -12,38 +12,51 @@ metadata:
 spec:
   type: {{ .Values.distributor.service.type }}
   ports:
+    - name: http
+      port: 3100
+      targetPort: http
+    {{- if .Values.traces.jaeger.thriftCompact }}
     - name: distributor-jaeger-thrift-compact
       port: 6831
       protocol: UDP
-      targetPort: 6831
-    - name: grpc
-      port: 9095
-      protocol: TCP
-      targetPort: 9095
+      targetPort: jaeger-thrift-compact
+    {{- end }}
+    {{- if .Values.traces.jaeger.thriftBinary }}
     - name: distributor-jaeger-thrift-binary
       port: 6832
       protocol: UDP
-      targetPort: 6832
+      targetPort: jaeger-thrift-binary
+    {{- end }}
+    {{- if .Values.traces.jaeger.thriftHttp }}
     - name: distributor-jaeger-thrift-http
       port: 14268
       protocol: TCP
-      targetPort: 14268
+      targetPort: jaeger-thrift-http
+    {{- end }}
+    {{- if .Values.traces.jaeger.grpc }}
     - name: distributor-jaeger-grpc
       port: 14250
       protocol: TCP
-      targetPort: 14250
+      targetPort: jaeger-grpc
+    {{- end }}
+    {{- if .Values.traces.zipkin }}
     - name: distributor-zipkin
       port: 9411
       protocol: TCP
-      targetPort: 9411
+      targetPort: zipkin
+    {{- end }}
+    {{- if .Values.traces.otlp }}
     - name: distributor-otlp
       port: 55680
       protocol: TCP
-      targetPort: 55680
+      targetPort: otlp
+    {{- end }}
+    {{- if .Values.traces.opencensus }}
     - name: distributor-opencensus
       port: 55678
       protocol: TCP
-      targetPort: 55678
+      targetPort: opencensus
+    {{- end }}
   {{- if .Values.distributor.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.distributor.service.loadBalancerIP  }}
   {{- end }}

--- a/charts/tempo-distributed/templates/distributor/service-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/service-distributor.yaml
@@ -1,14 +1,14 @@
-apiVersion: v1
+  apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "tempo.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.distributorLabels" . | nindent 4 }}
-{{- with .Values.distributor.service.annotations }}
+  {{- with .Values.distributor.service.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
-{{- end }}
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.distributor.service.type }}
   ports:
@@ -44,5 +44,12 @@ spec:
       port: 55678
       protocol: TCP
       targetPort: 55678
+  {{- if .Values.distributor.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.distributor.service.loadBalancerIP  }}
+  {{- end }}
+  {{- with .Values.distributor.service.loadBalancerSourceRanges}}
+  loadBalancerSourceRanges:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     {{- include "tempo.distributorSelectorLabels" . | nindent 4 }}

--- a/charts/tempo-distributed/templates/query-frontend/deployment-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/deployment-query-frontend.yaml
@@ -75,7 +75,7 @@ spec:
               name: jaeger-metrics
           env:
             - name: JAEGER_AGENT_HOST
-              value: {{ template "tempo.fullname" . }}
+              value: {{ template "tempo.fullname" . }}-distributor
           {{- with .Values.queryFrontend.query.extraEnv }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/tempo-distributed/templates/query-frontend/service-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/service-query-frontend.yaml
@@ -5,9 +5,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.queryFrontendLabels" . | nindent 4 }}
-  {{- with .Values.queryFrontend.annotations }}
+  {{- with .Values.queryFrontend.service.annotations }}
   annotations:
-    {{ toYaml . | indent 4 }}
+    {{ toYaml . | nindent 4 }}
   {{- end }}
 spec:
   ports:

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -112,7 +112,12 @@ distributor:
   service:
     # -- Annotations for distributor service
     annotations: {}
+    # -- Type of service for the distributor
     type: ClusterIP
+    # -- If type is LoadBalancer you can assign the IP to the LoadBalancer
+    loadBalancerIP: ""
+    # -- If type is LoadBalancer limit incoming traffic from IPs.
+    loadBalancerSourceRanges: []
   # -- The name of the PriorityClass for distributor pods
   priorityClassName: null
   # -- Annotations for distributor pods
@@ -266,6 +271,9 @@ queryFrontend:
     repository: null
     # -- Docker image tag for the query-frontend image. Overrides `tempo.image.tag`
     tag: null
+  service:
+    # -- Annotations for queryFrontend service
+    annotations: {}
   # -- The name of the PriorityClass for query-frontend pods
   priorityClassName: null
   # -- Annotations for query-frontend pods

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -313,6 +313,24 @@ queryFrontend:
   # -- Extra volumes for query-frontend deployment
   extraVolumes: []
 
+traces:
+  jaeger:
+    # -- Enable Tempo to ingest Jaeger traces. Enabling protocols from Jaeger is mandatory.
+    enabled: false
+    # -- Enable Tempo to ingest Jaeger GRPC traces
+    grpc: false
+    # -- Enable Tempo to ingest Jaeger Thrift Binary traces
+    thriftBinary: false
+    # -- Enable Tempo to ingest Jaeger Thrift Compact traces
+    thriftCompact: false
+    # -- Enable Tempo to ingest Jaeger Thrift HTTP traces
+    thriftHttp: false
+  # -- Enable Tempo to ingest Zipkin traces
+  zipkin: false
+  # -- Enable Tempo to ingest Open Telementry traces
+  otlp: false
+  # -- Enable Tempo to ingest Open Census traces
+  opencensus: false
 
 config: |
   auth_enabled: false
@@ -324,16 +342,42 @@ config: |
         store: memberlist
   distributor:
     receivers:
+      {{ if .Values.traces.jaeger.enabled }}
       jaeger:
         protocols:
-          grpc:
-            endpoint: 0.0.0.0:14250
-          thrift_binary:
-            endpoint: 0.0.0.0:6832
+          {{- if .Values.traces.jaeger.thriftCompact }}
           thrift_compact:
             endpoint: 0.0.0.0:6831
+          {{- end }}
+          {{- if .Values.traces.jaeger.thriftBinary }}
+          thrift_binary:
+            endpoint: 0.0.0.0:6832
+          {{- end }}
+          {{- if .Values.traces.jaeger.thriftHttp }}
           thrift_http:
             endpoint: 0.0.0.0:14268
+          {{- end }}
+          {{- if .Values.traces.jaeger.grpc }}
+          grpc:
+            endpoint: 0.0.0.0:14250
+          {{- end }}
+      {{- end }}
+      {{- if .Values.traces.zipkin}}
+      zipkin:
+        endpoint: 0.0.0.0:9411
+      {{- end }}
+      {{- if .Values.traces.otlp}}
+      otlp:
+        protocols:
+          http:
+            endpoint: 0.0.0.0:55680
+          grpc:
+            endpoint: 0.0.0.0:55680
+      {{- end }}
+      {{- if .Values.traces.opencensus}}
+      opencensus:
+        endpoint: 0.0.0.0:55678
+      {{- end }}
   querier:
     frontend_worker:
       frontend_address: {{ include "tempo.queryFrontendFullname" . }}:9095

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -315,8 +315,6 @@ queryFrontend:
 
 traces:
   jaeger:
-    # -- Enable Tempo to ingest Jaeger traces. Enabling protocols from Jaeger is mandatory.
-    enabled: false
     # -- Enable Tempo to ingest Jaeger GRPC traces
     grpc: false
     # -- Enable Tempo to ingest Jaeger Thrift Binary traces
@@ -327,8 +325,11 @@ traces:
     thriftHttp: false
   # -- Enable Tempo to ingest Zipkin traces
   zipkin: false
-  # -- Enable Tempo to ingest Open Telementry traces
-  otlp: false
+  otlp:
+    # -- Enable Tempo to ingest Open Telementry HTTP traces
+    http: false
+    # -- Enable Tempo to ingest Open Telementry GRPC traces
+    grpc: false
   # -- Enable Tempo to ingest Open Census traces
   opencensus: false
 
@@ -342,7 +343,7 @@ config: |
         store: memberlist
   distributor:
     receivers:
-      {{ if .Values.traces.jaeger.enabled }}
+      {{- if  or (.Values.traces.jaeger.thriftCompact) (.Values.traces.jaeger.thriftBinary) (.Values.traces.jaeger.thriftHttp) (.Values.traces.jaeger.grpc) }}
       jaeger:
         protocols:
           {{- if .Values.traces.jaeger.thriftCompact }}
@@ -366,13 +367,17 @@ config: |
       zipkin:
         endpoint: 0.0.0.0:9411
       {{- end }}
-      {{- if .Values.traces.otlp}}
+      {{- if or (.Values.traces.otlp.http) (.Values.traces.otlp.grpc) }}
       otlp:
         protocols:
+          {{- if .Values.traces.otlp.http }}
           http:
             endpoint: 0.0.0.0:55680
+          {{- end }}
+          {{- if .Values.traces.otlp.grpc }}
           grpc:
             endpoint: 0.0.0.0:55680
+          {{- end }}
       {{- end }}
       {{- if .Values.traces.opencensus}}
       opencensus:


### PR DESCRIPTION
**Description of changes**

With this change it would be possible to set additional settings in the Distributor service if you will use a `LoadBalancer` to receive traffic. Also fixed to add annotations in the QueryFrontend.

**Benefits**

- Specify which IP the LoadBalancer should get.
- Specify which IP ranges are allowed.
- Fix annotations in the queryFrontend service.

Signed-off-by: Whyeasy <Whyeasy@users.noreply.github.com>