### PR TITLE
[loki-distributed] chore: do not deploy pvc if compactor not enabled. create pv for ruler

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.2.1
-version: 0.33.1
+version: 0.33.2
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/templates/compactor/persistentvolumeclaim-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/persistentvolumeclaim-compactor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.compactor.persistence.enabled }}
+{{- if and .Values.compactor.enabled .Values.compactor.persistence.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/loki-distributed/templates/compactor/service-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/service-compactor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.compactor.enabled }}
+{{- if and .Values.compactor.enabled .Values.compactor.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/loki-distributed/templates/ruler/deployment-ruler.yaml
+++ b/charts/loki-distributed/templates/ruler/deployment-ruler.yaml
@@ -113,7 +113,12 @@ spec:
         - name: tmp
           emptyDir: {}
         - name: data
+          {{- if .Values.ruler.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: data-{{ include "loki.rulerFullname" . }}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
         {{- with .Values.ruler.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/loki-distributed/templates/ruler/persistentvolumeclaim-ruler.yaml
+++ b/charts/loki-distributed/templates/ruler/persistentvolumeclaim-ruler.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.ruler.enabled .Values.ruler.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-{{ include "loki.rulerFullname" . }}
+  labels:
+    {{- include "loki.rulerLabels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- with .Values.ruler.persistence.storageClass }}
+  storageClassName: {{ if (eq "-" .) }}""{{ else }}{{ . }}{{ end }}
+  {{- end }}
+  resources:
+    requests:
+      storage: "{{ .Values.ruler.persistence.size }}"
+{{- end }}


### PR DESCRIPTION
The current chart allows you to enable persistence to true for compactor and deploy a pvc even though the compactor is disabled causing the helm deployment to fail. In addition we have defined persistence for the ruler but it is not being created anywhere. This PR attempts to fix both issues. 