### PR TITLE
[grafana] Release helm chart  6.6.4, fixed CVE

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.6.3
-appVersion: 7.4.3
+version: 6.6.4
+appVersion: 7.4.5
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -59,8 +59,8 @@ This version requires Helm >= 3.1.0.
 | `securityContext`                         | Deployment securityContext                    | `{"runAsUser": 472, "runAsGroup": 472, "fsGroup": 472}`  |
 | `priorityClassName`                       | Name of Priority Class to assign pods         | `nil`                                                   |
 | `image.repository`                        | Image repository                              | `grafana/grafana`                                       |
-| `image.tag`                               | Image tag (`Must be >= 5.0.0`)                | `7.4.3`                                                 |
-| `image.sha`                               | Image sha (optional)                          | `16dc29783ec7d4a23fa19207507586344c6797023604347eb3e8ea5ae431e181` |
+| `image.tag`                               | Image tag (`Must be >= 5.0.0`)                | `7.4.5`                                                 |
+| `image.sha`                               | Image sha (optional)                          | `2b56f6106ddc376bb46d974230d530754bf65a640dfbc5245191d72d3b49efc6` |
 | `image.pullPolicy`                        | Image pull policy                             | `IfNotPresent`                                          |
 | `image.pullSecrets`                       | Image pull secrets                            | `{}`                                                    |
 | `service.type`                            | Kubernetes service type                       | `ClusterIP`                                             |

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -53,7 +53,7 @@ livenessProbe:
 
 image:
   repository: grafana/grafana
-  tag: 7.4.3
+  tag: 7.4.5
   sha: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Update image tag in chart. It is actually 7.4.5

In that release fixed  many [CVE](https://github.com/grafana/grafana/blob/master/CHANGELOG.md)

#### PR Checklist
- [X] Chart Version bumped
- [X] Variables and other changes are documented in the README.md

