### PR TITLE
[loki] Allow for specifying automountServiceAccountToken for Loki Helm Charts

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 2.5.0
+version: 2.5.1
 appVersion: v2.2.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki/templates/serviceaccount.yaml
+++ b/charts/loki/templates/serviceaccount.yaml
@@ -11,5 +11,6 @@ metadata:
     {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
   name: {{ template "loki.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}
 

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -198,6 +198,7 @@ serviceAccount:
   create: true
   name:
   annotations: {}
+  automountServiceAccountToken: true
 
 terminationGracePeriodSeconds: 4800
 


### PR DESCRIPTION
**What this PR does / why we need it:**
Allow for specifying the automountServiceAccountToken field on all Loki service accounts. Details about this toggle and what it's used for can be found [here](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server)

Also see corresponding PRs for loki-canary (#512) and loki-distributed (#513).
