### PR TITLE
[agent] create grafana agent chart

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: agent
+description: Grafana Agent is a telemetry collector for sending metrics, logs, and trace data to the opinionated Grafana observability stack.
+type: application
+appVersion: 0.14.0
+version: 1.0.0
+home: https://github.com/grafana/agent/
+sources:
+  - https://grafana.com/docs/grafana-cloud/agent/
+icon: https://raw.githubusercontent.com/grafana/agent/main/docs/assets/logo_and_name.png
+maintainers:
+  - name: ???
+    email: ???

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,0 +1,121 @@
+# agent
+
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.14.0](https://img.shields.io/badge/AppVersion-0.14.0-informational?style=flat-square)
+
+Grafana Agent is a telemetry collector for sending metrics, logs, and trace data to the opinionated Grafana observability stack.
+
+## Source Code
+
+* <https://grafana.com/docs/grafana-cloud/agent/>
+
+## Chart Repo
+
+Add the following repo to use the chart:
+
+```console
+helm repo add grafana https://grafana.github.io/helm-charts
+```
+
+## Upgrading
+
+A major chart version change indicates that there is an incompatible breaking change needing manual actions.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity configuration for pods |
+| agentServerConfig | string | See `values.yaml` | Section for configuring the server part of the agent |
+| annotations | object | `{}` | Annotations for the SaemonSet |
+| containerSecurityContext | object | `{"privileged":true,"runAsUser":0}` | The security context for container |
+| defaultVolumeMounts | list | See `values.yaml` | Default volume mounts. Corresponds to `volumes`. |
+| defaultVolumes | list | See `values.yaml` | Default volumes that are mounted into pods. In most cases, these should not be changed. Use `extraVolumes`/`extraVolumeMounts` for additional custom volumes. |
+| extraArgs | list | `[]` |  |
+| extraEnv | list | `[]` | Extra environment variables |
+| extraEnvFrom | list | `[]` | Extra environment variables from secrets or configmaps |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
+| fullnameOverride | string | `nil` | Overrides the chart's computed fullname |
+| image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
+| image.registry | string | `"docker.io"` | The Docker registry |
+| image.repository | string | `"grafana/agent"` | Docker image repository |
+| image.tag | string | `nil` | Overrides the image tag whose default is the chart's appVersion |
+| imagePullSecrets | list | `[]` | Image pull secrets for Docker images |
+| integrationsConfig | string | See `values.yaml` | Section for configuring the integrations part of the agent |
+| loki.basicAuth | object | `{}` | Credentials of the remote endpoint |
+| loki.config | string | See `values.yaml` | Section for configuring the loki part of the agent |
+| loki.enabled | bool | `true` | Enable metrics collection in daemonset mode. automatically mount /var/log and /var/lib/docker/containers to the pod when enabled |
+| loki.pushURL | string | `"http://localhost/loki/api/v1/push"` |  |
+| loki.tenant | string | `""` | Add the tenant option to the requests, usefull when using multitenant loki feature |
+| nameOverride | string | `nil` | Overrides the chart's name |
+| nodeSelector | object | `{}` | Node selector for pods |
+| podAnnotations | object | `{}` | Pod annotations |
+| podLabels | object | `{}` | Pod labels |
+| podSecurityContext | object | `{}` | The security context for pods |
+| priorityClassName | string | `nil` | The name of the PriorityClass |
+| prometheusDaemonSet.basicAuth | object | `{}` | Credentials of the remote endpoint |
+| prometheusDaemonSet.config | string | See `values.yaml` | Section for configuring the prometheus daemonset part of the agent |
+| prometheusDaemonSet.enabled | bool | `true` | Enable metrics collection in daemonset mode |
+| prometheusDaemonSet.remoteWriteURL | string | `"http://localhost/api/prom/push"` |  |
+| prometheusDaemonSet.tenant | string | `""` | Add the X-Scope-OrgID header to the requests, usefull when using multitenant cortex feature |
+| prometheusDeployment.basicAuth | object | `{}` | Credentials of the remote endpoint |
+| prometheusDeployment.config | string | See `values.yaml` | Section for configuring the prometheus deployment part of the agent |
+| prometheusDeployment.enabled | bool | `true` | Enable metrics collection in deployment mode |
+| prometheusDeployment.remoteWriteURL | string | `"http://localhost/api/prom/push"` |  |
+| prometheusDeployment.tenant | string | `""` | Add the X-Scope-OrgID header to the requests, usefull when using multitenant cortex feature |
+| rbac.create | bool | `true` | Specifies whether RBAC resources are to be created |
+| rbac.pspEnabled | bool | `false` | Specifies whether a PodSecurityPolicy is to be created |
+| resources | object | `{}` | Resource requests and limits |
+| serviceAccount.annotations | object | `{}` | Annotations for the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a ServiceAccount should be created |
+| serviceAccount.imagePullSecrets | list | `[]` | Image pull secrets for the service account |
+| serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. If not set and `create` is true, a name is generated using the fullname template |
+| tempo.basicAuth | object | `{}` | Credentials of the remote endpoint |
+| tempo.config | string | See `values.yaml` | Section for configuring the tempo daemonset part of the agent |
+| tempo.enabled | bool | `true` | Enable trace collection in daemonset mode |
+| tempo.remoteWriteURL | string | `"http://localhost"` |  |
+| tempo.tenant | string | `""` | Add the X-Scope-OrgID header to the requests, usefull when using multitenant tempo feature |
+| tolerations | list | `[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"}]` | Tolerations for pods. By default, pods will be scheduled on master nodes. |
+| updateStrategy | object | `{"type":"RollingUpdate"}` | The update strategy for the DaemonSet |
+
+## Configuration
+
+The config file for the Agent must be configured as string.
+This is necessary because the contents are passed through the `tpl` function.
+With this, the file can be templated and assembled from reusable YAML snippets.
+See `values.yaml´ for details.
+
+### node\_exporter
+
+If you want to use the `node\_exporter` integration, please add it to the `integrationsConfig`
+section and also include the following changes:
+```yaml
+integrationsConfig: |
+  agent:
+    enabled: true
+  node_exporter:
+    enabled: true
+    rootfs_path: /host/root
+    sysfs_path: /host/sys
+    procfs_path: /host/procfs
+extraVolumes:
+  - hostPath:
+      path: /
+    name: rootfs
+  - hostPath:
+      path: /sys
+    name: sysfs
+  - hostPath:
+      path: /proc
+    name: procfs
+extraVolumeMounts:
+  - mountPath: /host/root
+    name: rootfs
+    readOnly: true
+  - mountPath: /host/sys
+    name: sysfs
+    readOnly: true
+  - mountPath: /host/proc
+    name: procfs
+    readOnly: true
+```

--- a/charts/agent/README.md.gotmpl
+++ b/charts/agent/README.md.gotmpl
@@ -1,0 +1,65 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Chart Repo
+
+Add the following repo to use the chart:
+
+```console
+helm repo add grafana https://grafana.github.io/helm-charts
+```
+
+## Upgrading
+
+A major chart version change indicates that there is an incompatible breaking change needing manual actions.
+
+{{ template "chart.valuesSection" . }}
+
+## Configuration
+
+The config file for the Agent must be configured as string.
+This is necessary because the contents are passed through the `tpl` function.
+With this, the file can be templated and assembled from reusable YAML snippets.
+See `values.yaml´ for details.
+
+### node\_exporter
+
+If you want to use the `node\_exporter` integration, please add it to the `integrationsConfig`
+section and also include the following changes:
+```yaml
+integrationsConfig: |
+  agent:
+    enabled: true
+  node_exporter:
+    enabled: true
+    rootfs_path: /host/root
+    sysfs_path: /host/sys
+    procfs_path: /host/procfs
+extraVolumes:
+  - hostPath:
+      path: /
+    name: rootfs
+  - hostPath:
+      path: /sys
+    name: sysfs
+  - hostPath:
+      path: /proc
+    name: procfs
+extraVolumeMounts:
+  - mountPath: /host/root
+    name: rootfs
+    readOnly: true
+  - mountPath: /host/sys
+    name: sysfs
+    readOnly: true
+  - mountPath: /host/proc
+    name: procfs
+    readOnly: true
+```

--- a/charts/agent/templates/NOTES.txt
+++ b/charts/agent/templates/NOTES.txt
@@ -1,0 +1,5 @@
+***********************************************************************
+ Welcome to Grafana Agent
+ Chart version: {{ .Chart.Version }}
+ Agent version: {{ .Values.image.tag | default .Chart.AppVersion }}
+***********************************************************************

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -1,0 +1,66 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "agent.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "agent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "agent.labels" -}}
+helm.sh/chart: {{ include "agent.chart" . }}
+{{ include "agent.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "agent.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+{{- define "agent-deployment.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "agent.name" . }}-deployment
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account
+*/}}
+{{- define "agent.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "agent.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/agent/templates/clusterrole.yaml
+++ b/charts/agent/templates/clusterrole.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.rbac.create }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "agent.fullname" . }}
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/metrics
+      - nodes/proxy
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - watch
+      - list
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+{{- end }}

--- a/charts/agent/templates/clusterrolebinding.yaml
+++ b/charts/agent/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "agent.fullname" . }}
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "agent.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "agent.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -1,0 +1,119 @@
+{{- if or .Values.prometheusDaemonSet.enabled (or .Values.loki.enabled .Values.tempo.enabled) }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "agent.fullname" . }}
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  minReadySeconds: 10
+  selector:
+    matchLabels:
+      {{- include "agent.selectorLabels" . | nindent 6 }}
+  updateStrategy:
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
+  template:
+    metadata:
+      labels:
+        {{- include "agent.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "agent.serviceAccountName" . }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: agent
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "-config.file=/etc/agent/agent.yaml"
+            {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agent
+            {{- if .Values.loki.enabled }}
+            - name: varlog
+              mountPath: /var/log
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            {{- end }}
+            {{- with .Values.defaultVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          env:
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http-metrics
+              containerPort: 80
+              protocol: TCP
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          secret:
+            secretName: {{ include "agent.fullname" . }}
+        {{- if .Values.loki.enabled }}
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        {{- end }}
+        {{- with .Values.defaultVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -1,0 +1,101 @@
+{{- if .Values.prometheusDeployment.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agent.fullname" . }}
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{ toYaml . | indent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "agent-deployment.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "agent-deployment.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{ toYaml . | indent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{ toYaml . | indent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "agent.serviceAccountName" . }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: agent
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "-config.file=/etc/agent/agent-deployment.yaml"
+            {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agent
+            {{- with .Values.defaultVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          env:
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http-metrics
+              containerPort: 80
+              protocol: TCP
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          secret:
+            secretName: {{ include "agent.fullname" . }}
+        {{- with .Values.defaultVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/charts/agent/templates/podsecuritypolicy.yaml
+++ b/charts/agent/templates/podsecuritypolicy.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.rbac.create .Values.rbac.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "agent.fullname" . }}
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+spec:
+  {{- toYaml .Values.podSecurityPolicy | nindent 2 }}
+{{- end }}

--- a/charts/agent/templates/secret.yaml
+++ b/charts/agent/templates/secret.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "agent.fullname" . }}
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+stringData:
+  agent.yaml: |
+    server:
+      {{- tpl .Values.agentServerConfig . | nindent 6 }}
+    integrations:
+      {{- tpl .Values.integrationsConfig . | nindent 6 }}
+    {{- if .Values.prometheusDaemonSet.enabled }}
+    prometheus:
+      {{- tpl .Values.prometheusDaemonSet.config . | nindent 6 }}
+    {{- end }}
+    {{- if .Values.loki.enabled }}
+    loki:
+      {{- tpl .Values.loki.config . | nindent 6 }}
+    {{- end }}
+    {{- if .Values.tempo.enabled }}
+    tempo:
+      {{- tpl .Values.loki.config . | nindent 6 }}
+    {{- end }}
+  agent-deployment.yaml: |
+    {{- if .Values.prometheusDeployment.enabled }}
+    server:
+      {{- tpl .Values.agentServerConfig . | nindent 6 }}
+    integrations:
+      {{- tpl .Values.integrationsConfig . | nindent 6 }}
+    prometheus:
+      {{- tpl .Values.prometheusDeployment.config . | nindent 6 }}
+    {{- end }}

--- a/charts/agent/templates/serviceaccount.yaml
+++ b/charts/agent/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agent.serviceAccountName" . }}
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- with .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -130,8 +130,8 @@ prometheusDaemonSet:
   enabled: true
   # -- Credentials of the remote endpoint
   basicAuth: {}
-    # username: 
-    # password: 
+    # username:
+    # password:
   # -- Remote write URL:
   remoteWriteURL: http://localhost/api/prom/push
   # -- Add the X-Scope-OrgID header to the requests, usefull when using multitenant cortex feature
@@ -275,8 +275,8 @@ prometheusDeployment:
   enabled: true
   # -- Credentials of the remote endpoint
   basicAuth: {}
-    # username: 
-    # password: 
+    # username:
+    # password:
   # -- Remote write URL:
   remoteWriteURL: http://localhost/api/prom/push
   # -- Add the X-Scope-OrgID header to the requests, usefull when using multitenant cortex feature
@@ -329,8 +329,8 @@ loki:
   enabled: true
   # -- Credentials of the remote endpoint
   basicAuth: {}
-    # username: 
-    # password: 
+    # username:
+    # password:
   # -- Remote Push URL:
   pushURL: http://localhost/loki/api/v1/push
   # -- Add the tenant option to the requests, usefull when using multitenant loki feature
@@ -604,8 +604,8 @@ tempo:
   enabled: true
   # -- Credentials of the remote endpoint
   basicAuth: {}
-    # username: 
-    # password: 
+    # username:
+    # password:
   # -- Remote write URL:
   remoteWriteURL: http://localhost
   # -- Add the X-Scope-OrgID header to the requests, usefull when using multitenant tempo feature

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -1,0 +1,671 @@
+# -- Overrides the chart's name
+nameOverride: null
+
+# -- Overrides the chart's computed fullname
+fullnameOverride: null
+
+image:
+  # -- The Docker registry
+  registry: docker.io
+  # -- Docker image repository
+  repository: grafana/agent
+  # -- Overrides the image tag whose default is the chart's appVersion
+  tag: null
+  # -- Docker image pull policy
+  pullPolicy: IfNotPresent
+
+# -- Image pull secrets for Docker images
+imagePullSecrets: []
+
+# -- Annotations for the SaemonSet
+annotations: {}
+
+# -- The update strategy for the DaemonSet
+updateStrategy:
+  type: RollingUpdate
+
+# -- Pod labels
+podLabels: {}
+
+# -- Pod annotations
+podAnnotations: {}
+#  prometheus.io/scrape: "true"
+#  prometheus.io/port: "http-metrics"
+
+# -- The name of the PriorityClass
+priorityClassName: null
+
+# -- Resource requests and limits
+resources: {}
+#  limits:
+#    cpu: 200m
+#    memory: 128Mi
+#  requests:
+#    cpu: 100m
+#    memory: 128Mi
+
+# -- The security context for pods
+podSecurityContext: {}
+
+# -- The security context for container
+containerSecurityContext:
+  privileged: true
+  runAsUser: 0
+
+rbac:
+  # -- Specifies whether RBAC resources are to be created
+  create: true
+  # -- Specifies whether a PodSecurityPolicy is to be created
+  pspEnabled: false
+
+serviceAccount:
+  # -- Specifies whether a ServiceAccount should be created
+  create: true
+  # -- The name of the ServiceAccount to use.
+  # If not set and `create` is true, a name is generated using the fullname template
+  name: null
+  # -- Image pull secrets for the service account
+  imagePullSecrets: []
+  # -- Annotations for the service account
+  annotations: {}
+
+# -- Node selector for pods
+nodeSelector: {}
+
+# -- Affinity configuration for pods
+affinity: {}
+
+# -- Tolerations for pods. By default, pods will be scheduled on master nodes.
+tolerations:
+  - key: node-role.kubernetes.io/master
+    operator: Exists
+    effect: NoSchedule
+
+# -- Default volumes that are mounted into pods. In most cases, these should not be changed.
+# Use `extraVolumes`/`extraVolumeMounts` for additional custom volumes.
+# @default -- See `values.yaml`
+defaultVolumes:
+  - name: etcmachineid
+    hostPath:
+      path: /etc/machine-id
+
+# -- Default volume mounts. Corresponds to `volumes`.
+# @default -- See `values.yaml`
+defaultVolumeMounts:
+  - name: etcmachineid
+    mountPath: /etc/machine-id
+    readOnly: true
+
+# Extra volumes to be added in addition to those specified under `defaultVolumes`.
+extraVolumes: []
+
+# Extra volume mounts together. Corresponds to `extraVolumes`.
+extraVolumeMounts: []
+
+# Extra args for the Promtail container.
+extraArgs: []
+# -- Example:
+# -- extraArgs:
+# --   - -prometheus.wal-directory=/tmp/agent/data
+
+# -- Extra environment variables
+extraEnv: []
+
+# -- Extra environment variables from secrets or configmaps
+extraEnvFrom: []
+
+# -- Section for configuring the server part of the agent
+# @default -- See `values.yaml`
+agentServerConfig: |
+  log_level: info
+
+# -- Section for configuring the integrations part of the agent
+# @default -- See `values.yaml`
+integrationsConfig: |
+  agent:
+    enabled: true
+
+prometheusDaemonSet:
+  # -- Enable metrics collection in daemonset mode
+  enabled: true
+  # -- Credentials of the remote endpoint
+  basicAuth: {}
+    # username: 
+    # password: 
+  # -- Remote write URL:
+  remoteWriteURL: http://localhost/api/prom/push
+  # -- Add the X-Scope-OrgID header to the requests, usefull when using multitenant cortex feature
+  tenant: ""
+  # -- Section for configuring the prometheus daemonset part of the agent
+  # @default -- See `values.yaml`
+  config: |
+    configs:
+      - host_filter: true
+        name: agent
+        global:
+          remote_write:
+            - url: {{ .Values.prometheusDaemonSet.remoteWriteURL }}
+              {{- if .Values.prometheusDaemonSet.basicAuth }}
+              basic_auth:
+                  password: {{ .Values.prometheusDaemonSet.basicAuth.password }}
+                  username: {{ .Values.prometheusDaemonSet.basicAuth.username }}
+              {{- end }}
+              {{- if .Values.prometheusDaemonSet.tenant }}
+              headers:
+                "X-Scope-OrgID": {{ .Values.prometheusDaemonSet.tenant }}
+              {{- end }}
+        scrape_configs:
+          - job_name: kubernetes-pods
+            kubernetes_sd_configs:
+              - role: pod
+            relabel_configs:
+              - action: drop
+                regex: "false"
+                source_labels:
+                  - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+              - action: keep
+                regex: .*-metrics
+                source_labels:
+                  - __meta_kubernetes_pod_container_port_name
+              - action: replace
+                regex: (https?)
+                replacement: $1
+                source_labels:
+                  - __meta_kubernetes_pod_annotation_prometheus_io_scheme
+                target_label: __scheme__
+              - action: replace
+                regex: (.+)
+                replacement: $1
+                source_labels:
+                  - __meta_kubernetes_pod_annotation_prometheus_io_path
+                target_label: __metrics_path__
+              - action: replace
+                regex: (.+?)(\:\d+)?;(\d+)
+                replacement: $1:$3
+                source_labels:
+                  - __address__
+                  - __meta_kubernetes_pod_annotation_prometheus_io_port
+                target_label: __address__
+              - action: drop
+                regex: ""
+                source_labels:
+                  - __meta_kubernetes_pod_label_name
+              - action: replace
+                replacement: $1
+                separator: /
+                source_labels:
+                  - __meta_kubernetes_namespace
+                  - __meta_kubernetes_pod_label_name
+                target_label: job
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_namespace
+                target_label: namespace
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_name
+                target_label: pod
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_container_name
+                target_label: container
+              - action: replace
+                separator: ':'
+                source_labels:
+                  - __meta_kubernetes_pod_name
+                  - __meta_kubernetes_pod_container_name
+                  - __meta_kubernetes_pod_container_port_name
+                target_label: instance
+              - action: labelmap
+                regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
+                replacement: __param_$1
+              - action: drop
+                regex: Succeeded|Failed
+                source_labels:
+                  - __meta_kubernetes_pod_phase
+          - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            job_name: kube-system/kubelet
+            kubernetes_sd_configs:
+              - role: node
+            relabel_configs:
+              - replacement: kubernetes.default.svc.cluster.local:443
+                target_label: __address__
+              - replacement: https
+                target_label: __scheme__
+              - regex: (.+)
+                replacement: /api/v1/nodes/${1}/proxy/metrics
+                source_labels:
+                  - __meta_kubernetes_node_name
+                target_label: __metrics_path__
+            tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: false
+          - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            job_name: kube-system/cadvisor
+            kubernetes_sd_configs:
+              - role: node
+            metric_relabel_configs:
+              - action: drop
+                regex: container_([a-z_]+);
+                source_labels:
+                  - __name__
+                  - image
+              - action: drop
+                regex: container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)
+                source_labels:
+                  - __name__
+            relabel_configs:
+              - replacement: kubernetes.default.svc.cluster.local:443
+                target_label: __address__
+              - regex: (.+)
+                replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+                source_labels:
+                  - __meta_kubernetes_node_name
+                target_label: __metrics_path__
+            scheme: https
+            tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: false
+    global:
+        scrape_interval: 15s
+    wal_directory: /var/lib/agent/data
+
+prometheusDeployment:
+  # -- Enable metrics collection in deployment mode
+  enabled: true
+  # -- Credentials of the remote endpoint
+  basicAuth: {}
+    # username: 
+    # password: 
+  # -- Remote write URL:
+  remoteWriteURL: http://localhost/api/prom/push
+  # -- Add the X-Scope-OrgID header to the requests, usefull when using multitenant cortex feature
+  tenant: ""
+  # -- Section for configuring the prometheus deployment part of the agent
+  # @default -- See `values.yaml`
+  config: |
+    configs:
+      - host_filter: false
+        name: agent
+        global:
+          remote_write:
+            - url: {{ .Values.prometheusDeployment.remoteWriteURL }}
+              {{- if .Values.prometheusDeployment.basicAuth }}
+              basic_auth:
+                  password: {{ .Values.prometheusDeployment.basicAuth.password }}
+                  username: {{ .Values.prometheusDeployment.basicAuth.username }}
+              {{- end }}
+              {{- if .Values.prometheusDeployment.tenant }}
+              headers:
+                "X-Scope-OrgID": {{ .Values.prometheusDeployment.tenant }}
+              {{- end }}
+        scrape_configs:
+          - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            job_name: default/kubernetes
+            kubernetes_sd_configs:
+              - role: endpoints
+            metric_relabel_configs:
+              - action: keep
+                regex: workqueue_queue_duration_seconds_bucket|process_cpu_seconds_total|process_resident_memory_bytes|workqueue_depth|rest_client_request_duration_seconds_bucket|workqueue_adds_total|up|rest_client_requests_total|apiserver_request_total|go_goroutines
+                source_labels:
+                  - __name__
+            relabel_configs:
+              - action: keep
+                regex: apiserver
+                source_labels:
+                  - __meta_kubernetes_service_label_component
+            scheme: https
+            tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: false
+                server_name: kubernetes
+    global:
+        scrape_interval: 15s
+    wal_directory: /var/lib/agent/data
+
+loki:
+  # -- Enable metrics collection in daemonset mode.
+  # automatically mount /var/log and /var/lib/docker/containers to the pod when enabled
+  enabled: true
+  # -- Credentials of the remote endpoint
+  basicAuth: {}
+    # username: 
+    # password: 
+  # -- Remote Push URL:
+  pushURL: http://localhost/loki/api/v1/push
+  # -- Add the tenant option to the requests, usefull when using multitenant loki feature
+  tenant: ""
+  # -- Section for configuring the loki part of the agent
+  # @default -- See `values.yaml`
+  config: |
+    configs:
+      - clients:
+          - url: {{ .Values.loki.pushURL }}
+            {{- if .Values.loki.basicAuth }}
+            basic_auth:
+                password: {{ .Values.loki.basicAuth.password }}
+                username: {{ .Values.loki.basicAuth.username }}
+            {{- end }}
+            {{- if .Values.loki.tenant }}
+            tenant_id: {{ .Values.loki.tenant }}
+            {{- end }}
+        name: default
+        scrape_configs:
+          - job_name: kubernetes-pods-name
+            kubernetes_sd_configs:
+              - role: pod
+            pipeline_stages:
+              - docker: {}
+            relabel_configs:
+              - source_labels:
+                  - __meta_kubernetes_pod_label_name
+                target_label: __service__
+              - source_labels:
+                  - __meta_kubernetes_pod_node_name
+                target_label: __host__
+              - action: drop
+                regex: ""
+                source_labels:
+                  - __service__
+              - action: labelmap
+                regex: __meta_kubernetes_pod_label_(.+)
+              - action: replace
+                replacement: $1
+                separator: /
+                source_labels:
+                  - __meta_kubernetes_namespace
+                  - __service__
+                target_label: job
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_namespace
+                target_label: namespace
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_name
+                target_label: pod
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_container_name
+                target_label: container
+              - replacement: /var/log/pods/*$1/*.log
+                separator: /
+                source_labels:
+                  - __meta_kubernetes_pod_uid
+                  - __meta_kubernetes_pod_container_name
+                target_label: __path__
+          - job_name: kubernetes-pods-app
+            kubernetes_sd_configs:
+              - role: pod
+            pipeline_stages:
+              - docker: {}
+            relabel_configs:
+              - action: drop
+                regex: .+
+                source_labels:
+                  - __meta_kubernetes_pod_label_name
+              - source_labels:
+                  - __meta_kubernetes_pod_label_app
+                target_label: __service__
+              - source_labels:
+                  - __meta_kubernetes_pod_node_name
+                target_label: __host__
+              - action: drop
+                regex: ""
+                source_labels:
+                  - __service__
+              - action: labelmap
+                regex: __meta_kubernetes_pod_label_(.+)
+              - action: replace
+                replacement: $1
+                separator: /
+                source_labels:
+                  - __meta_kubernetes_namespace
+                  - __service__
+                target_label: job
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_namespace
+                target_label: namespace
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_name
+                target_label: pod
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_container_name
+                target_label: container
+              - replacement: /var/log/pods/*$1/*.log
+                separator: /
+                source_labels:
+                  - __meta_kubernetes_pod_uid
+                  - __meta_kubernetes_pod_container_name
+                target_label: __path__
+          - job_name: kubernetes-pods-direct-controllers
+            kubernetes_sd_configs:
+              - role: pod
+            pipeline_stages:
+              - docker: {}
+            relabel_configs:
+              - action: drop
+                regex: .+
+                separator: ""
+                source_labels:
+                  - __meta_kubernetes_pod_label_name
+                  - __meta_kubernetes_pod_label_app
+              - action: drop
+                regex: '[0-9a-z-.]+-[0-9a-f]{8,10}'
+                source_labels:
+                  - __meta_kubernetes_pod_controller_name
+              - source_labels:
+                  - __meta_kubernetes_pod_controller_name
+                target_label: __service__
+              - source_labels:
+                  - __meta_kubernetes_pod_node_name
+                target_label: __host__
+              - action: drop
+                regex: ""
+                source_labels:
+                  - __service__
+              - action: labelmap
+                regex: __meta_kubernetes_pod_label_(.+)
+              - action: replace
+                replacement: $1
+                separator: /
+                source_labels:
+                  - __meta_kubernetes_namespace
+                  - __service__
+                target_label: job
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_namespace
+                target_label: namespace
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_name
+                target_label: pod
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_container_name
+                target_label: container
+              - replacement: /var/log/pods/*$1/*.log
+                separator: /
+                source_labels:
+                  - __meta_kubernetes_pod_uid
+                  - __meta_kubernetes_pod_container_name
+                target_label: __path__
+          - job_name: kubernetes-pods-indirect-controller
+            kubernetes_sd_configs:
+              - role: pod
+            pipeline_stages:
+              - docker: {}
+            relabel_configs:
+              - action: drop
+                regex: .+
+                separator: ""
+                source_labels:
+                  - __meta_kubernetes_pod_label_name
+                  - __meta_kubernetes_pod_label_app
+              - action: keep
+                regex: '[0-9a-z-.]+-[0-9a-f]{8,10}'
+                source_labels:
+                  - __meta_kubernetes_pod_controller_name
+              - action: replace
+                regex: ([0-9a-z-.]+)-[0-9a-f]{8,10}
+                source_labels:
+                  - __meta_kubernetes_pod_controller_name
+                target_label: __service__
+              - source_labels:
+                  - __meta_kubernetes_pod_node_name
+                target_label: __host__
+              - action: drop
+                regex: ""
+                source_labels:
+                  - __service__
+              - action: labelmap
+                regex: __meta_kubernetes_pod_label_(.+)
+              - action: replace
+                replacement: $1
+                separator: /
+                source_labels:
+                  - __meta_kubernetes_namespace
+                  - __service__
+                target_label: job
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_namespace
+                target_label: namespace
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_name
+                target_label: pod
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_container_name
+                target_label: container
+              - replacement: /var/log/pods/*$1/*.log
+                separator: /
+                source_labels:
+                  - __meta_kubernetes_pod_uid
+                  - __meta_kubernetes_pod_container_name
+                target_label: __path__
+          - job_name: kubernetes-pods-static
+            kubernetes_sd_configs:
+              - role: pod
+            pipeline_stages:
+              - docker: {}
+            relabel_configs:
+              - action: drop
+                regex: ""
+                source_labels:
+                  - __meta_kubernetes_pod_annotation_kubernetes_io_config_mirror
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_label_component
+                target_label: __service__
+              - source_labels:
+                  - __meta_kubernetes_pod_node_name
+                target_label: __host__
+              - action: drop
+                regex: ""
+                source_labels:
+                  - __service__
+              - action: labelmap
+                regex: __meta_kubernetes_pod_label_(.+)
+              - action: replace
+                replacement: $1
+                separator: /
+                source_labels:
+                  - __meta_kubernetes_namespace
+                  - __service__
+                target_label: job
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_namespace
+                target_label: namespace
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_name
+                target_label: pod
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_container_name
+                target_label: container
+              - replacement: /var/log/pods/*$1/*.log
+                separator: /
+                source_labels:
+                  - __meta_kubernetes_pod_annotation_kubernetes_io_config_mirror
+                  - __meta_kubernetes_pod_container_name
+                target_label: __path__
+    positions_directory: /tmp/positions
+
+tempo:
+  # -- Enable trace collection in daemonset mode
+  enabled: true
+  # -- Credentials of the remote endpoint
+  basicAuth: {}
+    # username: 
+    # password: 
+  # -- Remote write URL:
+  remoteWriteURL: http://localhost
+  # -- Add the X-Scope-OrgID header to the requests, usefull when using multitenant tempo feature
+  tenant: ""
+  # -- Section for configuring the tempo daemonset part of the agent
+  # @default -- See `values.yaml`
+  config: |
+    configs:
+      - remote_write:
+          - endpoint: {{ .Values.tempo.remoteWriteURL }}
+            insecure: true
+            {{- if .Values.tempo.basicAuth }}
+            basic_auth:
+                password: {{ .Values.tempo.basicAuth.password }}
+                username: {{ .Values.tempo.basicAuth.username }}
+            {{- end }}
+            {{- if .Values.tempo.tenant }}
+            headers:
+              "X-Scope-OrgID": {{ .Values.tempo.tenant }}
+            {{- end }}
+            retry_on_failure:
+                enabled: false
+        batch:
+            send_batch_size: 1000
+            timeout: 5s
+        name: default
+        receivers:
+            jaeger:
+                protocols:
+                    grpc: null
+                    thrift_binary: null
+                    thrift_compact: null
+                    thrift_http: null
+                remote_sampling:
+                    insecure: true
+                    strategy_file: /etc/agent/strategies.json
+            opencensus: null
+            otlp:
+                protocols:
+                    grpc: null
+                    http: null
+            zipkin: null
+        scrape_configs:
+          - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            job_name: kubernetes-pods
+            kubernetes_sd_configs:
+              - role: pod
+            relabel_configs:
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_namespace
+                target_label: namespace
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_name
+                target_label: pod
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_container_name
+                target_label: container
+            tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: false


### PR DESCRIPTION
A very simple chart to install grafana-agent

To keep it simple I configured it to have all services (prometheus, loki and tempo) on the same pod (daemonset) and a separate pod (deployment) for another prometheus to scrape cluster metrics as recommended.

All services configuration are based from the [upstream](https://github.com/grafana/agent/blob/main/production/kubernetes/) with some improvements.