### PR TITLE
[loki-distributed] Add the restartPolicy to all of the Deployments in the chart

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.2.0
-version: 0.28.0
+version: 0.29.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.28.0](https://img.shields.io/badge/Version-0.28.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
+![Version: 0.29.0](https://img.shields.io/badge/Version-0.29.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 
@@ -38,6 +38,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | compactor.podAnnotations | object | `{}` | Annotations for compactor pods |
 | compactor.priorityClassName | string | `nil` | The name of the PriorityClass for compactor pods |
 | compactor.resources | object | `{}` | Resource requests and limits for the compactor |
+| compactor.restartPolicy | string | `nil` | Restart Policy for the pod |
 | compactor.terminationGracePeriodSeconds | int | `30` | Grace period to allow the compactor to shutdown before it is killed |
 | compactor.tolerations | list | `[]` | Tolerations for compactor pods |
 | distributor.affinity | string | Hard node and soft zone anti-affinity | Affinity for distributor pods. Passed through `tpl` and, thus, to be configured as string |
@@ -54,6 +55,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | distributor.priorityClassName | string | `nil` | The name of the PriorityClass for distributor pods |
 | distributor.replicas | int | `1` | Number of replicas for the distributor |
 | distributor.resources | object | `{}` | Resource requests and limits for the distributor |
+| distributor.restartPolicy | string | `nil` | Restart Policy for the pod |
 | distributor.terminationGracePeriodSeconds | int | `30` | Grace period to allow the distributor to shutdown before it is killed |
 | distributor.tolerations | list | `[]` | Tolerations for distributor pods |
 | fullnameOverride | string | `nil` | Overrides the chart's computed fullname |
@@ -92,6 +94,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | gateway.readinessProbe.timeoutSeconds | int | `1` |  |
 | gateway.replicas | int | `1` | Number of replicas for the gateway |
 | gateway.resources | object | `{}` | Resource requests and limits for the gateway |
+| gateway.restartPolicy | string | `nil` | Restart Policy for the pod |
 | gateway.service.annotations | object | `{}` | Annotations for the gateway service |
 | gateway.service.clusterIP | string | `nil` | ClusterIP of the gateway service |
 | gateway.service.loadBalancerIP | string | `nil` | Load balancer IPO address if service type is LoadBalancer |
@@ -250,6 +253,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | queryFrontend.priorityClassName | string | `nil` | The name of the PriorityClass for query-frontend pods |
 | queryFrontend.replicas | int | `1` | Number of replicas for the query-frontend |
 | queryFrontend.resources | object | `{}` | Resource requests and limits for the query-frontend |
+| queryFrontend.restartPolicy | string | `nil` | Restart Policy for the pod |
 | queryFrontend.terminationGracePeriodSeconds | int | `30` | Grace period to allow the query-frontend to shutdown before it is killed |
 | queryFrontend.tolerations | list | `[]` | Tolerations for query-frontend pods |
 | rbac.pspEnabled | bool | `false` | If enabled, a PodSecurityPolicy is created |
@@ -272,6 +276,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | ruler.priorityClassName | string | `nil` | The name of the PriorityClass for ruler pods |
 | ruler.replicas | int | `1` | Number of replicas for the ruler |
 | ruler.resources | object | `{}` | Resource requests and limits for the ruler |
+| ruler.restartPolicy | string | `nil` | Restart Policy for the pod |
 | ruler.terminationGracePeriodSeconds | int | `300` | Grace period to allow the ruler to shutdown before it is killed |
 | ruler.tolerations | list | `[]` | Tolerations for ruler pods |
 | serviceAccount.annotations | object | `{}` | Annotations for the service account |
@@ -302,6 +307,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | tableManager.priorityClassName | string | `nil` | The name of the PriorityClass for table-manager pods |
 | tableManager.replicas | int | `1` | Number of replicas for the table-manager |
 | tableManager.resources | object | `{}` | Resource requests and limits for the table-manager |
+| tableManager.restartPolicy | string | `nil` | Restart Policy for the pod |
 | tableManager.terminationGracePeriodSeconds | int | `30` | Grace period to allow the table-manager to shutdown before it is killed |
 | tableManager.tolerations | list | `[]` | Tolerations for table-manager pods |
 

--- a/charts/loki-distributed/templates/compactor/deployment-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/deployment-compactor.yaml
@@ -28,6 +28,9 @@ spec:
     spec:
       serviceAccountName: {{ include "loki.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}
+      {{- with .Values.compactor.restartPolicy }}
+      restartPolicy: {{ . }}
+      {{- end }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/loki-distributed/templates/distributor/deployment-distributor.yaml
+++ b/charts/loki-distributed/templates/distributor/deployment-distributor.yaml
@@ -30,6 +30,9 @@ spec:
         app.kubernetes.io/part-of: memberlist
     spec:
       serviceAccountName: {{ include "loki.serviceAccountName" . }}
+      {{- with .Values.distributor.restartPolicy }}
+      restartPolicy: {{ . }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/loki-distributed/templates/gateway/deployment-gateway.yaml
+++ b/charts/loki-distributed/templates/gateway/deployment-gateway.yaml
@@ -29,6 +29,9 @@ spec:
         {{- include "loki.gatewaySelectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "loki.serviceAccountName" . }}
+      {{- with .Values.gateway.restartPolicy }}
+      restartPolicy: {{ . }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/loki-distributed/templates/query-frontend/deployment-query-frontend.yaml
+++ b/charts/loki-distributed/templates/query-frontend/deployment-query-frontend.yaml
@@ -28,6 +28,9 @@ spec:
         {{- include "loki.queryFrontendSelectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "loki.serviceAccountName" . }}
+      {{- with .Values.queryFrontend.restartPolicy }}
+      restartPolicy: {{ . }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/loki-distributed/templates/ruler/deployment-ruler.yaml
+++ b/charts/loki-distributed/templates/ruler/deployment-ruler.yaml
@@ -32,6 +32,9 @@ spec:
     spec:
       serviceAccountName: {{ include "loki.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}
+      {{- with .Values.ruler.restartPolicy }}
+      restartPolicy: {{ . }}
+      {{- end }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/loki-distributed/templates/table-manager/deployment-table-manager.yaml
+++ b/charts/loki-distributed/templates/table-manager/deployment-table-manager.yaml
@@ -25,6 +25,9 @@ spec:
         {{- include "loki.tableManagerSelectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "loki.serviceAccountName" . }}
+      {{- with .Values.tableManager.restartPolicy }}
+      restartPolicy: {{ . }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -295,6 +295,8 @@ distributor:
   extraVolumes: []
   # -- Resource requests and limits for the distributor
   resources: {}
+  # -- Restart Policy for the pod
+  restartPolicy: null
   # -- Grace period to allow the distributor to shutdown before it is killed
   terminationGracePeriodSeconds: 30
   # -- Affinity for distributor pods. Passed through `tpl` and, thus, to be configured as string
@@ -406,6 +408,8 @@ queryFrontend:
   extraVolumes: []
   # -- Resource requests and limits for the query-frontend
   resources: {}
+  # -- Restart Policy for the pod
+  restartPolicy: null
   # -- Grace period to allow the query-frontend to shutdown before it is killed
   terminationGracePeriodSeconds: 30
   # -- Affinity for query-frontend pods. Passed through `tpl` and, thus, to be configured as string
@@ -458,6 +462,8 @@ tableManager:
   extraVolumes: []
   # -- Resource requests and limits for the table-manager
   resources: {}
+  # -- Restart Policy for the pod
+  restartPolicy: null
   # -- Grace period to allow the table-manager to shutdown before it is killed
   terminationGracePeriodSeconds: 30
   # -- Affinity for table-manager pods. Passed through `tpl` and, thus, to be configured as string
@@ -525,6 +531,8 @@ gateway:
     allowPrivilegeEscalation: false
   # -- Resource requests and limits for the gateway
   resources: {}
+  # -- Restart Policy for the pod
+  restartPolicy: null
   # -- Grace period to allow the gateway to shutdown before it is killed
   terminationGracePeriodSeconds: 30
   # -- Affinity for gateway pods. Passed through `tpl` and, thus, to be configured as string
@@ -713,6 +721,8 @@ compactor:
   extraVolumes: []
   # -- Resource requests and limits for the compactor
   resources: {}
+  # -- Restart Policy for the pod
+  restartPolicy: null
   # -- Grace period to allow the compactor to shutdown before it is killed
   terminationGracePeriodSeconds: 30
   # -- Node selector for compactor pods
@@ -760,6 +770,8 @@ ruler:
   extraVolumes: []
   # -- Resource requests and limits for the ruler
   resources: {}
+  # -- Restart Policy for the pod
+  restartPolicy: null
   # -- Grace period to allow the ruler to shutdown before it is killed
   terminationGracePeriodSeconds: 300
   # -- Affinity for ruler pods. Passed through `tpl` and, thus, to be configured as string


### PR DESCRIPTION
We have run into a situation where we want to make sure the Loki gateway pod is replaced rather than restarted if it errors out or stops, but we noticed that the `restartPolicy` option was not on any of the `Deployment` templates.