### PR TITLE
[grafana] Bump Grafana to v8.0.1

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.12.0
-appVersion: 8.0.0
+version: 6.12.1
+appVersion: 8.0.1
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -69,7 +69,7 @@ livenessProbe:
 
 image:
   repository: grafana/grafana
-  tag: 8.0.0
+  tag: 8.0.1
   sha: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Bump app and image to Grafana v8.0.1

https://github.com/grafana/grafana/releases/tag/v8.0.1