### PR TITLE
[tempo] Fix tempo template for extraVolumeMounts

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 0.6.5
+version: 0.6.6
 appVersion: v0.6.0
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 0.6.5](https://img.shields.io/badge/Version-0.6.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.0](https://img.shields.io/badge/AppVersion-v0.6.0-informational?style=flat-square)
+![Version: 0.6.6](https://img.shields.io/badge/Version-0.6.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.0](https://img.shields.io/badge/AppVersion-v0.6.0-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 

--- a/charts/tempo/templates/statefulset.yaml
+++ b/charts/tempo/templates/statefulset.yaml
@@ -64,7 +64,7 @@ spec:
             {{- toYaml .Values.tempo.extraEnv | nindent 12 }}
           {{- end }}
         volumeMounts:
-        {{- if .Values.tempo.extraVolumeMounts }}
+        {{- if .Values.tempo.extraVolumeMounts -}}
           {{ toYaml .Values.tempo.extraVolumeMounts | nindent 8 }}
         {{- end }}
         - mountPath: /conf
@@ -94,7 +94,7 @@ spec:
         resources:
           {{- toYaml .Values.tempoQuery.resources | nindent 10 }}
         volumeMounts:
-        {{- if .Values.tempoQuery.extraVolumeMounts }}
+        {{- if .Values.tempoQuery.extraVolumeMounts -}}
           {{ toYaml .Values.tempoQuery.extraVolumeMounts | nindent 8 }}
         {{- end }}
         - mountPath: /conf

--- a/charts/tempo/templates/statefulset.yaml
+++ b/charts/tempo/templates/statefulset.yaml
@@ -100,6 +100,9 @@ spec:
         - mountPath: /conf
           name: tempo-query-conf
       volumes:
+      {{- if .Values.extraVolumes -}}
+        {{ toYaml .Values.extraVolumes | nindent 6 }}
+      {{- end }}
       - configMap:
           name: {{ template "tempo.name" . }}-query
         name: tempo-query-conf

--- a/charts/tempo/templates/statefulset.yaml
+++ b/charts/tempo/templates/statefulset.yaml
@@ -65,7 +65,7 @@ spec:
           {{- end }}
         volumeMounts:
         {{- if .Values.tempo.extraVolumeMounts }}
-          {{ toYaml .Values.tempo.extraVolumeMounts | nindent 12 }}
+          {{ toYaml .Values.tempo.extraVolumeMounts | nindent 8 }}
         {{- end }}
         - mountPath: /conf
           name: tempo-conf
@@ -95,7 +95,7 @@ spec:
           {{- toYaml .Values.tempoQuery.resources | nindent 10 }}
         volumeMounts:
         {{- if .Values.tempoQuery.extraVolumeMounts }}
-          {{ toYaml .Values.tempoQuery.extraVolumeMounts | nindent 12 }}
+          {{ toYaml .Values.tempoQuery.extraVolumeMounts | nindent 8 }}
         {{- end }}
         - mountPath: /conf
           name: tempo-query-conf


### PR DESCRIPTION
This PR fixes broken indents, which causes the error below when extraVolumeMounts is enabled.
```
Error: YAML parse error on tempo/templates/statefulset.yaml: error converting YAML to JSON: yaml: line 61: did not find expected key
```
I also added trim markers for removing empty lines.