### PR TITLE
[fluent-bit] Deprecate the Fluent-bit chart.

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -1,9 +1,11 @@
 apiVersion: "v1"
 name: fluent-bit
-version: 2.2.0
+version: 2.3.0
 appVersion: v2.1.0
 kubeVersion: "^1.10.0-0"
 description: "Uses fluent-bit Loki go plugin for gathering logs and sending them to Loki"
+# This Helm chart is deprecated and no longer maintained.
+deprecated: true
 home: https://grafana.com/loki
 icon: https://raw.githubusercontent.com/grafana/loki/master/docs/sources/logo.png
 sources:

--- a/charts/fluent-bit/README.md
+++ b/charts/fluent-bit/README.md
@@ -1,6 +1,6 @@
 # Fluent Bit Loki chart
 
-DEPRECATED. Advised to use the official Fluent-Bit chart at https://github.com/fluent/helm-charts and use the official Loki output (https://docs.fluentbit.io/manual/pipeline/outputs/loki).
+DEPRECATED. Please use the official Fluent-Bit chart at https://github.com/fluent/helm-charts.
 
 This chart install the Fluent Bit application to ship logs to Loki. It defines daemonset on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 

--- a/charts/fluent-bit/README.md
+++ b/charts/fluent-bit/README.md
@@ -1,5 +1,7 @@
 # Fluent Bit Loki chart
 
+DEPRECATED. Advised to use the official Fluent-Bit chart at https://github.com/fluent/helm-charts and use the official Loki output (https://docs.fluentbit.io/manual/pipeline/outputs/loki).
+
 This chart install the Fluent Bit application to ship logs to Loki. It defines daemonset on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Get Repo Info

--- a/charts/fluent-bit/templates/NOTES.txt
+++ b/charts/fluent-bit/templates/NOTES.txt
@@ -4,10 +4,6 @@ Please use the official fluent-bit chart
 
 https://github.com/fluent/helm-charts
 
-and the official loki output
-
-https://docs.fluentbit.io/manual/pipeline/outputs/loki
-
 !WARNING! !WARNING! !WARNING! !WARNING! !WARNING!
 
 Verify the application is working by running these commands:

--- a/charts/fluent-bit/templates/NOTES.txt
+++ b/charts/fluent-bit/templates/NOTES.txt
@@ -1,3 +1,15 @@
+!WARNING! !WARNING! !WARNING! !WARNING! !WARNING!
+
+Please use the official fluent-bit chart 
+
+https://github.com/fluent/helm-charts
+
+and the official loki output
+
+https://docs.fluentbit.io/manual/pipeline/outputs/loki
+
+!WARNING! !WARNING! !WARNING! !WARNING! !WARNING!
+
 Verify the application is working by running these commands:
   kubectl --namespace {{ .Release.Namespace }} port-forward daemonset/{{ include "fluent-bit-loki.fullname" . }} {{ .Values.config.port }}
   curl http://127.0.0.1:{{ .Values.config.port }}/api/v1/metrics/prometheus


### PR DESCRIPTION
**Description**

As discussed on Slack; This chart should be deprecated as there as an official helm chart from Fluent-bit and Loki is an official output. 

**Changes**

- Set the `deprecrated` flag. So users will get a warning when installing this chart.
- Updated README to point to the official chart and guide.

**Additional Information**

This [page](https://grafana.com/docs/loki/latest/clients/fluentbit/) should probably be updated.

Signed-off-by: Whyeasy <Whyeasy@users.noreply.github.com>