### PR TITLE
[promtail] Disable __path__ override when config.hash annotation is not present

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.1.0
-version: 3.3.0
+version: 3.3.1
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 3.3.0](https://img.shields.io/badge/Version-3.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 3.3.1](https://img.shields.io/badge/Version-3.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -266,8 +266,10 @@ config:
         target_label: __path__
       - action: replace
         replacement: /var/log/pods/*$1/*.log
+        regex: true/(.*)
         separator: /
         source_labels:
+          - __meta_kubernetes_pod_annotationpresent_kubernetes_io_config_hash
           - __meta_kubernetes_pod_annotation_kubernetes_io_config_hash
           - __meta_kubernetes_pod_container_name
         target_label: __path__


### PR DESCRIPTION
Since https://github.com/grafana/helm-charts/pull/202, with the default config, promtail sends duplicate logs for pods with container of the same name running on the same host. See this fix and the discussion above for the technical details: https://github.com/grafana/helm-charts/pull/202#commitcomment-47148139

This PR uses @shkrid fix (thanks by the way), which adds a check that the `kubernetes.io/config.hash` annotation is present before replacing.

This might also fix https://github.com/grafana/loki/issues/3443