### PR TITLE
[tempo] update maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,6 @@
 /charts/grafana/ @maorfr @rtluckie @torstenwalter @Xtigyro @zanhsieh
 /charts/loki-distributed/ @unguiculus
 /charts/loki-canary/ @unguiculus
-/charts/tempo @swartz-k @joe-elliott @annanay25 @mdisibio @dgzlopes @mapno
-/charts/tempo-distributed @swartz-k @joe-elliott @annanay25 @mdisibio @dgzlopes @mapno
+/charts/tempo/ @annanay25 @dgzlopes @joe-elliott @mapno @mdisibio @swartz-k
+/charts/tempo-distributed/ @annanay25 @dgzlopes @joe-elliott @mapno @mdisibio @swartz-k
 /charts/enterprise-metrics/ @jdbaldry

--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 0.6.6
+version: 0.6.7
 appVersion: v0.6.0
 engine: gotpl
 home: https://grafana.net
@@ -10,7 +10,11 @@ icon: https://raw.githubusercontent.com/grafana/tempo/master/docs/tempo/website/
 sources:
   - https://github.com/grafana/tempo
 maintainers:
-  - name: Joe Elliott
+  - name: joe-elliott
     email: number101010@gmail.com
-  - name: Swartz K
+  - name: swartz-k
     email: 9215868@gmail.com
+  - name: annanay25
+  - name: mdisibio
+  - name: dgzlopes
+  - name: mapno

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 0.6.6](https://img.shields.io/badge/Version-0.6.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.0](https://img.shields.io/badge/AppVersion-v0.6.0-informational?style=flat-square)
+![Version: 0.6.7](https://img.shields.io/badge/Version-0.6.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.0](https://img.shields.io/badge/AppVersion-v0.6.0-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 
@@ -10,8 +10,12 @@ Grafana Tempo Single Binary Mode
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| Joe Elliott | number101010@gmail.com |  |
-| Swartz K | 9215868@gmail.com |  |
+| joe-elliott | number101010@gmail.com |  |
+| swartz-k | 9215868@gmail.com |  |
+| annanay25 |  |  |
+| mdisibio |  |  |
+| dgzlopes |  |  |
+| mapno |  |  |
 
 ## Source Code
 


### PR DESCRIPTION
- Add all CODEOWNERS as maintainers to tempo chart.
- use GitHub usernames as maintainer names
- sort CODEOWNERS by GitHub username

Signed-off-by: Torsten Walter <mail@torstenwalter.de>