### PR TITLE
fluent-bit: enable turning on dque

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: fluent-bit
-version: 2.2.0
+version: 2.2.1
 appVersion: v2.1.0
 kubeVersion: "^1.10.0-0"
 description: "Uses fluent-bit Loki go plugin for gathering logs and sending them to Loki"

--- a/charts/fluent-bit/README.md
+++ b/charts/fluent-bit/README.md
@@ -85,6 +85,11 @@ For more details, read the [Fluent Bit documentation](../../../cmd/fluent-bit/RE
 | `loki.serviceScheme`     | The scheme of the Loki service.                                                                    | `http`                           |
 | `loki.user`              | The http basic auth username to access the Loki service.                                           |                                  |
 | `loki.password`          | The http basic auth password to access the Loki service.                                           |                                  |
+| `config.dque`            | Turn on Buffering using dque see [Official Fluent Bit output Plugin documentation](https://grafana.com/docs/loki/latest/clients/fluentbit/)                                                                     |           `false`                     |
+| `config.dque.bufferType` | dque                                                                                               | `dque`                           |
+| `config.dque.dir`        | dque data dir                                                                                      |`/tmp/flb-storage/buffer`         |
+| `config.dque.name`       | dque name                                                                                          | `loki.0`                         |
+| `config.dque.segmentSize`| dque Seqent size                                                                                   | `500`                            |
 | `config.port`            | the Fluent Bit port to listen. (This is mainly used to serve metrics)                              | `2020`                           |
 | `config.tenantID`        | The tenantID used by default to push logs to Loki                                                  | `''`                             |
 | `config.batchWait`       | Time to wait before send a log batch to Loki, full or not. (unit: secs)                            | `1`                              |

--- a/charts/fluent-bit/templates/configmap.yaml
+++ b/charts/fluent-bit/templates/configmap.yaml
@@ -44,6 +44,13 @@ data:
         BatchWait {{ .Values.config.batchWait }}
         BatchSize {{ int .Values.config.batchSize }}
         Labels {{ .Values.config.labels }}
+        {{- if .Values.config.dque.enabled }}
+        Buffer true
+        BufferType {{ .Values.config.dque.bufferType }}
+        DqueDir {{ .Values.config.dque.dir }}
+        DqueName {{ .Values.config.dque.name }}
+        DqueSegmentSize {{ .Values.config.dque.segmentSize }}
+        {{- end }}
         RemoveKeys {{ include "helm-toolkit.utils.joinListWithComma" .Values.config.removeKeys }}
         AutoKubernetesLabels {{ .Values.config.autoKubernetesLabels }}
         LabelMapPath /fluent-bit/etc/labelmap.json
@@ -70,4 +77,3 @@ data:
 
   labelmap.json: |-
     {{- .Values.config.labelMap | toPrettyJson | nindent 4}}
-

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -7,6 +7,12 @@ loki:
   # user: user
   # password: pass
 config:
+  dque:
+    enabled: false   # set this to true to turn on dque https://grafana.com/docs/loki/latest/clients/fluentbit/
+    bufferType: dque
+    dir: /tmp/flb-storage/buffer
+    name: loki.0
+    segmentSize: 500
   port: 2020
   tenantID: '""'
   batchWait: 1


### PR DESCRIPTION
Signed-off-by: Marco Sartori <2761500+marcosartori@users.noreply.github.com>

Reason For PR: 

Using fluent bit to forward to loki I have this error many times when sending logs.

```
entry out of order' for stream:
```

by enabling dque after reading the docs seems to resolve the issue. *see fluentbit version below

Enables dque in the config map, disabled as it is now by default

# ct results

**lint**
```
Linting chart 'fluent-bit => (version: "2.2.1", path: "charts/fluent-bit")'
Checking chart 'fluent-bit => (version: "2.2.1", path: "charts/fluent-bit")' for a version bump...
Old chart version: 2.2.0
New chart version: 2.2.1
Chart version ok.
Validating /mycharts/charts/fluent-bit/Chart.yaml...
Validation success! 👍
==> Linting charts/fluent-bit

1 chart(s) linted, 0 chart(s) failed
------------------------------------------------------------------------------------------------------------------------
 ✔︎ fluent-bit => (version: "2.2.1", path: "charts/fluent-bit")
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully
```
**lint-and-install**
Just pasting the end bit

```
========================================================================================================================
Deleting release 'fluent-bit-huwvx4o7bp'...
release "fluent-bit-huwvx4o7bp" uninstalled
Deleting namespace 'fluent-bit-huwvx4o7bp'...
namespace "fluent-bit-huwvx4o7bp" deleted
Namespace 'fluent-bit-huwvx4o7bp' terminated.
------------------------------------------------------------------------------------------------------------------------
 ✔︎ fluent-bit => (version: "2.2.1", path: "charts/fluent-bit")
------------------------------------------------------------------------------------------------------------------------
All charts linted and installed successfully
```

by setting in values or using set this will then appear in the config map, eg

```
helm template myrelease charts/fluent-bit --set config.dque.enabled=true
```

```
        Buffer true
        BufferType dque
        DqueDir /tmp/flb-storage/buffer
        DqueName loki.0
        DqueSegmentSize 500
```


*fluent-bit-version
Seems like fluentbit version is still 1.4 according to this https://github.com/grafana/loki/blob/master/cmd/fluent-bit/Dockerfile#L6 .  
I created a new image based off of 1.7, and pushed to my own docker repo which then allowed the dque to work.

So to be clear in the enviroment I am in my fluent bit loki version is based of 1.7 and not the one in dockerhub based off 1.4


