### PR TITLE
[tempo-distributed] Gossip ring headless

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.9.10
+version: 0.9.11
 appVersion: 1.0.1
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.9.10](https://img.shields.io/badge/Version-0.9.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
+![Version: 0.9.11](https://img.shields.io/badge/Version-0.9.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/service-gossip-ring.yaml
+++ b/charts/tempo-distributed/templates/service-gossip-ring.yaml
@@ -7,6 +7,8 @@ metadata:
     app.kubernetes.io/component: {{ template "tempo.gossipRing.name" . }}
     {{- include "tempo.labels" . | nindent 4 }}
 spec:
+  type: ClusterIP
+  clusterIP: None
   ports:
     - name: gossip-ring
       port: 7946


### PR DESCRIPTION
Set gossip ring to be a headless service to provide a more consistent cluster connection.

Note that I incremented the patch version twice. Please merge this first:

https://github.com/grafana/helm-charts/pull/497