### PR TITLE
[fluent-bit]  Change default helm apiVersion

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
-apiVersion: "v1"
+apiVersion: "v2"
 name: fluent-bit
-version: 2.2.0
+version: 3.0.0
 appVersion: v2.1.0
 kubeVersion: "^1.10.0-0"
 description: "Uses fluent-bit Loki go plugin for gathering logs and sending them to Loki"

--- a/charts/fluent-bit/README.md
+++ b/charts/fluent-bit/README.md
@@ -72,6 +72,17 @@ helm delete my-release
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
+
+## Upgrading an existing Release to a new major version
+
+A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an
+incompatible breaking change needing manual actions.
+
+### To 3.0.0
+
+This version requires Helm >= 3.0.0. Changes the default ApiVersion of Helm to `v2`. Read more on migrating helm chart to `v2` [here](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/).
+
+
 ## Configuration
 
 The following tables lists the configurable parameters of the Fluent Bit chart and their default values.


### PR DESCRIPTION
Increases to default apiVersion from Helm v2.x to Helm v3.x. Since this change is not backwards compatible (due to certain Helm versions not working anymore), this change requires a new major bump of the chart.

This change is being implemented as part of following issue(s):
  * #301 