### PR TITLE
[grafana] Add envFromSecret to downloadDashboards

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.4.8
+version: 6.5.0
 appVersion: 7.4.2
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -188,6 +188,7 @@ This version requires Helm >= 3.1.0.
 | `testFramework.imagePullPolicy`           | `test-framework` image pull policy.           | `IfNotPresent`                                          |
 | `testFramework.securityContext`           | `test-framework` securityContext              | `{}`                                                    |
 | `downloadDashboards.env`                  | Environment variables to be passed to the `download-dashboards` container | `{}`                        |
+| `downloadDashboards.envFromSecret`        | Name of a Kubernetes secret (must be manually created in the same namespace) containing values to be added to the environment. Can be templated | `""` |
 | `downloadDashboards.resources`            | Resources of `download-dashboards` container  | `{}`                                                    |
 | `downloadDashboardsImage.repository`      | Curl docker image repo                        | `curlimages/curl`                                       |
 | `downloadDashboardsImage.tag`             | Curl docker image tag                         | `7.73.0`                                                |

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -56,6 +56,11 @@ initContainers:
       - name: "{{ $key }}"
         value: "{{ $value }}"
 {{- end }}
+{{- if .Values.downloadDashboards.envFromSecret }}
+    envFrom:
+      - secretRef:
+          name: {{ tpl .Values.downloadDashboards.envFromSecret . }}
+{{- end }}
     volumeMounts:
       - name: config
         mountPath: "/etc/grafana/download_dashboards.sh"

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -106,6 +106,7 @@ downloadDashboardsImage:
 
 downloadDashboards:
   env: {}
+  envFromSecret: ""
   resources: {}
 
 ## Pod Annotations


### PR DESCRIPTION
Enables fetching `token` for dashboard download from secret

Example would be:

```
...

downloadDashboards:
  envFromSecret: "my-github-private-token"

...

dashboards:
  default:
    example:
      url: https://github.com/raw/my-private-repo/<commit_hash>/dashboard.json
      token: ${MY_GITHUB_PRIVATE_TOKEN}

...
```

Renders:
```
...
      initContainers:
        - name: download-dashboards
          ...
          envFrom:
            - secretRef:
                name: my-secret-token

...
```

Signed-off-by: Yurii Matsiuk <ymatsiuk@users.noreply.github.com>