### PR TITLE
chore: Add enterprise-metrics repo dependencies to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,6 +41,9 @@ jobs:
           helm repo add elastic https://helm.elastic.co
           helm repo add grafana https://grafana.github.io/helm-charts
           helm repo add prometheus https://prometheus-community.github.io/helm-charts
+          helm repo add minio https://helm.min.io
+          helm repo add hashicorp https://helm.releases.hashicorp.com
+          helm repo add deprecated-helm-stable https://charts.helm.sh/stable
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.0


### PR DESCRIPTION
Should fix https://github.com/grafana/helm-charts/runs/2024690122

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>