### PR TITLE
[grafana] Bump Grafana to v7.5.3

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.7.2
-appVersion: 7.5.2
+version: 6.7.3
+appVersion: 7.5.3
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -53,7 +53,7 @@ livenessProbe:
 
 image:
   repository: grafana/grafana
-  tag: 7.5.2
+  tag: 7.5.3
   sha: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Bump app and image to Grafana v7.5.3

https://github.com/grafana/grafana/releases/tag/v7.5.3