### PR TITLE
[promtail] Tolerate node-role.kubernetes.io/control-plane:NoSchedule taints

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.2.1
-version: 3.5.1
+version: 3.6.0
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 3.5.1](https://img.shields.io/badge/Version-3.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
+![Version: 3.6.0](https://img.shields.io/badge/Version-3.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 
@@ -124,7 +124,7 @@ The new release which will pick up again from the existing `positions.yaml`.
 | serviceMonitor.namespace | string | `nil` | Alternative namespace for ServiceMonitor resources |
 | serviceMonitor.namespaceSelector | object | `{}` | Namespace selector for ServiceMonitor resources |
 | serviceMonitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
-| tolerations | list | `[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"}]` | Tolerations for pods. By default, pods will be scheduled on master nodes. |
+| tolerations | list | `[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane","operator":"Exists"}]` | Tolerations for pods. By default, pods will be scheduled on master/control-plane nodes. |
 | updateStrategy | object | `{}` | The update strategy for the DaemonSet |
 
 ## Configuration

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -109,9 +109,12 @@ nodeSelector: {}
 # -- Affinity configuration for pods
 affinity: {}
 
-# -- Tolerations for pods. By default, pods will be scheduled on master nodes.
+# -- Tolerations for pods. By default, pods will be scheduled on master/control-plane nodes.
 tolerations:
   - key: node-role.kubernetes.io/master
+    operator: Exists
+    effect: NoSchedule
+  - key: node-role.kubernetes.io/control-plane
     operator: Exists
     effect: NoSchedule
 


### PR DESCRIPTION
The Kubernetes project is moving away from offensive wording and as part
of this KEP-2067 was accepted to replace the
`node-role.kubernetes.io/master:NoSchedule` taint with
`node-role.kubernetes.io/control-plane:NoSchedule`.

To be compatible with clusters that already use the new taint this pull
request adds an additional toleration for it. This change can't really
break existing setups because we continue to tolerate the old taint as
well.

Additional links:
- https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/README.md
- https://github.com/kubernetes/enhancements/issues/2067
- https://github.com/kubernetes/kubeadm/issues/2200

Signed-off-by: Max Rosin <git@hackrid.de>