### PR TITLE
[loki-distributed] default number of ingester should be 2

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.2.0
-version: 0.28.0
+version: 0.28.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -120,7 +120,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | ingester.persistence.storageClass | string | `nil` | Storage class to be used. If defined, storageClassName: <storageClass>. If set to "-", storageClassName: "", which disables dynamic provisioning. If empty or set to null, no storageClassName spec is set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack). |
 | ingester.podAnnotations | object | `{}` | Annotations for ingester pods |
 | ingester.priorityClassName | string | `nil` | The name of the PriorityClass for ingester pods |
-| ingester.replicas | int | `1` | Number of replicas for the ingester |
+| ingester.replicas | int | `2` | Number of replicas for the ingester |
 | ingester.resources | object | `{}` | Resource requests and limits for the ingester |
 | ingester.terminationGracePeriodSeconds | int | `300` | Grace period to allow the ingester to shutdown before it is killed. Especially for the ingestor, this must be increased. It must be long enough so ingesters can be gracefully shutdown flushing/transferring all data and to successfully leave the member ring on shutdown. |
 | ingester.tolerations | list | `[]` | Tolerations for ingester pods |

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.28.0](https://img.shields.io/badge/Version-0.28.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
+![Version: 0.28.1](https://img.shields.io/badge/Version-0.28.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -208,7 +208,7 @@ prometheusRule:
 # Configuration for the ingester
 ingester:
   # -- Number of replicas for the ingester
-  replicas: 1
+  replicas: 2
   image:
     # -- The Docker registry for the ingester image. Overrides `loki.image.registry`
     registry: null


### PR DESCRIPTION
If we take the default value of 1 ingester, the distributor output there log:

```
level=warn ts=2021-04-09T20:16:09.463337401Z caller=logging.go:71 traceID=76858732ade9f1b2 msg="POST /loki/api/v1/push (500) 151.072µs Response: \"at least 2 live replicas required, could only find 1\\n\" ws: false; Connection: close; Content-Length: 937; Content-Type: application/x-protobuf; User-Agent: promtail/2.2.0; "
```

Signed-off-by: Nicolas Vanheuverzwijn <nicolas.vanheu@gmail.com>