### PR TITLE
[promtail] create service without needing to enable servicemonitor

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.2.0
-version: 3.5.0
+version: 3.5.1
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -113,6 +113,7 @@ The new release which will pick up again from the existing `positions.yaml`.
 | rbac.pspEnabled | bool | `false` | Specifies whether a PodSecurityPolicy is to be created |
 | readinessProbe | object | See `values.yaml` | Readiness probe |
 | resources | object | `{}` | Resource requests and limits |
+| service.enabled | bool | `false` | If enabled, Service resource for Promtail is created |
 | serviceAccount.annotations | object | `{}` | Annotations for the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a ServiceAccount should be created |
 | serviceAccount.imagePullSecrets | list | `[]` | Image pull secrets for the service account |

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 3.5.1](https://img.shields.io/badge/Version-3.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
+![Version: 3.5.1](https://img.shields.io/badge/Version-3.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 3.5.0](https://img.shields.io/badge/Version-3.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
+![Version: 3.5.1](https://img.shields.io/badge/Version-3.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/templates/service-metrics.yaml
+++ b/charts/promtail/templates/service-metrics.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceMonitor.enabled }}
+{{- if or .Values.service.enabled .Values.serviceMonitor.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -154,6 +154,10 @@ extraEnv: []
 # -- Extra environment variables from secrets or configmaps
 extraEnvFrom: []
 
+service:
+  # -- If enabled, Service resource for Promtail is created
+  enabled: false
+
 # ServiceMonitor configuration
 serviceMonitor:
   # -- If enabled, ServiceMonitor resources for Prometheus Operator are created


### PR DESCRIPTION
Fixes https://github.com/grafana/helm-charts/issues/240

Added new value to default Helm values `service.enabled` which defaults to false to match `serviceMonitor.enabled`.

Updated the yaml template for the Promtail metrics Service to be created either when `service.enabled` or `serviceMonitor.enabled` is `true`. Decided to use an or condition here so it can still be provisioned by just setting `serviceMonitor.enabled`, so `service.enabled` can be omitted, but also want the new `service.enabled` to create the Service, without needing to enable `serviceMonitor.enabled` and have it provision whatever else that comes with it.

First PR here, so apologies for anything I've missed. Also unsure if the naming is fine, let me know if the new value should be more along the lines of `serviceMetrics.enabled` or something like that.