### PR TITLE
[tempo-distributed] Explicitly set ingestion overrides

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.9.4
+version: 0.9.5
 appVersion: 0.7.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.9.4](https://img.shields.io/badge/Version-0.9.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
+![Version: 0.9.5](https://img.shields.io/badge/Version-0.9.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -140,6 +140,7 @@ The memcached default args are removed and should be provided manually. The sett
 | memcachedExporter.image.repository | string | `"prom/memcached-exporter"` | Memcached Exporter Docker image repository |
 | memcachedExporter.image.tag | string | `"v0.8.0"` | Memcached Exporter Docker image tag |
 | memcachedExporter.resources | object | `{}` |  |
+| overrides | string | `"overrides: {}\n"` |  |
 | querier.affinity | string | Hard node and soft zone anti-affinity | Affinity for querier pods. Passed through `tpl` and, thus, to be configured as string |
 | querier.extraArgs | list | `[]` | Additional CLI args for the querier |
 | querier.extraEnv | list | `[]` | Environment variables to add to the querier pods |

--- a/charts/tempo-distributed/templates/configmap-tempo.yaml
+++ b/charts/tempo-distributed/templates/configmap-tempo.yaml
@@ -9,6 +9,6 @@ data:
   tempo-query.yaml: |
     {{- tpl .Values.queryFrontend.query.config . | nindent 4 }}
   overrides.yaml: |
-    overrides: {}
+    {{- tpl .Values.overrides . | nindent 4 }}
   tempo.yaml: |
     {{- tpl .Values.config . | nindent 4 }}

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -421,6 +421,10 @@ config: |
         service: memcached-client
         timeout: 500ms
 
+# Set ingestion overrides
+overrides: |
+  overrides: {}
+
 # memcached is for all of the Tempo pieces to coordinate with each other.
 # you can use your self memcacherd by set enable: false and host + service
 memcached:


### PR DESCRIPTION
### Problem 

Can't easily generate tenant specific overrides in the `tempo-distributed` helm deployment. 

### Proposed solution

Explicitly set [ingestion overrides](https://grafana.com/docs/tempo/latest/configuration/ingestion-limit/).