### PR TITLE
[tempo] add additional otlp ports

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 0.6.6
+version: 0.6.8
 appVersion: v0.6.0
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 0.6.6](https://img.shields.io/badge/Version-0.6.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.0](https://img.shields.io/badge/AppVersion-v0.6.0-informational?style=flat-square)
+![Version: 0.6.8](https://img.shields.io/badge/Version-0.6.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.0](https://img.shields.io/badge/AppVersion-v0.6.0-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 

--- a/charts/tempo/templates/service.yaml
+++ b/charts/tempo/templates/service.yaml
@@ -58,10 +58,18 @@ spec:
     port: 9411
     protocol: TCP
     targetPort: 9411
-  - name: tempo-otlp
+  - name: tempo-otlp-legacy
     port: 55680
     protocol: TCP
     targetPort: 55680
+  - name: tempo-otlp-http
+    port: 55681
+    protocol: TCP
+    targetPort: 55681
+  - name: tempo-otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
   - name: tempo-opencensus
     port: 55678
     protocol: TCP

--- a/charts/tempo/templates/statefulset.yaml
+++ b/charts/tempo/templates/statefulset.yaml
@@ -54,7 +54,11 @@ spec:
         - containerPort: 9411
           name: zipkin
         - containerPort: 55680
-          name: otlp
+          name: otlp-legacy
+        - containerPort: 4317
+          name: otlp-grpc
+        - containerPort: 55681
+          name: otlp-http
         - containerPort: 55678
           name: opencensus
         resources:


### PR DESCRIPTION

The OTLP change the default ports for http and grpc:
https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md

this also fixed a startup issue when defining both of the otlp protocols.

I kept the original one likewise the OTLP team seems to do this during transition phase


```
level=error ts=2021-03-29T19:00:27.711699252Z caller=app.go:235 msg="module failed" module=distributor err="invalid service state: Failed, expected: Running, failure: failed to start subservices not healthy, 0 terminated, 1 failed: [Error starting receiver listen tcp 0.0.0.0:55680: bind: address already in use]"
```

values in single-binary helm chart would then look like this:
```
    receivers:
      otlp:
        protocols:
          http:
            endpoint: 0.0.0.0:55681
          grpc:
            endpoint: 0.0.0.0:4317
```