### PR TITLE
Fail pipeline if CODEOWNERS are not up to date

### DIFF
--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -15,3 +15,4 @@ jobs:
       - name: check CODEOWNERS for modifications
         run: |
           git diff --exit-code || echo "::warning::There is at least one codeowner mismatch."
+          git diff --exit-code


### PR DESCRIPTION
The intention of this pipeline was to check that CODEOWNERS file is in sync with the maintainers defined in the individual charts.
At the moment this does not work for two reasons:
a) it just prints a waning in the log and does not fail the pipeline => So we could as well just remove it
b) maintainers in charts are not valid GitHub usernames

So we could either remove the CODEOWNERS check or fix maintainers in the charts and let the check fail if something is not correct.

