### PR TITLE
[enterprise-metrics] fix: Remove jsonnet-bundler symlink for tanka-util

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .vscode
 .project
 .settings
+/charts/enterprise-metrics/vendor/tanka-util

--- a/charts/enterprise-metrics/CHANGELOG.md
+++ b/charts/enterprise-metrics/CHANGELOG.md
@@ -12,6 +12,10 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## Unreleased
 
+## 1.3.4
+
+* [BUGFIX] Removed symlinks from chart to fix Rancher repository imports. #504
+
 ## 1.3.3
 
 * [FEATURE] The GEM config now uses the `{{ .Release.Name }}` variable as the default value for `cluster_name` which removes the need to additionally override this setting during an initial install. #500

--- a/charts/enterprise-metrics/Chart.yaml
+++ b/charts/enterprise-metrics/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.3.3
+version: 1.3.4
 appVersion: v1.3.0
 description: 'Grafana Enterprise Metrics'
 engine: gotpl

--- a/charts/enterprise-metrics/vendor/tanka-util
+++ b/charts/enterprise-metrics/vendor/tanka-util
@@ -1,1 +1,0 @@
-github.com/grafana/jsonnet-libs/tanka-util


### PR DESCRIPTION
Symlinks break Rancher helm repository import.

Fixes #502 

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>