### PR TITLE
[loki-distributed] upgraded the podManagementPolicy to Parallel and bumped the chart major version

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.2.0
-version: 1.0.0
+version: 0.31.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.2.0
-version: 0.30.0
+version: 1.0.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,7 +1,6 @@
 # loki-distributed
 
-
-![Version: 0.31.0](https://img.shields.io/badge/Version-0.31.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square) 
+![Version: 0.31.0](https://img.shields.io/badge/Version-0.31.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 
@@ -10,8 +9,6 @@ Helm chart for Grafana Loki in microservices mode
 * <https://github.com/grafana/loki>
 * <https://grafana.com/oss/loki/>
 * <https://grafana.com/docs/loki/latest/>
-
-
 
 ## Chart Repo
 
@@ -28,7 +25,9 @@ helm repo add grafana https://grafana.github.io/helm-charts
 Major version upgrades listed here indicate that there is an incompatible breaking change needing manual actions.
 
 ### From 0.30.x to 0.31.0
+
 This version updates the `podManagementPolicy` of running the Loki components as `StatefulSet`'s to `Parallel` instead of the default `OrderedReady` in order to allow better scalability for Loki e.g. in case the pods weren't terminated gracefully. This change requires a manual action deleting the existing StatefulSets before upgrading with Helm.
+
 ```bash
 # Delete the Ingesters StatefulSets
 kubectl delete statefulset RELEASE_NAME-loki-distributed-ingester -n LOKI_NAMESPACE --cascade=orphan
@@ -328,7 +327,6 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | tableManager.terminationGracePeriodSeconds | int | `30` | Grace period to allow the table-manager to shutdown before it is killed |
 | tableManager.tolerations | list | `[]` | Tolerations for table-manager pods |
 
-
 ## Components
 
 The chart supports the compontents shown in the following table.
@@ -349,7 +347,6 @@ The other components are optional.
 | memcached-frontend |  ✅ |  ❎ |
 | memcached-index-queries |  ✅ |  ❎ |
 | memcached-index-writes |  ✅ |  ❎ |
-
 
 ## Configuration
 
@@ -490,7 +487,6 @@ and automatically proxies requests to the correct Loki components (distributor, 
 The gateway must be enabled if an Ingress is required, since the Ingress exposes the gateway only.
 If the gateway is enabled, Grafana and log shipping agents, such as Promtail, should be configured to use the gateway.
 If NetworkPolicies are enabled, they are more restrictive if the gateway is enabled.
-
 
 ## Metrics
 

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -25,9 +25,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 Major version upgrades listed here indicate that there is an incompatible breaking change needing manual actions.
 
 ### From 0.30.x to 0.31.0
-
 This version updates the `podManagementPolicy` of running the Loki components as `StatefulSet`'s to `Parallel` instead of the default `OrderedReady` in order to allow better scalability for Loki e.g. in case the pods weren't terminated gracefully. This change requires a manual action deleting the existing StatefulSets before upgrading with Helm.
-
 ```bash
 # Delete the Ingesters StatefulSets
 kubectl delete statefulset RELEASE_NAME-loki-distributed-ingester -n LOKI_NAMESPACE --cascade=orphan

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,7 @@
 # loki-distributed
 
-![Version: 0.30.0](https://img.shields.io/badge/Version-0.30.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
+
+![Version: 0.31.0](https://img.shields.io/badge/Version-0.31.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square) 
 
 Helm chart for Grafana Loki in microservices mode
 
@@ -9,6 +10,8 @@ Helm chart for Grafana Loki in microservices mode
 * <https://github.com/grafana/loki>
 * <https://grafana.com/oss/loki/>
 * <https://grafana.com/docs/loki/latest/>
+
+
 
 ## Chart Repo
 
@@ -22,9 +25,9 @@ helm repo add grafana https://grafana.github.io/helm-charts
 
 ### Upgrading an existing Release to a new major version
 
-A major chart version change (like v0.0.30 -> v1.0.0) indicates that there is an incompatible breaking change needing manual actions.
+Major version upgrades listed here indicate that there is an incompatible breaking change needing manual actions.
 
-### From 0.30.x to 1.0.0
+### From 0.30.x to 0.31.0
 This version updates the `podManagementPolicy` of running the Loki components as `StatefulSet`'s to `Parallel` instead of the default `OrderedReady` in order to allow better scalability for Loki e.g. in case the pods weren't terminated gracefully. This change requires a manual action deleting the existing StatefulSets before upgrading with Helm.
 ```bash
 # Delete the Ingesters StatefulSets
@@ -32,7 +35,6 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-ingester -n LOKI_NAMESP
 # Delete the Queriers StatefulSets
 kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPACE --cascade=orphan
 ```
-
 
 ## Values
 
@@ -326,6 +328,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | tableManager.terminationGracePeriodSeconds | int | `30` | Grace period to allow the table-manager to shutdown before it is killed |
 | tableManager.tolerations | list | `[]` | Tolerations for table-manager pods |
 
+
 ## Components
 
 The chart supports the compontents shown in the following table.
@@ -346,6 +349,7 @@ The other components are optional.
 | memcached-frontend |  ✅ |  ❎ |
 | memcached-index-queries |  ✅ |  ❎ |
 | memcached-index-writes |  ✅ |  ❎ |
+
 
 ## Configuration
 
@@ -486,6 +490,7 @@ and automatically proxies requests to the correct Loki components (distributor, 
 The gateway must be enabled if an Ingress is required, since the Ingress exposes the gateway only.
 If the gateway is enabled, Grafana and log shipping agents, such as Promtail, should be configured to use the gateway.
 If NetworkPolicies are enabled, they are more restrictive if the gateway is enabled.
+
 
 ## Metrics
 

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -18,6 +18,22 @@ Add the following repo to use the chart:
 helm repo add grafana https://grafana.github.io/helm-charts
 ```
 
+## Upgrading
+
+### Upgrading an existing Release to a new major version
+
+A major chart version change (like v0.0.30 -> v1.0.0) indicates that there is an incompatible breaking change needing manual actions.
+
+### From 0.30.x to 1.0.0
+This version updates the `podManagementPolicy` of running the Loki components as `StatefulSet`'s to `Parallel` instead of the default `OrderedReady` in order to allow better scalability for Loki e.g. in case the pods weren't terminated gracefully. This change requires a manual action deleting the existing StatefulSets before upgrading with Helm.
+```bash
+# Delete the Ingesters StatefulSets
+kubectl delete statefulset RELEASE_NAME-loki-distributed-ingester -n LOKI_NAMESPACE --cascade=orphan
+# Delete the Queriers StatefulSets
+kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPACE --cascade=orphan
+```
+
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/charts/loki-distributed/README.md.gotmpl
+++ b/charts/loki-distributed/README.md.gotmpl
@@ -33,7 +33,6 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 
 {{ template "chart.valuesSection" . }}
 
-
 ## Components
 
 The chart supports the compontents shown in the following table.
@@ -54,7 +53,6 @@ The other components are optional.
 | memcached-frontend |  ✅ |  ❎ |
 | memcached-index-queries |  ✅ |  ❎ |
 | memcached-index-writes |  ✅ |  ❎ |
-
 
 ## Configuration
 
@@ -195,7 +193,6 @@ and automatically proxies requests to the correct Loki components (distributor, 
 The gateway must be enabled if an Ingress is required, since the Ingress exposes the gateway only.
 If the gateway is enabled, Grafana and log shipping agents, such as Promtail, should be configured to use the gateway.
 If NetworkPolicies are enabled, they are more restrictive if the gateway is enabled.
-
 
 ## Metrics
 

--- a/charts/loki-distributed/README.md.gotmpl
+++ b/charts/loki-distributed/README.md.gotmpl
@@ -16,6 +16,21 @@ Add the following repo to use the chart:
 helm repo add grafana https://grafana.github.io/helm-charts
 ```
 
+## Upgrading
+
+### Upgrading an existing Release to a new major version
+
+Major version upgrades listed here indicate that there is an incompatible breaking change needing manual actions.
+
+### From 0.30.x to 0.31.0
+This version updates the `podManagementPolicy` of running the Loki components as `StatefulSet`'s to `Parallel` instead of the default `OrderedReady` in order to allow better scalability for Loki e.g. in case the pods weren't terminated gracefully. This change requires a manual action deleting the existing StatefulSets before upgrading with Helm.
+```bash
+# Delete the Ingesters StatefulSets
+kubectl delete statefulset RELEASE_NAME-loki-distributed-ingester -n LOKI_NAMESPACE --cascade=orphan
+# Delete the Queriers StatefulSets
+kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPACE --cascade=orphan
+```
+
 {{ template "chart.valuesSection" . }}
 
 

--- a/charts/loki-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/statefulset-ingester.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
 spec:
   replicas: {{ .Values.ingester.replicas }}
+  podManagementPolicy: Parallel
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/charts/loki-distributed/templates/querier/statefulset-querier.yaml
+++ b/charts/loki-distributed/templates/querier/statefulset-querier.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
 spec:
   replicas: {{ .Values.querier.replicas }}
+  podManagementPolicy: Parallel
   updateStrategy:
     rollingUpdate:
       partition: 0


### PR DESCRIPTION
upgraded the podManagementPolicy to Parallel and bumped the chart major version. This PR addresses #435 

Signed-off-by: Sherif Ayad <sherif.k.ayad@gmail.com>