### PR TITLE
[grafana] Use same data path as grafana container image

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.10.0
+version: 6.11.0
 appVersion: 7.5.5
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -532,7 +532,7 @@ dashboardsConfigMaps: {}
 ##
 grafana.ini:
   paths:
-    data: /var/lib/grafana/data
+    data: /var/lib/grafana/
     logs: /var/log/grafana
     plugins: /var/lib/grafana/plugins
     provisioning: /etc/grafana/provisioning


### PR DESCRIPTION
The grafana container image uses /var/lib/grafana (instead of
/var/lib/grafana/data) as the default data path.
This patch aligns the behavior and mitigates a regression introduced
by https://github.com/grafana/helm-charts/pull/453

Signed-off-by: Jack Henschel <jackdev@mailbox.org>