### PR TITLE
[loki-distributed] Allow to configure storage through chart values

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.2.1
-version: 0.31.3
+version: 0.31.4
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -89,24 +89,14 @@ loki:
       reject_old_samples_max_age: 168h
       max_cache_freshness_per_query: 10m
 
+    {{- if .Values.loki.schemaConfig}}
     schema_config:
-      configs:
-        - from: 2020-09-07
-          store: boltdb-shipper
-          object_store: filesystem
-          schema: v11
-          index:
-            prefix: loki_index_
-            period: 24h
-
+      {{- toYaml .Values.loki.schemaConfig | nindent 2}}
+    {{- end}}
+    {{- if .Values.loki.storageConfig}}
     storage_config:
-      boltdb_shipper:
-        shared_store: filesystem
-        active_index_directory: /var/loki/index
-        cache_location: /var/loki/cache
-        cache_ttl: 168h
-      filesystem:
-        directory: /var/loki/chunks
+      {{- toYaml .Values.loki.storageConfig | nindent 2}}
+    {{- end}}
 
     chunk_store_config:
       max_look_back_period: 0s
@@ -149,6 +139,30 @@ loki:
       rule_path: /tmp/loki/scratch
       alertmanager_url: https://alertmanager.xx
       external_url: https://alertmanager.xx
+
+  schemaConfig:
+    configs:
+      - from: 2020-09-07
+        store: boltdb-shipper
+        object_store: filesystem
+        schema: v11
+        index:
+          prefix: loki_index_
+          period: 24h
+
+  storageConfig:
+    boltdb_shipper:
+      shared_store: filesystem
+      active_index_directory: /var/loki/index
+      cache_location: /var/loki/cache
+      cache_ttl: 168h
+    filesystem:
+      directory: /var/loki/chunks
+# -- uncomment to configure each storage
+#    azure: {}
+#    gcs: {}
+#    s3: {}
+#    boltdb: {}
 
 serviceAccount:
   # -- Specifies whether a ServiceAccount should be created


### PR DESCRIPTION
Hi!

I've added `schemaConfig ` and `storageConfig ` to allow us to configure different storages without needing to overwrite the whole config string that is used to create the config map.

The default behaviour is still using the same values:

```
loki:
  schemaConfig:
    configs:
      - from: 2020-09-07
        store: boltdb-shipper
        object_store: filesystem
        schema: v11
        index:
          prefix: loki_index_
          period: 24h

  storageConfig:
    boltdb_shipper:
      shared_store: filesystem
      active_index_directory: /var/loki/index
      cache_location: /var/loki/cache
      cache_ttl: 168h
    filesystem:
      directory: /var/loki/chunks
```

but we can now overwrite it with each specific storage, e.g., azure:

```
loki:
  schemaConfig:
    configs:
    - from: "2018-04-15"
      index:
        period: 168h
        prefix: index_
      object_store: filesystem
      schema: v9
      store: boltdb
    - from: "2020-09-28"
      store: boltdb-shipper
      object_store: azure
      schema: v11
      index:
        prefix: loki_index_
        period: 24h

  storageConfig:
    boltdb:
      directory: /var/loki/index
    filesystem:
      directory: /var/loki/chunks
    azure:
      container_name: <REDACTED>
      account_name: <REDACTED>
      account_key: <REDACTED>
      request_timeout: 0
    boltdb_shipper:
      active_index_directory: /var/loki/index
      shared_store: azure
      cache_location: /var/loki/cache
```

NOTE: I've tried to run `helm-docs` but I'm getting an error.

Thanks!