### PR TITLE
[promtail] Set log_level without needing to overwrite server file

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.1.0
-version: 3.3.1
+version: 3.4.0
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.1.0
-version: 3.2.0
+version: 3.2.1
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 3.2.1](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 3.2.1](https://img.shields.io/badge/Version-3.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 
@@ -68,9 +68,9 @@ The new release which will pick up again from the existing `positions.yaml`.
 | annotations | object | `{}` | Annotations for the SaemonSet |
 | config | object | See `values.yaml` | Section for crafting Promtails config file. The only directly relevant value is `config.file` which is a templated string that references the other values and snippets below this key. |
 | config.file | string | See `values.yaml` | Config file contents for Promtail. Must be configured as string. It is templated so it can be assembled from reusable snippets in order to avoid redundancy. |
+| config.logLevel | string | `"info"` | The log level of the Promtail server Must be reference in `config.file` to configure `server.log_level` See default config in `values.yaml` |
 | config.lokiAddress | string | `"http://loki-gateway/loki/api/v1/push"` | The Loki address to post logs to. Must be reference in `config.file` to configure `client.url`. See default config in `values.yaml` |
 | config.serverPort | int | `3101` | The port of the Promtail server Must be reference in `config.file` to configure `server.http_listen_port` See default config in `values.yaml` |
-| config.logLevel | string | `info` | The log level of the Promtail server Must be reference in `config.file` to configure `server.log_level` See default config in `values.yaml` |
 | config.snippets | object | See `values.yaml` | A section of reusable snippets that can be reference in `config.file`. Custom snippets may be added in order to reduce redundancy. This is especially helpful when multiple `kubernetes_sd_configs` are use which usually have large parts in common. |
 | config.snippets.extraClientConfigs | string | empty | You can put here any keys that will be directly added to the config file's 'client' block. |
 | config.snippets.extraScrapeConfigs | string | empty | You can put here any additional scrape configs you want to add to the config file. |
@@ -210,6 +210,7 @@ extraPorts:
 config:
   file: |
     server:
+      log_level: {{ .Values.config.logLevel }}
       http_listen_port: {{ .Values.config.serverPort }}
 
     client:

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 3.2.1](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 
@@ -70,6 +70,7 @@ The new release which will pick up again from the existing `positions.yaml`.
 | config.file | string | See `values.yaml` | Config file contents for Promtail. Must be configured as string. It is templated so it can be assembled from reusable snippets in order to avoid redundancy. |
 | config.lokiAddress | string | `"http://loki-gateway/loki/api/v1/push"` | The Loki address to post logs to. Must be reference in `config.file` to configure `client.url`. See default config in `values.yaml` |
 | config.serverPort | int | `3101` | The port of the Promtail server Must be reference in `config.file` to configure `server.http_listen_port` See default config in `values.yaml` |
+| config.logLevel | string | `info` | The log level of the Promtail server Must be reference in `config.file` to configure `server.log_level` See default config in `values.yaml` |
 | config.snippets | object | See `values.yaml` | A section of reusable snippets that can be reference in `config.file`. Custom snippets may be added in order to reduce redundancy. This is especially helpful when multiple `kubernetes_sd_configs` are use which usually have large parts in common. |
 | config.snippets.extraClientConfigs | string | empty | You can put here any keys that will be directly added to the config file's 'client' block. |
 | config.snippets.extraScrapeConfigs | string | empty | You can put here any additional scrape configs you want to add to the config file. |

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 3.3.1](https://img.shields.io/badge/Version-3.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 3.4.0](https://img.shields.io/badge/Version-3.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/README.md.gotmpl
+++ b/charts/promtail/README.md.gotmpl
@@ -149,6 +149,7 @@ extraPorts:
 config:
   file: |
     server:
+      log_level: {{"}}"}} .Values.config.logLevel {{"}}"}}
       http_listen_port: {{"{{"}} .Values.config.serverPort {{"}}"}}
 
     client:

--- a/charts/promtail/README.md.gotmpl
+++ b/charts/promtail/README.md.gotmpl
@@ -149,7 +149,7 @@ extraPorts:
 config:
   file: |
     server:
-      log_level: {{"}}"}} .Values.config.logLevel {{"}}"}}
+      log_level: {{"{{"}} .Values.config.logLevel {{"}}"}}
       http_listen_port: {{"{{"}} .Values.config.serverPort {{"}}"}}
 
     client:

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -218,6 +218,10 @@ podSecurityPolicy:
 # which is a templated string that references the other values and snippets below this key.
 # @default -- See `values.yaml`
 config:
+  # -- The log level of the Promtail server
+  # Must be reference in `config.file` to configure `server.log_level`
+  # See default config in `values.yaml`
+  logLevel: info
   # -- The port of the Promtail server
   # Must be reference in `config.file` to configure `server.http_listen_port`
   # See default config in `values.yaml`
@@ -441,7 +445,7 @@ config:
   # @default -- See `values.yaml`
   file: |
     server:
-      log_level: info
+      log_level: {{ .Values.config.logLevel }}
       http_listen_port: {{ .Values.config.serverPort }}
 
     client:


### PR DESCRIPTION
This change adds the option to customize the existent log_level configuration in the config file without needing to replace the whole file in the local values.yaml as `file:` is a single string.

Signed-off-by: lucioveloso <lucio.veloso@gmail.com>