### PR TITLE
[grafana] Add `enableServiceLinks` Chart Option

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.13.2
+version: 6.13.3
 appVersion: 8.0.3
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -116,6 +116,7 @@ This version requires Helm >= 3.1.0.
 | `envValueFrom`                            | Environment variables from alternate sources. See the API docs on [EnvVarSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvarsource-v1-core) for format details.  | `{}` |
 | `envFromSecret`                           | Name of a Kubernetes secret (must be manually created in the same namespace) containing values to be added to the environment. Can be templated | `""` |
 | `envRenderSecret`                         | Sensible environment variables passed to pods and stored as secret | `{}`                               |
+| `enableServiceLinks`                      | Inject Kubernetes services as environment variables. | `true`                                           |
 | `extraSecretMounts`                       | Additional grafana server secret mounts       | `[]`                                                    |
 | `extraVolumeMounts`                       | Additional grafana server volume mounts       | `[]`                                                    |
 | `extraConfigmapMounts`                    | Additional grafana server configMap volume mounts | `[]`                                                |

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -159,6 +159,7 @@ imagePullSecrets:
   - name: {{ . }}
 {{- end}}
 {{- end }}
+enableServiceLinks: {{ .Values.enableServiceLinks }}
 containers:
 {{- if .Values.sidecar.dashboards.enabled }}
   - name: {{ template "grafana.name" . }}-sc-dashboard

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -382,6 +382,10 @@ envFromSecret: ""
 ## This can be useful for auth tokens, etc
 envRenderSecret: {}
 
+# Inject Kubernetes services as environment variables.
+# See https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#environment-variables
+enableServiceLinks: true
+
 ## Additional grafana server secret mounts
 # Defines additional mounts with secrets. Secrets must be manually created in the namespace.
 extraSecretMounts: []


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/33682 added a feature to enable Jaeger tracing when environment variables such as `JAEGER_AGENT_HOST` and `JAEGER_AGENT_PORT` are both set.

If you have a Kubernetes service in the same namespace named `jaeger`, and `enableServiceLinks` which defaults to `true` is set, this causes `JAEGER_AGENT_PORT` to be set to something like `udp://172.18.64.21:5775`, resulting in errors

```
service init failed: cannot obtain reporter config from env: cannot parse env var JAEGER_AGENT_PORT=udp://172.18.64.21:5775: strconv.ParseInt: parsing "udp://172.18.64.21:5775": invalid s
```

This option allows the disabling of the injected service environment variables.

Tested it out on my own installation.