### PR TITLE
[promtail] Add SecurityContextConstraints to make it compatible with OpenShift

### DIFF
--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -113,6 +113,7 @@ The new release which will pick up again from the existing `positions.yaml`.
 | rbac.pspEnabled | bool | `false` | Specifies whether a PodSecurityPolicy is to be created |
 | readinessProbe | object | See `values.yaml` | Readiness probe |
 | resources | object | `{}` | Resource requests and limits |
+| securityContextConstraints.enabled | bool | `false` | If enabled, SecurityContextConstraints will be created if the host is using OpenShift |
 | serviceAccount.annotations | object | `{}` | Annotations for the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a ServiceAccount should be created |
 | serviceAccount.imagePullSecrets | list | `[]` | Image pull secrets for the service account |

--- a/charts/promtail/templates/securitycontextconstraints.yaml
+++ b/charts/promtail/templates/securitycontextconstraints.yaml
@@ -1,4 +1,4 @@
-{{- if (.Capabilities.APIVersions.Has "security.openshift.io/v1") -}}
+{{- if and .Values.securityContextConstraints.enabled (.Capabilities.APIVersions.Has "security.openshift.io/v1") -}}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:

--- a/charts/promtail/templates/securitycontextconstraints.yaml
+++ b/charts/promtail/templates/securitycontextconstraints.yaml
@@ -1,0 +1,34 @@
+{{- if (.Capabilities.APIVersions.Has "security.openshift.io/v1") -}}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ include "promtail.fullname" . }}
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: null
+readOnlyRootFilesystem: true
+requiredDropCapabilities: 
+- ALL
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+- {{ printf "system:serviceaccount:%s:%s" .Release.Namespace  (include "promtail.serviceAccountName" $)}}
+volumes:
+- 'configMap'
+- 'secret'
+- 'hostPath'
+{{- end }}

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -86,6 +86,10 @@ containerSecurityContext:
       - ALL
   allowPrivilegeEscalation: false
 
+# -- SecurityContextConstraint for OpenShift
+securityContextConstraints:
+  enabled: false
+  
 rbac:
   # -- Specifies whether RBAC resources are to be created
   create: true


### PR DESCRIPTION
This overcomes the limitations set for the default security context in the Openshift distro of Kubernetes. 

@unguiculus I am of the opinion that maybe we can set the key as `openshift.securityContextConstraints.enabled` instead of just `securityContextConstraints.enabled`. Since in general people might end up adding more `openshift` specific overrides. 

I am working on deploying `loki-stack` on openshift so I'll try extend this support to wherever it's required.  