### PR TITLE
[tempo] Use specific tag for tempo-query image

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 0.6.4
+version: 0.6.5
 appVersion: v0.6.0
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 0.6.4](https://img.shields.io/badge/Version-0.6.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.0](https://img.shields.io/badge/AppVersion-v0.6.0-informational?style=flat-square)
+![Version: 0.6.5](https://img.shields.io/badge/Version-0.6.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.0](https://img.shields.io/badge/AppVersion-v0.6.0-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 
@@ -63,7 +63,7 @@ Grafana Tempo Single Binary Mode
 | tempoQuery.extraVolumeMounts | list | `[]` | Volume mounts to add |
 | tempoQuery.pullPolicy | string | `"IfNotPresent"` |  |
 | tempoQuery.repository | string | `"grafana/tempo-query"` |  |
-| tempoQuery.tag | string | `"latest"` |  |
+| tempoQuery.tag | string | `"0.6.0"` |  |
 | tolerations | list | `[]` |  |
 
 ----------------------------------------------

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -76,7 +76,7 @@ tempo:
 
 tempoQuery:
   repository: grafana/tempo-query
-  tag: latest
+  tag: 0.6.0
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
This PR is setting a specific version for the `temp-query` image. Without this change the query fails because of https://github.com/grafana/tempo/pull/574.