### PR TITLE
[grafana] Remove namespace for PSP in grafana helm chart

### DIFF
--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -656,7 +656,7 @@ volumes:
 {{- if and .Values.persistence.enabled (eq .Values.persistence.type "pvc") }}
   - name: storage
     persistentVolumeClaim:
-      claimName: {{ tpl (.Values.persistence.existingClaim .) | default (include "grafana.fullname" .) }}
+      claimName: {{ tpl (.Values.persistence.existingClaim | default (include "grafana.fullname" .)) . }}
 {{- else if and .Values.persistence.enabled (eq .Values.persistence.type "statefulset") }}
 # nothing
 {{- else }}


### PR DESCRIPTION
The PodSecurityPolicy is not a namespaced resource.

Links:
- https://stackoverflow.com/questions/55707978/can-a-pod-security-policy-be-applied-to-a-namespace

On a k3d cluster:
```
$ kubectl api-resources --namespaced=false -o wide | grep -i podsecuritypolicy
podsecuritypolicies               psp          policy/v1beta1                    false        PodSecurityPolicy                [create delete deletecollection get list patch update watch]
```

```
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.0", GitCommit:"af46c47ce925f4c4ad5cc8d1fca46c7b77d13b38", GitTreeState:"clean", BuildDate:"2020-12-08T17:59:43Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"19", GitVersion:"v1.19.4+k3s1", GitCommit:"2532c10faad43e2b6e728fdcc01662dc13d37764", GitTreeState:"clean", BuildDate:"2020-11-18T22:11:18Z", GoVersion:"go1.15.2", Compiler:"gc", Platform:"linux/amd64"}
```