### PR TITLE
[loki-distributed] Add relabelings to ServiceMonitor

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.2.0
-version: 0.31.0
+version: 0.31.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.31.0](https://img.shields.io/badge/Version-0.31.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
+![Version: 0.31.1](https://img.shields.io/badge/Version-0.31.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 
@@ -304,6 +304,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | serviceMonitor.labels | object | `{}` | Additional ServiceMonitor labels |
 | serviceMonitor.namespace | string | `nil` | Alternative namespace for ServiceMonitor resources |
 | serviceMonitor.namespaceSelector | object | `{}` | Namespace selector for ServiceMonitor resources |
+| serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig |
 | serviceMonitor.scheme | string | `"http"` | ServiceMonitor will use http by default, but you can pick https as well |
 | serviceMonitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | serviceMonitor.tlsConfig | string | `nil` | ServiceMonitor will use these tlsConfig settings to make the health check requests |

--- a/charts/loki-distributed/templates/compactor/servicemonitor-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/servicemonitor-compactor.yaml
@@ -33,6 +33,10 @@ spec:
       {{- with .scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+      {{- with .relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/loki-distributed/templates/distributor/servicemonitor-distributor.yaml
+++ b/charts/loki-distributed/templates/distributor/servicemonitor-distributor.yaml
@@ -32,6 +32,10 @@ spec:
       {{- with .scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+      {{- with .relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/loki-distributed/templates/ingester/servicemonitor-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/servicemonitor-ingester.yaml
@@ -32,6 +32,10 @@ spec:
       {{- with .scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+      {{- with .relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/loki-distributed/templates/memcached-chunks/servicemonitor-memcached-chunks.yaml
+++ b/charts/loki-distributed/templates/memcached-chunks/servicemonitor-memcached-chunks.yaml
@@ -33,6 +33,10 @@ spec:
       {{- with .scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+      {{- with .relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/memcached-frontend/servicemonitor-memcached-frontend.yaml
+++ b/charts/loki-distributed/templates/memcached-frontend/servicemonitor-memcached-frontend.yaml
@@ -33,6 +33,10 @@ spec:
       {{- with .scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+      {{- with .relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/memcached-index-queries/servicemonitor-memcached-index-queries.yaml
+++ b/charts/loki-distributed/templates/memcached-index-queries/servicemonitor-memcached-index-queries.yaml
@@ -33,6 +33,10 @@ spec:
       {{- with .scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+      {{- with .relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/memcached-index-writes/servicemonitor-memcached-index-writes.yaml
+++ b/charts/loki-distributed/templates/memcached-index-writes/servicemonitor-memcached-index-writes.yaml
@@ -33,6 +33,10 @@ spec:
       {{- with .scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+      {{- with .relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/querier/servicemonitor-querier.yaml
+++ b/charts/loki-distributed/templates/querier/servicemonitor-querier.yaml
@@ -32,6 +32,10 @@ spec:
       {{- with .scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+      {{- with .relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/loki-distributed/templates/query-frontend/servicemonitor-query-frontend.yaml
+++ b/charts/loki-distributed/templates/query-frontend/servicemonitor-query-frontend.yaml
@@ -32,6 +32,10 @@ spec:
       {{- with .scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+      {{- with .relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/loki-distributed/templates/ruler/servicemonitor-ruler.yaml
+++ b/charts/loki-distributed/templates/ruler/servicemonitor-ruler.yaml
@@ -33,6 +33,10 @@ spec:
       {{- with .scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+      {{- with .relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/loki-distributed/templates/table-manager/servicemonitor-table-manager.yaml
+++ b/charts/loki-distributed/templates/table-manager/servicemonitor-table-manager.yaml
@@ -33,6 +33,10 @@ spec:
       {{- with .scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+      {{- with .relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -181,6 +181,9 @@ serviceMonitor:
   interval: null
   # -- ServiceMonitor scrape timeout in Go duration format (e.g. 15s)
   scrapeTimeout: null
+  # -- ServiceMonitor relabel configs to apply to samples before scraping
+  # https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+  relabelings: []
   # -- ServiceMonitor will use http by default, but you can pick https as well
   scheme: http
   # -- ServiceMonitor will use these tlsConfig settings to make the health check requests


### PR DESCRIPTION
Example:

```yaml
serviceMonitor:
  enabled: true
  relabelings:
  - separator: /
    sourceLabels:
    - namespace
    - __meta_kubernetes_pod_label_app_kubernetes_io_component
    targetLabel: job
```