### PR TITLE
Custom grafana loki and prometheus datasource jsonData field

### DIFF
--- a/charts/loki-stack/Chart.yaml
+++ b/charts/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 2.3.1
+version: 2.3.2
 appVersion: v2.1.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki-stack/templates/datasources.yaml
+++ b/charts/loki-stack/templates/datasources.yaml
@@ -20,6 +20,13 @@ data:
       access: proxy
       url: http://{{(include "loki.serviceName" .)}}:{{ .Values.loki.service.port }}
       version: 1
+{{- if .Values.loki.datasource.jsonData }}
+      jsonData:
+  {{- range $key, $value := .Values.loki.datasource.jsonData }}
+        {{ $key }}: {{ $value }}
+  {{- end }}
+{{- end }}
+
 {{- end }}
 {{- if .Values.prometheus.enabled }}
     - name: Prometheus
@@ -27,5 +34,11 @@ data:
       access: proxy
       url: http://{{ include "prometheus.fullname" .}}:{{ .Values.prometheus.server.service.servicePort }}{{ .Values.prometheus.server.prefixURL }}
       version: 1
+{{- if .Values.prometheus.datasource.jsonData }}
+      jsonData:
+  {{- range $key, $value := .Values.prometheus.datasource.jsonData }}
+        {{ $key }}: {{ $value }}
+  {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/loki-stack/values.yaml
+++ b/charts/loki-stack/values.yaml
@@ -1,5 +1,7 @@
 loki:
   enabled: true
+  datasource:
+    jsonData: {}
 
 promtail:
   enabled: true
@@ -17,6 +19,8 @@ grafana:
 
 prometheus:
   enabled: false
+  datasource:
+    jsonData: {}
 
 filebeat:
   enabled: false


### PR DESCRIPTION
Allows to define datasource's  `jsonData` field when installing loki-stack:

    helm install loki loki-stack/grafana --set loki.datasource.jsonData.maxLines=5000

Signed-off-by: Mateus Caruccio <mateus.caruccio@getupcloud.com>