### PR TITLE
[grafana] fix Ingress resource API version compatibility check

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.4.7
+version: 6.4.8
 appVersion: 7.4.2
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/ingress.yaml
+++ b/charts/grafana/templates/ingress.yaml
@@ -4,10 +4,10 @@
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $ingressPathType := .Values.ingress.pathType -}}
 {{- $extraPaths := .Values.ingress.extraPaths -}}
-{{- $newAPI := .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+{{- $newAPI := .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
 {{- if $newAPI -}}
 apiVersion: networking.k8s.io/v1
-{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else }}
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
current implementation does not aligned well with the case when `networking.k8s.io/v1beta1` API group DO exist but does not contain Ingress resource defined inside. E.g. it might consist only of NetworkPolicy object and nothing else.

the proposed change adds more precise verification whether Ingress resource is really present inside the API groups.