### PR TITLE
[grafana] Add annotations for grafana template secret.yaml

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.8.0
+version: 6.8.1
 appVersion: 7.5.3
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/secret.yaml
+++ b/charts/grafana/templates/secret.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ template "grafana.namespace" . }}
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
+{{- with .Values.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 type: Opaque
 data:
   {{- if and (not .Values.admin.existingSecret) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) }}


### PR DESCRIPTION
Goals: 
There is a common use case that credentials need to be fetched from  Vault when deploying grafana, some annotations need to be added for secret.yaml

example like this:
https://banzaicloud.com/blog/inject-secrets-into-pods-vault-revisited/

apiVersion: v1
kind: Secret
metadata:
  name: sample-secret
  annotations:
    vault.security.banzaicloud.io/vault-addr: "https://vault.default.svc.cluster.local:8200"
    vault.security.banzaicloud.io/vault-role: "default" # In case of Secrets the webhook's ServiceAccount is used
    vault.security.banzaicloud.io/vault-skip-verify: "true"
    vault.security.banzaicloud.io/vault-path: "kubernetes"
type: kubernetes.io/dockerconfigjson
data:
......