### PR TITLE
Disable loki-stack loki tests if loki disabled

### DIFF
--- a/charts/loki-stack/templates/tests/loki-test-configmap.yaml
+++ b/charts/loki-stack/templates/tests/loki-test-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.loki.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -50,3 +51,4 @@ data:
       jq -e '.streams[].entries[].line == "foobar"'
     }
 
+{{- end }}

--- a/charts/loki-stack/templates/tests/loki-test-pod.yaml
+++ b/charts/loki-stack/templates/tests/loki-test-pod.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.loki.enabled }]
 apiVersion: v1
 kind: Pod
 metadata:
@@ -28,3 +29,4 @@ spec:
   - name: tests
     configMap:
       name: {{ template "loki-stack.fullname" . }}-test
+{{- end }}


### PR DESCRIPTION
This fixes a bug that occurs when trying to install the loki-stack chart with loki disabled:

```
│ Error: template: loki-stack/templates/tests/loki-test-pod.yaml:22:24: executing "loki-stack/templates/tests/loki-test-pod.yaml" at <.Values.loki.service.port>: nil pointer evaluating interface {}.port
```

This error is from terraform helm_release, but the error makes sense and should be the same with regular ol' helm.