### PR TITLE
[tempo-distributed] update maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,6 @@
 /charts/grafana/ @maorfr @rtluckie @torstenwalter @Xtigyro @zanhsieh
 /charts/loki-distributed/ @unguiculus
 /charts/loki-canary/ @unguiculus
-/charts/tempo @swartz-k @joe-elliott @annanay25 @mdisibio @dgzlopes @mapno
-/charts/tempo-distributed @swartz-k @joe-elliott @annanay25 @mdisibio @dgzlopes @mapno
+/charts/tempo/ @annanay25 @dgzlopes @joe-elliott @mapno @mdisibio @swartz-k
+/charts/tempo-distributed/ @annanay25 @dgzlopes @joe-elliott @mapno @mdisibio @swartz-k
 /charts/enterprise-metrics/ @jdbaldry

--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.8.7
+version: 0.8.8
 appVersion: 0.6.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/
@@ -10,7 +10,11 @@ icon: https://raw.githubusercontent.com/grafana/tempo/master/docs/tempo/website/
 sources:
   - https://github.com/grafana/tempo
 maintainers:
-  - name: Joe Elliott
+  - name: joe-elliott
     email: number101010@gmail.com
-  - name: Swartz K
+  - name: swartz-k
     email: 9215868@gmail.com
+  - name: annanay25
+  - name: mdisibio
+  - name: dgzlopes
+  - name: mapno

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.8.7](https://img.shields.io/badge/Version-0.8.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
+![Version: 0.8.8](https://img.shields.io/badge/Version-0.8.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 


### PR DESCRIPTION
- Add all CODEOWNERS as maintainers to tempo-distrubuted chart.
- use GitHub usernames as maintainer names
- sort CODEOWNERS by GitHub username

Related to https://github.com/grafana/helm-charts/pull/345

Signed-off-by: Torsten Walter <mail@torstenwalter.de>