### PR TITLE
[agent-traces] Adding Helm chart for Grafana Agent - Traces

### DIFF
--- a/.helmdocsignore
+++ b/.helmdocsignore
@@ -1,3 +1,4 @@
+charts/agent-traces
 charts/fluent-bit
 charts/grafana
 charts/loki

--- a/charts/agent-traces/.helmignore
+++ b/charts/agent-traces/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/agent-traces/Chart.yaml
+++ b/charts/agent-traces/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: agent-traces
+version: 0.1.0
+appVersion: v0.13.0
+kubeVersion: "^1.16.0-0"
+description: Grafana Agent - Traces
+home: https://grafana.com/docs/grafana-cloud/agent/
+icon: https://github.com/grafana/agent/raw/main/docs/assets/logo_and_name.png
+sources:
+  - https://github.com/grafana/agent
+maintainers:
+  - name: Jiri Tyr
+    email: jiri.tyr@gmail.com
+engine: gotpl

--- a/charts/agent-traces/README.md
+++ b/charts/agent-traces/README.md
@@ -1,0 +1,91 @@
+# Agent Helm Chart - Traces
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: v0.13.0](https://img.shields.io/badge/AppVersion-v0.13.0-informational?style=flat-square)
+
+This Helm chart allows to deploy only the Traces part of the Grafana Agent.
+
+
+## Prerequisites
+
+Make sure you have Helm [installed](https://helm.sh/docs/using_helm/#installing-helm).
+
+
+## Get Repo Info
+
+```shell
+helm repo add grafana https://grafana.github.io/helm-charts
+helm repo update
+```
+
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+
+
+## Deploy Agent
+
+This kind of deployment uses configuration specified at the time of deployment.
+
+```shell
+cat <<END | helm upgrade --create-namespace --namespace grafana --values - --install agent grafana/agent-traces
+# Keep the reserce names simple
+fullnameOverride: agent-traces
+
+# Configure Grafana Cloud credentials (username and password)
+accessConfig:
+  username: 12345
+secret:
+  data:
+    password: cdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZZYXWVUTSRQPONMLKJIHGFEDCBAzyxwvutsrqponmlkjihgfedc
+END
+```
+
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Jiri Tyr | jiri.tyr(at)gmail.com | [https://github.com/jtyr](https://github.com/jtyr) |
+
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| accessConfig.password_file | string | `"/var/run/secrets/grafana.com/agent/password"` | Location of the file holding the password used to authenticate to Tempo. |
+| accessConfig.url | string | `"tempo-us-central1.grafana.net:443"` | URL where to push the metrics. |
+| accessConfig.username | string | `""` | Username used to authenticate to Tempo. |
+| affinity | object | `{}` | Pod affinity. |
+| annotations | object | `{}` | DaemonSet annotations. |
+| config.agent | string | See the value in the `values.yaml` file. | Agent configuration template. |
+| config.strategies | string | See the value in the `values.yaml` file. | Sampling strategies configuration template. |
+| enabled | bool | `true` | Whether this chart is enabled. Useful when this chart is used as a dependency from another chart. |
+| env | list | `[]` | Environment variables for the Agent container. |
+| extraArgs | list | `[]` | Additional command arguments for the Agent container. |
+| extraConfig | object | `{}` | Extra top level Agent configuration. |
+| extraDefaultConfigConfig | list | `[]` | Extra config on the default configuration level. |
+| extraDefaultScrapeConfig | list | `[]` | Extra scrape config on the default configuration level. |
+| extraServiceConfig | list | `[]` | Extra Agent configuration on the service level. |
+| extraVolumeMounts | list | `[]` | Additional volume mounts for the Agent container. |
+| extraVolumes | list | `[]` | Additional volumes for the Pod. |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
+| image.repository | string | `"grafana/agent"` | Image repository and name. |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| livenessProbe.httpGet.path | string | `"/-/healthy"` | URL path used by the Agent container liveness probe. |
+| livenessProbe.httpGet.port | string | `"http-metrics"` | Container port used by the Agent container liveness probe. |
+| nodeSelector | object | `{}` | Pod node selector. |
+| podAnnotations."prometheus.io/port" | string | `"http-metrics"` | Annotation indicated which port to scrape. |
+| podAnnotations."prometheus.io/scrape" | string | `"true"` | Annotation indicating whether the metrics should be scraped from this Pod. |
+| rbac.create | bool | `true` | Whether to create Cluster Role and Cluster Role Binding. |
+| readinessProbe.httpGet.path | string | `"/-/ready"` | URL path used by the Agent container readiness probe. |
+| readinessProbe.httpGet.port | string | `"http-metrics"` | Container port used by the Agent container readiness probe. |
+| resources | object | `{}` | Resources for the Agent container. |
+| secret.annotations | object | `{}` | Secret annotations. |
+| secret.create | bool | `true` | Whether the Secret should be created. |
+| secret.data.password | string | `""` | Password used to authenticate with Tempo. |
+| secret.mount | bool | `true` | Whether to mount the secret inside the Agent container. |
+| securityContext | object | `{}` | Security context for the Agent container. |
+| service.annotations | object | `{}` | Service annotations. |
+| serviceAccount.annotations | object | `{}` | Service Account annotations. |
+| serviceAccount.create | bool | `true` | Whether the Service Account should be created. |
+| serviceAccount.name | string | `""` | Service Account name. |
+| tolerations[0].effect | string | `"NoSchedule"` | Pod toleration effect. |
+| tolerations[0].operator | string | `"Exists"` | Pod toleration operator. |

--- a/charts/agent-traces/templates/_helpers.tpl
+++ b/charts/agent-traces/templates/_helpers.tpl
@@ -1,0 +1,64 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "this.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "this.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "this.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "this.labels" -}}
+helm.sh/chart: {{ include "this.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ include "this.selectorLabels" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "this.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "this.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account
+*/}}
+{{- define "this.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "this.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/agent-traces/templates/clusterrole.yaml
+++ b/charts/agent-traces/templates/clusterrole.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.enabled .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "this.fullname" . }}
+  labels:
+    {{- include "this.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/proxy
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+{{- end }}

--- a/charts/agent-traces/templates/clusterrolebinding.yaml
+++ b/charts/agent-traces/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.enabled .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "this.fullname" . }}
+  labels:
+    {{- include "this.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "this.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "this.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/agent-traces/templates/configmap.yaml
+++ b/charts/agent-traces/templates/configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "this.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "this.labels" . | nindent 4 }}
+data:
+  agent.yaml: |
+    {{- tpl .Values.config.agent . | nindent 4}}
+  strategies.json: |
+    {{- .Values.config.strategies | nindent 4 }}
+{{- end }}

--- a/charts/agent-traces/templates/daemonset.yaml
+++ b/charts/agent-traces/templates/daemonset.yaml
@@ -1,0 +1,104 @@
+{{- if .Values.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "this.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "this.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.annotations | nindent 4 }}
+spec:
+  minReadySeconds: 10
+  selector:
+    matchLabels:
+      {{- include "this.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "this.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      containers:
+        - args:
+            - -config.file=/etc/agent/agent.yaml
+            {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          command:
+            - /bin/agent
+          env:
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          name: agent
+          ports:
+            - containerPort: 8080
+              name: http-metrics
+            - containerPort: 6831
+              name: thrift-compact
+              protocol: UDP
+            - containerPort: 6832
+              name: thrift-binary
+              protocol: UDP
+            - containerPort: 14268
+              name: thrift-http
+            - containerPort: 14250
+              name: thrift-grpc
+            - containerPort: 9411
+              name: zipkin
+            - containerPort: 55680
+              name: otlp
+            - containerPort: 55678
+              name: opencensus
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - mountPath: /etc/agent
+              name: agent-config
+            {{- if .Values.secret.mount }}
+            - mountPath: /var/run/secrets/grafana.com/agent
+              name: agent-secrets
+              readOnly: true
+            {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+              {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+      serviceAccount: {{ include "this.serviceAccountName" . }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      volumes:
+        - configMap:
+            name: {{ include "this.fullname" . }}
+          name: agent-config
+        {{- if .Values.secret.mount }}
+        - secret:
+            secretName: {{ include "this.fullname" . }}
+          name: agent-secrets
+        {{- end }}
+        {{- if .Values.extraVolumes }}{{ "\n" }}
+          {{- toYaml .Values.extraVolumes | indent 8 }}
+        {{- end }}
+  updateStrategy:
+    type: RollingUpdate
+{{- end }}

--- a/charts/agent-traces/templates/secret.yaml
+++ b/charts/agent-traces/templates/secret.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.enabled .Values.secret.create -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "this.fullname" . }}
+  labels:
+    {{- include "this.labels" . | nindent 4 }}
+  {{- with .Values.secret.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  {{- range $key, $value := .Values.secret.data }}
+  {{- if gt (len (tpl $value $)) 0 }}
+  {{ $key }}: {{ tpl $value $ | b64enc }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/agent-traces/templates/service.yaml
+++ b/charts/agent-traces/templates/service.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "this.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "this.labels" . | nindent 4 }}
+  {{- if .Values.service.annotations }}
+  annotations:
+    {{- tpl (toYaml .Values.service.annotations) . | nindent 4 }}
+  {{- end }}
+spec:
+  ports:
+    - name: agent-http-metrics
+      port: 8080
+      targetPort: 8080
+    - name: agent-thrift-compact
+      port: 6831
+      protocol: UDP
+      targetPort: 6831
+    - name: agent-thrift-binary
+      port: 6832
+      protocol: UDP
+      targetPort: 6832
+    - name: agent-thrift-http
+      port: 14268
+      targetPort: 14268
+    - name: agent-thrift-grpc
+      port: 14250
+      targetPort: 14250
+    - name: agent-zipkin
+      port: 9411
+      targetPort: 9411
+    - name: agent-otlp
+      port: 55680
+      targetPort: 55680
+    - name: agent-opencensus
+      port: 55678
+      targetPort: 55678
+  selector:
+    {{- include "this.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/agent-traces/templates/serviceaccount.yaml
+++ b/charts/agent-traces/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.enabled .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "this.serviceAccountName" . }}
+  labels:
+    {{- include "this.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/agent-traces/values.yaml
+++ b/charts/agent-traces/values.yaml
@@ -1,0 +1,173 @@
+# Whether this chart is enabled
+# (useful when this chart is used as a dependency from another chart)
+enabled: true
+
+# DaemonSet annotations
+annotations: {}
+
+# Pod annotations
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: http-metrics
+
+# Image configuration for the Agent container
+image:
+  repository: grafana/agent
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion
+  tag: ""
+
+# Additional command arguments for the Agent container
+extraArgs: []
+
+# Additional volumes for the Pod
+extraVolumes: []
+
+# Additional volume mounts for the Agent container
+extraVolumeMounts: []
+
+# Environment variables for the Agent container
+env: []
+
+# Readiness probe for the Agent container
+readinessProbe:
+  httpGet:
+    path: /-/ready
+    port: http-metrics
+
+# Liveness probe for the Agent container
+livenessProbe:
+  httpGet:
+    path: /-/healthy
+    port: http-metrics
+
+# Resources for the Agent container
+resources: {}
+
+# Security context for the Agent container
+securityContext: {}
+
+# Pod node selector
+nodeSelector: {}
+
+# Pod affinity
+affinity: {}
+
+# Pod tolerations
+tolerations:
+  - effect: NoSchedule
+    operator: Exists
+
+# Whether to create Cluster Role and Cluster Role Binding
+rbac:
+  create: true
+
+# Creation of the Sercret used by the Pod
+secret:
+  create: true
+  mount: true
+  annotations: {}
+  data:
+    password: ""
+
+# Creation of the Service Account used by the Pod
+serviceAccount:
+  create: true
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+  annotations: {}
+
+# Service annotations
+service:
+  annotations: {}
+
+# Grafana Cloud connection
+accessConfig:
+  url: tempo-us-central1.grafana.net:443
+  username: ""
+  # Path under which the secret.data.password is mounted in the container
+  password_file: /var/run/secrets/grafana.com/agent/password
+
+# Allow to extend the bellow Agent configuration
+extraConfig: {}
+extraServiceConfig: []
+extraDefaultConfigConfig: []
+extraDefaultScrapeConfig: []
+
+# Agent configuration
+config:
+  agent: |
+    server:
+      http_listen_port: 8080
+      log_level: info
+    tempo:
+      configs:
+        - name: default
+          push_config:
+            endpoint: {{ .Values.accessConfig.url }}
+            {{- if .Values.accessConfig.username }}
+            basic_auth:
+              username: {{ .Values.accessConfig.username }}
+              password_file: {{ .Values.accessConfig.password_file }}
+            {{- end }}
+            batch:
+              send_batch_size: 1000
+              timeout: 5s
+            retry_on_failure:
+              enabled: false
+          receivers:
+            jaeger:
+              protocols:
+                grpc: null
+                thrift_binary: null
+                thrift_compact: null
+                thrift_http: null
+              remote_sampling:
+                insecure: true
+                strategy_file: /etc/agent/strategies.json
+            opencensus: null
+            otlp:
+              protocols:
+                grpc: null
+                http: null
+            zipkin: null
+          scrape_configs:
+            - job_name: kubernetes-pods
+              kubernetes_sd_configs:
+                - role: pod
+              relabel_configs:
+                - action: replace
+                  source_labels:
+                    - __meta_kubernetes_namespace
+                  target_label: namespace
+                - action: replace
+                  source_labels:
+                    - __meta_kubernetes_pod_name
+                  target_label: pod
+                - action: replace
+                  source_labels:
+                    - __meta_kubernetes_pod_container_name
+                  target_label: container
+              bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: false
+            {{- with .Values.extraDefaultScrapeConfig }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
+        {{- with .Values.extraDefaultConfigConfig }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
+      {{- with .Values.extraServiceConfig }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
+    {{- with .Values.extraConfig }}{{ "\n" }}
+    {{- toYaml . }}
+    {{- end }}
+  strategies: |
+    {
+      "default_strategy": {
+        "param": 0.001,
+        "type": "probabilistic"
+      }
+    }


### PR DESCRIPTION
This PR is adding the Grafana Agent Helm chart for the Traces part. The intention is to keep the Helm chart small and maintainable and allow to use it from the [top-level Helm chart](https://github.com/grafana/helm-charts/pull/354).