### PR TITLE
[tempo-distributed] Fix replicas querier & deployment selectorlabels

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.8.0
+version: 0.8.1
 appVersion: 0.6.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/querier/deployment-querier.yaml
+++ b/charts/tempo-distributed/templates/querier/deployment-querier.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
 spec:
   minReadySeconds: 10
-  replicas: {{ .Values.queryFrontend.replicas }}
+  replicas: {{ .Values.querier.replicas }}
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/charts/tempo-distributed/templates/querier/deployment-querier.yaml
+++ b/charts/tempo-distributed/templates/querier/deployment-querier.yaml
@@ -15,7 +15,7 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      {{- include "tempo.querierLabels" . | nindent 6 }}
+      {{- include "tempo.querierSelectorLabels" . | nindent 6 }}
   strategy:
     rollingUpdate:
       maxSurge: 0

--- a/charts/tempo-distributed/templates/query-frontend/deployment-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/deployment-query-frontend.yaml
@@ -73,10 +73,8 @@ spec:
               name: jaeger-ui
             - containerPort: 16687
               name: jaeger-metrics
-          env:
-            - name: JAEGER_AGENT_HOST
-              value: {{ template "tempo.fullname" . }}-distributor
           {{- with .Values.queryFrontend.query.extraEnv }}
+          env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.queryFrontend.query.extraEnvFrom }}

--- a/charts/tempo-distributed/templates/query-frontend/deployment-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/deployment-query-frontend.yaml
@@ -15,7 +15,7 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      {{- include "tempo.queryFrontendLabels" . | nindent 6 }}
+      {{- include "tempo.queryFrontendSelectorLabels" . | nindent 6 }}
   strategy:
     rollingUpdate:
       maxSurge: 0


### PR DESCRIPTION
**Description**

Querier didn't had the correct replicas value pointed to it. Upgrading of a chart was not possible due to not using selector labels in the querier and queryFrontend deployment. Removed the hardcoded Jaeger client setting in `tempo-query`.

**Additional Information.**

Don't know if we need to make the chart `0.9.0` or `0.8.1` as upgrading was not working before and the actual deployments need to be deleted to make the upgrade work.