### PR TITLE
[agent-metrics] Adding Helm chart for Grafana Agent - Metrics

### DIFF
--- a/.helmdocsignore
+++ b/.helmdocsignore
@@ -1,3 +1,4 @@
+charts/agent-metrics
 charts/fluent-bit
 charts/grafana
 charts/loki

--- a/charts/agent-metrics/.helmignore
+++ b/charts/agent-metrics/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/agent-metrics/Chart.yaml
+++ b/charts/agent-metrics/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: agent-metrics
+version: 0.1.0
+appVersion: v0.13.0
+kubeVersion: "^1.16.0-0"
+description: Grafana Agent - Metrics
+home: https://grafana.com/docs/grafana-cloud/agent/
+icon: https://github.com/grafana/agent/raw/main/docs/assets/logo_and_name.png
+sources:
+  - https://github.com/grafana/agent
+maintainers:
+  - name: Jiri Tyr
+    email: jiri.tyr@gmail.com
+engine: gotpl

--- a/charts/agent-metrics/README.md
+++ b/charts/agent-metrics/README.md
@@ -1,0 +1,100 @@
+# Agent Helm Chart - Metrics
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: v0.13.0](https://img.shields.io/badge/AppVersion-v0.13.0-informational?style=flat-square)
+
+This Helm chart allows to deploy only the Metrics part of the Grafana Agent.
+
+
+## Prerequisites
+
+Make sure you have Helm [installed](https://helm.sh/docs/using_helm/#installing-helm).
+
+
+## Get Repo Info
+
+```shell
+helm repo add grafana https://grafana.github.io/helm-charts
+helm repo update
+```
+
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+
+
+## Deploy Agent
+
+This kind of deployment uses configuration specified at the time of deployment.
+
+```shell
+cat <<END | helm upgrade --create-namespace --namespace grafana --values - --install agent grafana/agent-metrics
+# Keep the reserce names simple
+fullnameOverride: agent-metrics
+
+# Configure Grafana Cloud credentials (username and password)
+accessConfig:
+  username: 12345
+secret:
+  data:
+    password: cdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZZYXWVUTSRQPONMLKJIHGFEDCBAzyxwvutsrqponmlkjihgfedc
+END
+```
+
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Jiri Tyr | jiri.tyr(at)gmail.com | [https://github.com/jtyr](https://github.com/jtyr) |
+
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| accessConfig.password_file | string | `"/var/run/secrets/grafana.com/agent/password"` | Location of the file holding the password used to authenticate to the metrics storage. |
+| accessConfig.url | string | `"https://prometheus-blocks-prod-us-central1.grafana.net/api/prom/push"` | URL where to push the traces. |
+| accessConfig.username | string | `""` | Username used to authenticate to the metrics storage. |
+| affinity | object | `{}` | Pod affinity. |
+| annotations | object | `{}` | DaemonSet and Deployment annotations. |
+| config.agent | string | See the value in the `values.yaml` file. | Agent configuration template used by the DaemonSet. |
+| config.agentDeployment | string | See the value in the `values.yaml` file. | Agent configuration template used by the Deployment. |
+| deployment.replicas | int | `1` | Number of replicas of the Deployment. |
+| enabled | bool | `true` | Whether this chart is enabled. Useful when this chart is used as a dependency from another chart. |
+| env | list | `[]` | Environment variables for the Agent container. |
+| extraArgs | list | `[]` | Additional command arguments for the Agent container. |
+| extraConfig | object | `{}` | Extra top level Agent configuration of the DaemonSet. |
+| extraDefaultConfigConfig | list | `[]` | Extra config on the default configuration level of the DaemonSet. |
+| extraDefaultScrapeConfig | list | `[]` | Extra scrape config on the default configuration level of the DaemonSet. |
+| extraDeploymentConfig | object | `{}` | Extra top level Agent configuration of the Deployment. |
+| extraDeploymentDefaultScrapeConfig | list | `[]` |Extra scrape config on the default configuration level of the Deployment. |
+| extraDeploymentServiceConfig | list | `[]` | Extra Agent configuration on the service level of the Deployment. |
+| extraDeploymentServiceConfigConfig | list | `[]` | Extra config on the default configuration level of the Deployment. |
+| extraServiceConfig | list | `[]` | Extra Agent configuration on the service level of the DaemonSet. |
+| extraVolumeMounts | list | `[]` | Additional volume mounts for the Agent container. |
+| extraVolumes | list | `[]` | Additional volumes for the Pod. |
+| globalScrapeInterval | string | `"15s"` | Default scraping interval for the Agent DaemonSet. |
+| globalScrapeIntervalDeployment | string | `"15s"` | Default scraping interval for the Agent Deployment. |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
+| image.repository | string | `"grafana/agent"` | Image repository and name. |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart `appVersion`. |
+| livenessProbe.httpGet.path | string | `"/-/healthy"` | URL path used by the Agent container liveness probe. |
+| livenessProbe.httpGet.port | string | `"http-metrics"` | Container port used by the Agent container liveness probe. |
+| nodeSelector | object | `{}` | Pod node selector. |
+| podAnnotations."prometheus.io/port" | string | `"http-metrics"` | Annotation indicated which port to scrape. |
+| podAnnotations."prometheus.io/scrape" | string | `"true"` | Annotation indicating whether the metrics should be scraped from this Pod. |
+| rbac.create | bool | `true` | Whether to create Cluster Role and Cluster Role Binding. |
+| readinessProbe.httpGet.path | string | `"/-/ready"` | URL path used by the Agent container readiness probe. |
+| readinessProbe.httpGet.port | string | `"http-metrics"` | Container port used by the Agent container readiness probe. |
+| resources | object | `{}` | Resources for the Agent container. |
+| scrapingService | object | `{}` | Scraping Service configuration of the DaemonSet. |
+| scrapingServiceDeployment | object | `{}` | Scraping Service configuration of the Deployment. |
+| secret.annotations | object | `{}` | Secret annotations. |
+| secret.create | bool | `true` | Whether the Secret should be created. |
+| secret.data.password | string | `""` | Password used to authenticate with the metrics storage. |
+| secret.mount | bool | `true` | Whether to mount the secret inside the Agent container. |
+| securityContext.privileged | bool | `true` | Whether the Agent container should run in privileged mode. |
+| securityContext.runAsUser | int | `0` | UID or name of the user under which to run the Agent container. |
+| serviceAccount.annotations | object | `{}` | Service Account annotations. |
+| serviceAccount.create | bool | `true` | Whether the Service Account should be created. |
+| serviceAccount.name | string | `""` | Service Account name. |
+| tolerations[0].effect | string | `"NoSchedule"` | Pod toleration effect. |
+| tolerations[0].operator | string | `"Exists"` | Pod toleration operator. |

--- a/charts/agent-metrics/templates/_helpers.tpl
+++ b/charts/agent-metrics/templates/_helpers.tpl
@@ -1,0 +1,91 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "this.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "this.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "this.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "this.fullnameDeployment" -}}
+{{- if .Values.fullnameOverride -}}
+{{- printf "%s-deployment" (.Values.fullnameOverride | trunc 52 | trimSuffix "-") -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-deployment" .Release.Name | trunc 52 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-deployment" (printf "%s-%s" .Release.Name $name | trunc 52 | trimSuffix "-") -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "this.labels" -}}
+helm.sh/chart: {{ include "this.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ include "this.selectorLabels" . }}
+{{- end }}
+
+{{- define "this.labelsDeployment" -}}
+helm.sh/chart: {{ include "this.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ include "this.selectorLabelsDeployment" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "this.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "this.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "this.selectorLabelsDeployment" -}}
+{{ include "this.selectorLabels" . }}
+app.kubernetes.io/component: deployment
+{{- end }}
+
+{{/*
+Create the name of the service account
+*/}}
+{{- define "this.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "this.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/agent-metrics/templates/clusterrole.yaml
+++ b/charts/agent-metrics/templates/clusterrole.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.enabled .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "this.fullname" . }}
+  labels:
+    {{- include "this.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/proxy
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+{{- end }}

--- a/charts/agent-metrics/templates/clusterrole.yaml
+++ b/charts/agent-metrics/templates/clusterrole.yaml
@@ -11,6 +11,7 @@ rules:
     resources:
       - nodes
       - nodes/proxy
+      - nodes/metrics
       - services
       - endpoints
       - pods

--- a/charts/agent-metrics/templates/clusterrolebinding.yaml
+++ b/charts/agent-metrics/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.enabled .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "this.fullname" . }}
+  labels:
+    {{- include "this.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "this.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "this.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/agent-metrics/templates/configmap-deployment.yaml
+++ b/charts/agent-metrics/templates/configmap-deployment.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.enabled .Values.config.agentDeployment }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "this.fullnameDeployment" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "this.labelsDeployment" . | nindent 4 }}
+data:
+  agent.yaml: |
+    {{- tpl .Values.config.agentDeployment . | nindent 4}}
+{{- end }}

--- a/charts/agent-metrics/templates/configmap.yaml
+++ b/charts/agent-metrics/templates/configmap.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.enabled .Values.config.agent }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "this.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "this.labels" . | nindent 4 }}
+data:
+  agent.yaml: |
+    {{- tpl .Values.config.agent . | nindent 4}}
+{{- end }}

--- a/charts/agent-metrics/templates/daemonset.yaml
+++ b/charts/agent-metrics/templates/daemonset.yaml
@@ -1,0 +1,86 @@
+{{- if and .Values.enabled .Values.config.agent }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "this.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "this.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.annotations | nindent 4 }}
+spec:
+  minReadySeconds: 10
+  selector:
+    matchLabels:
+      {{- include "this.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "this.labels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      containers:
+        - args:
+            - -config.file=/etc/agent/agent.yaml
+            - -prometheus.wal-directory=/tmp/agent/data
+            {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          command:
+            - /bin/agent
+          env:
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          name: agent
+          ports:
+            - containerPort: 8080
+              name: http-metrics
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - mountPath: /etc/agent
+              name: agent-config
+            {{- if .Values.secret.mount }}
+            - mountPath: /var/run/secrets/grafana.com/agent
+              name: agent-secrets
+              readOnly: true
+            {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+              {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+      serviceAccount: {{ include "this.serviceAccountName" . }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      volumes:
+        - configMap:
+            name: {{ include "this.fullname" . }}
+          name: agent-config
+        {{- if .Values.secret.mount }}
+        - secret:
+            secretName: {{ include "this.fullname" . }}
+          name: agent-secrets
+        {{- end }}
+        {{- if .Values.extraVolumes }}{{ "\n" }}
+          {{- toYaml .Values.extraVolumes | indent 8 }}
+        {{- end }}
+  updateStrategy:
+    type: RollingUpdate
+{{- end }}

--- a/charts/agent-metrics/templates/deployment.yaml
+++ b/charts/agent-metrics/templates/deployment.yaml
@@ -1,0 +1,86 @@
+{{- if and .Values.enabled .Values.config.agentDeployment }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "this.fullnameDeployment" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "this.labelsDeployment" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.annotations | nindent 4 }}
+spec:
+  minReadySeconds: 10
+  replicas: {{ .Values.deployment.replicas }}
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      {{- include "this.selectorLabelsDeployment" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "this.labelsDeployment" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-deployment.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      containers:
+        - args:
+            - -config.file=/etc/agent/agent.yaml
+            - -prometheus.wal-directory=/tmp/agent/data
+            {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          command:
+            - /bin/agent
+          env:
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          name: agent
+          ports:
+            - containerPort: 8080
+              name: http-metrics
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - mountPath: /etc/agent
+              name: agent-config
+            {{- if .Values.secret.mount }}
+            - mountPath: /var/run/secrets/grafana.com/agent
+              name: agent-secrets
+              readOnly: true
+            {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+              {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+      serviceAccount: {{ include "this.serviceAccountName" . }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      volumes:
+        - configMap:
+            name: {{ include "this.fullnameDeployment" . }}
+          name: agent-config
+        {{- if .Values.secret.mount }}
+        - secret:
+            secretName: {{ include "this.fullname" . }}
+          name: agent-secrets
+        {{- end }}
+        {{- if .Values.extraVolumes }}{{ "\n" }}
+          {{- toYaml .Values.extraVolumes | indent 8 }}
+        {{- end }}
+{{- end }}

--- a/charts/agent-metrics/templates/secret.yaml
+++ b/charts/agent-metrics/templates/secret.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.enabled .Values.secret.create -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "this.fullname" . }}
+  labels:
+    {{- include "this.labels" . | nindent 4 }}
+  {{- with .Values.secret.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  {{- range $key, $value := .Values.secret.data }}
+  {{- if gt (len (tpl $value $)) 0 }}
+  {{ $key }}: {{ tpl $value $ | b64enc }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/agent-metrics/templates/serviceaccount.yaml
+++ b/charts/agent-metrics/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.enabled .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "this.serviceAccountName" . }}
+  labels:
+    {{- include "this.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/agent-metrics/values.yaml
+++ b/charts/agent-metrics/values.yaml
@@ -1,0 +1,378 @@
+# Whether this chart is enabled
+# (useful when this chart is used as a dependency from another chart)
+enabled: true
+
+# DaemonSet annotations
+annotations: {}
+
+# Pod annotations
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: http-metrics
+
+# Image configuration for the Agent container
+image:
+  repository: grafana/agent
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion
+  tag: ""
+
+# Additional command arguments for the Agent container
+extraArgs: []
+
+# Additional volumes for the Pod
+extraVolumes: []
+
+# Additional volume mounts for the Agent container
+extraVolumeMounts: []
+
+# Environment variables for the Agent container
+env: []
+
+# Readiness probe for the Agent container
+readinessProbe:
+  httpGet:
+    path: /-/ready
+    port: http-metrics
+
+# Liveness probe for the Agent container
+livenessProbe:
+  httpGet:
+    path: /-/healthy
+    port: http-metrics
+
+# Resources for the Agent container
+resources: {}
+
+# Security context for the Agent container
+securityContext:
+  privileged: true
+  runAsUser: 0
+
+# Pod node selector
+nodeSelector: {}
+
+# Pod affinity
+affinity: {}
+
+# Pod tolerations
+tolerations:
+  - effect: NoSchedule
+    operator: Exists
+
+# Whether to create Cluster Role and Cluster Role Binding
+rbac:
+  create: true
+
+# Creation of the Sercret used by the Pod
+secret:
+  create: true
+  mount: true
+  annotations: {}
+  data:
+    password: ""
+
+# Creation of the Service Account used by the Pod
+serviceAccount:
+  create: true
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+  annotations: {}
+
+# Number of replicas for the Deployment
+deployment:
+  replicas: 1
+
+# Grafana Cloud connection
+accessConfig:
+  url: https://prometheus-blocks-prod-us-central1.grafana.net/api/prom/push
+  username: ""
+  # Path under which the secret.data.password is mounted in the container
+  password_file: /var/run/secrets/grafana.com/agent/password
+
+# Default scraping interval for the Agent DaemonSet
+globalScrapeInterval: 15s
+
+# Default scraping interval for the Agent Deployment
+globalScrapeIntervalDeployment: 15s
+
+# Scraping Service configuration of the DaemonSet
+scrapingService: {}
+
+# Scraping Service configuration of the Deployment
+scrapingServiceDeployment: {}
+
+# Allow to extend the bellow Agent DaemonSet configuration
+extraConfig: {}
+extraServiceConfig: []
+extraDefaultConfigConfig: []
+extraDefaultScrapeConfig: []
+
+# Allow to extend the bellow Agent Deployment configuration
+extraDeploymentConfig: {}
+extraDeploymentServiceConfig: []
+extraDeploymentServiceConfigConfig: []
+extraDeploymentDefaultScrapeConfig: []
+
+# Agent configuration
+config:
+  agent: |
+    integrations:
+      agent:
+        enabled: true
+    server:
+      http_listen_port: 8080
+      log_level: info
+    prometheus:
+      global:
+        scrape_interval: {{ .Values.globalScrapeInterval }}
+      wal_directory: /var/lib/agent/data
+      {{- if .Values.scrapingService }}
+      scraping_service:
+        {{- toYaml .Values.scrapingService | nindent 4 }}
+      {{- else }}
+      configs:
+        - name: default
+          host_filter: true
+          remote_write:
+            - url: {{ .Values.accessConfig.url }}
+              {{- if .Values.accessConfig.username }}
+              basic_auth:
+                username: {{ .Values.accessConfig.username }}
+                password_file: {{ .Values.accessConfig.password_file }}
+              {{- end }}
+          scrape_configs:
+            - job_name: grafana-agent
+              kubernetes_sd_configs:
+                - namespaces:
+                    names:
+                      - {{ .Release.Namespace }}
+                  role: pod
+              relabel_configs:
+                - action: keep
+                  regex: .*agent-(logs|metrics(|-deployment)|traces)
+                  source_labels:
+                    - __meta_kubernetes_pod_label_app_kubernetes_io_component
+                - action: keep
+                  regex: .*-metrics
+                  source_labels:
+                    - __meta_kubernetes_pod_container_port_name
+            - job_name: kubernetes-pods
+              kubernetes_sd_configs:
+                - role: pod
+              relabel_configs:
+                - action: drop
+                  regex: "false"
+                  source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+                - action: keep
+                  regex: .*-metrics
+                  source_labels:
+                    - __meta_kubernetes_pod_container_port_name
+                - action: replace
+                  regex: (https?)
+                  replacement: $1
+                  source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_scheme
+                  target_label: __scheme__
+                - action: replace
+                  regex: (.+)
+                  replacement: $1
+                  source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_path
+                  target_label: __metrics_path__
+                - action: replace
+                  regex: (.+?)(\:\d+)?;(\d+)
+                  replacement: $1:$3
+                  source_labels:
+                    - __address__
+                    - __meta_kubernetes_pod_annotation_prometheus_io_port
+                  target_label: __address__
+                - action: drop
+                  regex: ""
+                  source_labels:
+                    - __meta_kubernetes_pod_label_name
+                - action: replace
+                  replacement: $1
+                  separator: /
+                  source_labels:
+                    - __meta_kubernetes_namespace
+                    - __meta_kubernetes_pod_label_name
+                  target_label: job
+                - action: replace
+                  source_labels:
+                    - __meta_kubernetes_namespace
+                  target_label: namespace
+                - action: replace
+                  source_labels:
+                    - __meta_kubernetes_pod_name
+                  target_label: pod
+                - action: replace
+                  source_labels:
+                    - __meta_kubernetes_pod_container_name
+                  target_label: container
+                - action: replace
+                  separator: ':'
+                  source_labels:
+                    - __meta_kubernetes_pod_name
+                    - __meta_kubernetes_pod_container_name
+                    - __meta_kubernetes_pod_container_port_name
+                  target_label: instance
+                - action: labelmap
+                  regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
+                  replacement: __param_$1
+                - action: drop
+                  regex: Succeeded|Failed
+                  source_labels:
+                    - __meta_kubernetes_pod_phase
+            - job_name: {{ .Release.Namespace }}/kube-state-metrics
+              kubernetes_sd_configs:
+                - namespaces:
+                    names:
+                      - {{ .Release.Namespace }}
+                  role: pod
+              relabel_configs:
+                - action: keep
+                  regex: kube-state-metrics
+                  source_labels:
+                    - __meta_kubernetes_pod_label_name
+                - action: replace
+                  separator: ':'
+                  source_labels:
+                    - __meta_kubernetes_pod_name
+                    - __meta_kubernetes_pod_container_name
+                    - __meta_kubernetes_pod_container_port_name
+                  target_label: instance
+            - job_name: {{ .Release.Namespace }}/node-exporter
+              kubernetes_sd_configs:
+                - namespaces:
+                    names:
+                      - {{ .Release.Namespace }}
+                  role: pod
+              relabel_configs:
+                - action: keep
+                  regex: node-exporter
+                  source_labels:
+                    - __meta_kubernetes_pod_label_name
+                - action: replace
+                  source_labels:
+                    - __meta_kubernetes_pod_node_name
+                  target_label: instance
+                - action: replace
+                  source_labels:
+                    - __meta_kubernetes_namespace
+                  target_label: namespace
+            - job_name: kube-system/kubelet
+              kubernetes_sd_configs:
+                - role: node
+              relabel_configs:
+                - replacement: kubernetes.default.svc.cluster.local:443
+                  target_label: __address__
+                - replacement: https
+                  target_label: __scheme__
+                - regex: (.+)
+                  replacement: /api/v1/nodes/${1}/proxy/metrics
+                  source_labels:
+                    - __meta_kubernetes_node_name
+                  target_label: __metrics_path__
+              bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: false
+            - job_name: kube-system/cadvisor
+              kubernetes_sd_configs:
+                - role: node
+              metric_relabel_configs:
+                - action: drop
+                  regex: container_([a-z_]+);
+                  source_labels:
+                    - __name__
+                    - image
+                - action: drop
+                  regex: container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)
+                  source_labels:
+                    - __name__
+              relabel_configs:
+                - replacement: kubernetes.default.svc.cluster.local:443
+                  target_label: __address__
+                - regex: (.+)
+                  replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+                  source_labels:
+                    - __meta_kubernetes_node_name
+                  target_label: __metrics_path__
+              scheme: https
+              bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: false
+            {{- with .Values.extraDefaultScrapeConfig }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
+        {{- with .Values.extraServiceConfigConfig }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.extraServiceConfig }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
+    {{- with .Values.extraConfig }}{{ "\n" }}
+    {{- toYaml . }}
+    {{- end }}
+  agentDeployment: |
+    integrations:
+      agent:
+        enabled: true
+    server:
+      http_listen_port: 8080
+      log_level: info
+    prometheus:
+      global:
+        scrape_interval: {{ .Values.globalScrapeIntervalDeployment }}
+      wal_directory: /var/lib/agent/data
+      {{- if .Values.scrapingServiceDeployment }}
+      scraping_service:
+        {{- toYaml .Values.scrapingServiceDeployment | nindent 4 }}
+      {{- else }}
+      configs:
+        - name: default
+          host_filter: false
+          remote_write:
+            - url: {{ .Values.accessConfig.url }}
+              {{- if .Values.accessConfig.username }}
+              basic_auth:
+                username: {{ .Values.accessConfig.username }}
+                password_file: {{ .Values.accessConfig.password_file }}
+              {{- end }}
+          scrape_configs:
+            - job_name: default/kubernetes
+              kubernetes_sd_configs:
+                - role: endpoints
+              metric_relabel_configs:
+                - action: keep
+                  regex: workqueue_queue_duration_seconds_bucket|process_cpu_seconds_total|process_resident_memory_bytes|workqueue_depth|rest_client_request_duration_seconds_bucket|workqueue_adds_total|up|rest_client_requests_total|apiserver_request_total|go_goroutines
+                  source_labels:
+                    - __name__
+              relabel_configs:
+                - action: keep
+                  regex: apiserver
+                  source_labels:
+                    - __meta_kubernetes_service_label_component
+              scheme: https
+              bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: false
+                server_name: kubernetes
+            {{- with .Values.extraDeploymentDefaultScrapeConfig }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
+        {{- with .Values.extraDeploymentServiceConfigConfig }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.extraDeploymentServiceConfig }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
+    {{- with .Values.extraDeploymentConfig }}{{ "\n" }}
+    {{- toYaml . }}
+    {{- end }}


### PR DESCRIPTION
This PR is adding the Grafana Agent Helm chart for the Metrics part. The intention is to keep the Helm chart small and maintainable and allow to use it from the [top-level Helm chart](https://github.com/grafana/helm-charts/pull/354).