### PR TITLE
[tempo-distributed] Make possible to change service type for queryFrontend

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.9.3
+version: 0.9.4
 appVersion: 0.7.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.9.3](https://img.shields.io/badge/Version-0.9.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
+![Version: 0.9.4](https://img.shields.io/badge/Version-0.9.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -181,6 +181,7 @@ The memcached default args are removed and should be provided manually. The sett
 | queryFrontend.replicas | int | `1` | Number of replicas for the query-frontend |
 | queryFrontend.resources | object | `{}` | Resource requests and limits for the query-frontend |
 | queryFrontend.service.annotations | object | `{}` | Annotations for queryFrontend service |
+| queryFrontend.service.type | string | `"ClusterIP"` | Type of service for the queryFrontend |
 | queryFrontend.terminationGracePeriodSeconds | int | `30` | Grace period to allow the query-frontend to shutdown before it is killed |
 | queryFrontend.tolerations | list | `[]` | Tolerations for query-frontend pods |
 | serviceAccount.annotations | object | `{}` | Annotations for the service account |

--- a/charts/tempo-distributed/templates/query-frontend/service-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/service-query-frontend.yaml
@@ -10,6 +10,7 @@ metadata:
     {{ toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  type: {{ .Values.queryFrontend.service.type }}
   ports:
     - name: http
       port: 3100

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -274,6 +274,8 @@ queryFrontend:
   service:
     # -- Annotations for queryFrontend service
     annotations: {}
+    # -- Type of service for the queryFrontend
+    type: ClusterIP
   # -- The name of the PriorityClass for query-frontend pods
   priorityClassName: null
   # -- Annotations for query-frontend pods


### PR DESCRIPTION
I want to get rid of issue #399.
It should be pretty straightforward just creating the variable `.Values.queryFrontend.service.type`.