### PR TITLE
[promtail] fix extraPorts NetworkPolicy

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.1.0
-version: 3.4.0
+version: 3.4.1
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 3.4.0](https://img.shields.io/badge/Version-3.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 3.4.1](https://img.shields.io/badge/Version-3.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/templates/networkpolicy.yaml
+++ b/charts/promtail/templates/networkpolicy.yaml
@@ -97,8 +97,6 @@ spec:
       {{- end }}
     {{- end }}
 
-{{- end }}
-
 {{- if .Values.extraPorts }}
 ---
 apiVersion: networking.k8s.io/v1
@@ -119,4 +117,5 @@ spec:
         - port: {{ $extraPortConfig.containerPort }}
           protocol: {{ $extraPortConfig.protocol }}
   {{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
The *-egress-extra-ports NetworkPolicy was always declared
regardless of the value of .Values.networkPolicy.enabled.
This commit fixes this behavior to declare the policy
only if network policies are enabled for the chart.

Signed-off-by: Tomasz Kuzemko <tomasz@kuzemko.net>