### PR TITLE
[grafana] validate existence of ingress object in new networking api version

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.4.7
+version: 6.4.8
 appVersion: 7.4.2
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/ingress.yaml
+++ b/charts/grafana/templates/ingress.yaml
@@ -4,10 +4,10 @@
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $ingressPathType := .Values.ingress.pathType -}}
 {{- $extraPaths := .Values.ingress.extraPaths -}}
-{{- $newAPI := .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+{{- $newAPI := .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
 {{- if $newAPI -}}
 apiVersion: networking.k8s.io/v1
-{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else }}
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
otherwise the if statement will incorrectly use the networking api on
versions of k8s that don't have networking.k8s.io/v1/Ingress <v1.19

earlier PR from issue 271 fixed another issue related to the same recent change,
this should fix the specific error regarding ingress missing from networking.k8s.io/v1
in k8s clusters older than v1.19
https://github.com/grafana/helm-charts/issues/271