### PR TITLE
[fluent-bit] make the container parser value configurable

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: fluent-bit
-version: 2.2.0
+version: 2.2.1
 appVersion: v2.1.0
 kubeVersion: "^1.10.0-0"
 description: "Uses fluent-bit Loki go plugin for gathering logs and sending them to Loki"

--- a/charts/fluent-bit/README.md
+++ b/charts/fluent-bit/README.md
@@ -98,6 +98,7 @@ For more details, read the [Fluent Bit documentation](../../../cmd/fluent-bit/RE
 | `config.labels`          | A set of labels to send for every log                                                              | `'{job="fluent-bit"}'`           |
 | `config.autoKubernetesLabels` | If set to true, it will add all Kubernetes labels to Loki labels                                   | `false`                          |
 | `config.labelMap`        | Mapping of labels from a record. See [Fluent Bit documentation](../../../cmd/fluent-bit/README.md) |                                  |
+| `config.containerParser` | Specify which parser to use for /var/log/containers/*.log                                          | `docker`                         |
 | `config.parsers`         | Definition of extras fluent bit parsers. See [Official Fluent Bit documentation](https://docs.fluentbit.io/manual/filter/parser). The format is a sequence of mappings where each key is the same as the one in the [PARSER] section of parsers.conf file       | `[]`                            |
 | `config.extraOutputs`    | Definition of extras fluent bit outputs. See [Official Fluent Bit documentation](https://docs.fluentbit.io/manual/pipeline/outputs/). The format is a sequence of mappings where each key is the same as the one in the [OUTPUT]                                | `[]`                            |
 | `affinity`               | [affinity][affinity] settings for pod assignment                                                   | `{}`                             |

--- a/charts/fluent-bit/templates/configmap.yaml
+++ b/charts/fluent-bit/templates/configmap.yaml
@@ -22,7 +22,7 @@ data:
         Name           tail
         Tag            kube.*
         Path           /var/log/containers/*.log
-        Parser         docker
+        Parser         {{ .Values.config.containerParser }}
         DB             /run/fluent-bit/flb_kube.db
         Mem_Buf_Limit  {{ .Values.config.memBufLimit }}
     [FILTER]

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -21,6 +21,7 @@ config:
     - stream
   autoKubernetesLabels: false
   labels: '{job="fluent-bit"}'
+  containerParser: docker
   labelMap:
     kubernetes:
       namespace_name: namespace


### PR DESCRIPTION
The format of the logs in `/var/log/containers/*.log` on my nodes (k3s) is not in the default docker json-file format, which means I need to specify a custom parser.

`parsers` is already configurable, but if I `kubectl edit` the config map to change the `Parser` value of the [INPUT] , and then run `helm upgrade ..` my changes will be overritten.

This PR makes the value of `Parser` in the default `[INPUT] ` (/var/log/containers/*.log) to be configurable.

There might be a better variable name than `containerParser` though, but it was the best I could come up with.
