### PR TITLE
[loki-rule-operator] add new chart to install loki rules crds

### DIFF
--- a/charts/loki-rule-operator/Chart.yaml
+++ b/charts/loki-rule-operator/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: loki-rule-operator
+description: Install CRDs to handle Loki rules
+type: application
+sources:
+  - https://github.com/opsgy/loki-rule-operator
+version: 1.0.0
+appVersion: v0.5.0

--- a/charts/loki-rule-operator/README.md
+++ b/charts/loki-rule-operator/README.md
@@ -1,0 +1,51 @@
+
+# loki-rule-operator
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.5.0](https://img.shields.io/badge/AppVersion-v0.5.0-informational?style=flat-square)
+
+Install CRDs to handle Loki rules
+
+## Source Code
+
+* <https://github.com/opsgy/loki-rule-operator>
+
+## Chart Repo
+
+Add the following repo to use the chart:
+
+```console
+helm repo add grafana https://grafana.github.io/helm-charts
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| admissionWebhooks.annotations | object | `{}` | Additionnal annotations for the admission webhook |
+| admissionWebhooks.enabled | bool | `true` | Enable admission webhooks to validate CRDs |
+| affinity | object | `{}` | Affinity for the pod |
+| certManager.enabled | bool | `true` | Enable the creation of a Certificate for cert-manager. This is only useful if admissionWebhooks.enabled is true |
+| certManager.group | string | `"cert-manager.io"` |  |
+| certManager.issuerName | string | `"selfsigned"` | Name of the issuer |
+| certManager.kind | string | `"ClusterIssuer"` | Kind of issuer to use |
+| fullnameOverride | string | `""` | Overrides the chart's computed fullname |
+| image.pullPolicy | string | `"IfNotPresent"` | The pull policy |
+| image.repository | string | `"eu.gcr.io/opsgy-com/loki-rule-operator"` | The Docker registry for the image |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| imagePullSecrets | list | `[]` | Image pull secrets for Docker images |
+| loki.rulesConfigMap.name | string | `"loki-rules"` | Name of the loki configmap storing the rules |
+| loki.rulesConfigMap.namespace | string | `""` | Namespace where the loki rules configmap reside in |
+| nameOverride | string | `""` | Overrides the chart's name |
+| nodeSelector | object | `{}` | Node selector for the pod |
+| podAnnotations | object | `{}` | Annotations for pod |
+| podSecurityContext | object | `{"fsGroup":2000,"runAsUser":10000}` | The SecurityContext for pod |
+| replicaCount | int | `1` | Number of replica |
+| resources | object | `{}` | Resource requests and limits |
+| securityContext | object | `{"readOnlyRootFilesystem":true}` | The SecurityContext for the containers |
+| service | object | `{"port":443,"type":"ClusterIP"}` | Service configuration |
+| service.port | int | `443` | Port of the service |
+| service.type | string | `"ClusterIP"` | Type of service |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `"loki-rule-operator"` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| tolerations | list | `[]` | Toleration for the pod |

--- a/charts/loki-rule-operator/README.md.gotmpl
+++ b/charts/loki-rule-operator/README.md.gotmpl
@@ -1,0 +1,20 @@
+ 
+{{ template "chart.header" . }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Chart Repo
+
+Add the following repo to use the chart:
+
+```console
+helm repo add grafana https://grafana.github.io/helm-charts
+```
+
+{{ template "chart.valuesSection" . }}

--- a/charts/loki-rule-operator/crds/logging.opsgy.com_globallokirules.yaml
+++ b/charts/loki-rule-operator/crds/logging.opsgy.com_globallokirules.yaml
@@ -1,0 +1,88 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: globallokirules.logging.opsgy.com
+spec:
+  group: logging.opsgy.com
+  names:
+    kind: GlobalLokiRule
+    listKind: GlobalLokiRuleList
+    plural: globallokirules
+    singular: globallokirule
+  scope: Cluster
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: GlobalLokiRule is the Schema for the globallokirules API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GlobalLokiRuleSpec defines the desired state of GlobalLokiRule
+            properties:
+              groups:
+                items:
+                  properties:
+                    interval:
+                      type: string
+                    name:
+                      type: string
+                    rules:
+                      items:
+                        properties:
+                          alert:
+                            type: string
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          expr:
+                            type: string
+                          for:
+                            type: string
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      type: array
+                  type: object
+                type: array
+            type: object
+          status:
+            description: GlobalLokiRuleStatus defines the observed state of GlobalLokiRule
+            properties:
+              message:
+                type: string
+              valid:
+                type: boolean
+            required:
+            - valid
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/loki-rule-operator/crds/logging.opsgy.com_lokirules.yaml
+++ b/charts/loki-rule-operator/crds/logging.opsgy.com_lokirules.yaml
@@ -1,0 +1,88 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: lokirules.logging.opsgy.com
+spec:
+  group: logging.opsgy.com
+  names:
+    kind: LokiRule
+    listKind: LokiRuleList
+    plural: lokirules
+    singular: lokirule
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: LokiRule is the Schema for the lokirules API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LokiRuleSpec defines the desired state of LokiRule
+            properties:
+              groups:
+                items:
+                  properties:
+                    interval:
+                      type: string
+                    name:
+                      type: string
+                    rules:
+                      items:
+                        properties:
+                          alert:
+                            type: string
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          expr:
+                            type: string
+                          for:
+                            type: string
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      type: array
+                  type: object
+                type: array
+            type: object
+          status:
+            description: LokiRuleStatus defines the observed state of LokiRule
+            properties:
+              message:
+                type: string
+              valid:
+                type: boolean
+            required:
+            - valid
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/loki-rule-operator/templates/_helpers.tpl
+++ b/charts/loki-rule-operator/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "loki-rule-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "loki-rule-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "loki-rule-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "loki-rule-operator.labels" -}}
+helm.sh/chart: {{ include "loki-rule-operator.chart" . }}
+{{ include "loki-rule-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "loki-rule-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "loki-rule-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "loki-rule-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "loki-rule-operator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/loki-rule-operator/templates/certificate.yaml
+++ b/charts/loki-rule-operator/templates/certificate.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.certManager.enabled -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "loki-rule-operator.fullname" . }}
+  labels:
+    {{- include "loki-rule-operator.labels" . | nindent 4 }}
+spec:
+  dnsNames:
+  -  {{ include "loki-rule-operator.fullname" . }}.{{ .Release.Namespace }}.svc
+  issuerRef:
+    group: {{ .Values.certManager.group }}
+    kind: {{ .Values.certManager.kind }}
+    name: {{ .Values.certManager.issuerName }}
+  secretName: {{ include "loki-rule-operator.fullname" . }}
+{{- end }}

--- a/charts/loki-rule-operator/templates/cluster-role-binding.yaml
+++ b/charts/loki-rule-operator/templates/cluster-role-binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "loki-rule-operator.fullname" . }}
+  labels:
+    {{- include "loki-rule-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "loki-rule-operator.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "loki-rule-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/loki-rule-operator/templates/cluster-role.yaml
+++ b/charts/loki-rule-operator/templates/cluster-role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "loki-rule-operator.fullname" . }}
+  labels:
+    {{- include "loki-rule-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups: ["logging.opsgy.com"]
+  resources:
+  - globallokirules
+  - lokirules
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["logging.opsgy.com"]
+  resources:
+  - globallokirules/status
+  - lokirules/status
+  verbs: ["patch"]

--- a/charts/loki-rule-operator/templates/deployment.yaml
+++ b/charts/loki-rule-operator/templates/deployment.yaml
@@ -1,0 +1,98 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "loki-rule-operator.fullname" . }}
+  labels:
+    {{- include "loki-rule-operator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+  selector:
+    matchLabels:
+      {{- include "loki-rule-operator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "loki-rule-operator.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "loki-rule-operator.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+      - name: {{ .Chart.Name }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+        {{- if .Values.admissionWebhooks.enabled }}
+        - -enable-webhook
+        {{- end }}
+        - -rules-configmap={{ .Values.loki.rulesConfigMap.namespace | default .Release.Namespace }}/{{ .Values.loki.rulesConfigMap.name }}
+
+        ports:
+        - name: https
+          containerPort: 9443
+          protocol: TCP
+        - name: metrics
+          containerPort: 8080
+          protocol: TCP
+        - name: health
+          containerPort: 8081
+          protocol: TCP
+
+        # Health checks
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: health
+          failureThreshold: 3
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: health
+          failureThreshold: 20
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 10
+        resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+
+        volumeMounts:
+        - name: tls-secret
+          mountPath: /tmp/k8s-webhook-server/serving-certs
+
+      volumes:
+      - name: tls-secret
+        secret:
+          secretName: loki-rule-operator
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/loki-rule-operator/templates/role-binding.yaml
+++ b/charts/loki-rule-operator/templates/role-binding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "loki-rule-operator.fullname" . }}
+  namespace: {{ .Values.loki.rulesConfigMap.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "loki-rule-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "loki-rule-operator.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "loki-rule-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/loki-rule-operator/templates/role.yaml
+++ b/charts/loki-rule-operator/templates/role.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "loki-rule-operator.fullname" . }}
+  namespace: {{ .Values.loki.rulesConfigMap.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "loki-rule-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["create"]
+- apiGroups: [""]
+  resourceNames:
+  - {{ .Values.loki.rulesConfigMap.name }}
+  resources:
+  - configmaps
+  verbs: ["get", "update"]

--- a/charts/loki-rule-operator/templates/service.yaml
+++ b/charts/loki-rule-operator/templates/service.yaml
@@ -1,0 +1,20 @@
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki-rule-operator.fullname" . }}
+  labels:
+    {{- include "loki-rule-operator.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - name: https
+    port: {{ .Values.service.port }}
+    targetPort: https
+    protocol: TCP
+  - name: metrics
+    port: 8080
+    targetPort: metrics
+    protocol: TCP
+  selector:
+    {{- include "loki-rule-operator.selectorLabels" . | nindent 4 }}

--- a/charts/loki-rule-operator/templates/serviceaccount.yaml
+++ b/charts/loki-rule-operator/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "loki-rule-operator.serviceAccountName" . }}
+  labels:
+    {{- include "loki-rule-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/loki-rule-operator/templates/webhook.yaml
+++ b/charts/loki-rule-operator/templates/webhook.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.admissionWebhooks.enabled -}}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ include "loki-rule-operator.fullname" . }}
+  labels:
+    {{- include "loki-rule-operator.labels" . | nindent 4 }}
+  {{- if .Values.certManager.enabled }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "loki-rule-operator.fullname" . }}
+    {{- with .Values.admissionWebhooks.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{ else }}
+    {{- with .Values.admissionWebhooks.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+webhooks:
+- name: loki-rule.logging.opsgy.com
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  rules:
+    - operations: ["CREATE","UPDATE"]
+      apiGroups: ["logging.opsgy.com"]
+      apiVersions: ["v1", "v1beta1"]
+      resources: ["lokirules"]
+  clientConfig:
+    service:
+      name: {{ include "loki-rule-operator.fullname" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /validate-logging-opsgy-com-v1beta1-lokirule
+      port: {{ .Values.service.port }}
+  sideEffects: None
+{{- end }}

--- a/charts/loki-rule-operator/values.yaml
+++ b/charts/loki-rule-operator/values.yaml
@@ -1,0 +1,90 @@
+# Default values for loki-rule-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Number of replica
+replicaCount: 1
+
+image:
+  # -- The Docker registry for the image
+  repository: eu.gcr.io/opsgy-com/loki-rule-operator
+  # -- The pull policy
+  pullPolicy: IfNotPresent
+  # -- Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# -- Image pull secrets for Docker images
+imagePullSecrets: []
+# -- Overrides the chart's name
+nameOverride: ""
+# -- Overrides the chart's computed fullname
+fullnameOverride: ""
+
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: true
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: "loki-rule-operator"
+
+# -- Annotations for pod
+podAnnotations: {}
+
+# -- The SecurityContext for pod
+podSecurityContext:
+  fsGroup: 2000
+  runAsUser: 10000
+
+# -- The SecurityContext for the containers
+securityContext:
+  readOnlyRootFilesystem: true
+
+# -- Service configuration
+service:
+  # -- Type of service
+  type: ClusterIP
+  # -- Port of the service
+  port: 443
+
+# -- Resource requests and limits
+resources: {}
+#  limits:
+#    memory: 50Mi
+#    cpu: 50m
+#  requests:
+#    memory: 50Mi
+#    cpu: 50m
+
+loki:
+  rulesConfigMap:
+    # -- Name of the loki configmap storing the rules
+    name: loki-rules
+    # -- Namespace where the loki rules configmap reside in
+    namespace: ""
+
+admissionWebhooks:
+  # -- Enable admission webhooks to validate CRDs
+  enabled: true
+  # -- Additionnal annotations for the admission webhook
+  annotations: {}
+
+certManager:
+  # -- Enable the creation of a Certificate for cert-manager. This is only useful if admissionWebhooks.enabled is true
+  enabled: true
+  # Group of the issuer
+  group: cert-manager.io
+  # -- Kind of issuer to use
+  kind: ClusterIssuer
+  # -- Name of the issuer
+  issuerName: selfsigned
+
+# -- Node selector for the pod
+nodeSelector: {}
+
+# -- Toleration for the pod
+tolerations: []
+
+# -- Affinity for the pod
+affinity: {}


### PR DESCRIPTION
This PR introduces a new helm-chart that add CRDs to manage loki rules.

I beleive it resolves these two issues :
https://github.com/grafana/loki/issues/2990
https://github.com/grafana/loki/issues/3456

See https://github.com/opsgy/loki-rule-operator for source code