### PR TITLE
[fluent-bit] - Add custom filters, inputs, outputs and parsers using fluent bit DSL

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: fluent-bit
-version: 2.3.0
+version: 3.0.0
 appVersion: v2.1.0
 kubeVersion: "^1.10.0-0"
 description: "Uses fluent-bit Loki go plugin for gathering logs and sending them to Loki"

--- a/charts/fluent-bit/README.md
+++ b/charts/fluent-bit/README.md
@@ -100,8 +100,10 @@ For more details, read the [Fluent Bit documentation](../../../cmd/fluent-bit/RE
 | `config.labels`          | A set of labels to send for every log                                                              | `'{job="fluent-bit"}'`           |
 | `config.autoKubernetesLabels` | If set to true, it will add all Kubernetes labels to Loki labels                                   | `false`                          |
 | `config.labelMap`        | Mapping of labels from a record. See [Fluent Bit documentation](../../../cmd/fluent-bit/README.md) |                                  |
-| `config.parsers`         | Definition of extras fluent bit parsers. See [Official Fluent Bit documentation](https://docs.fluentbit.io/manual/filter/parser). The format is a sequence of mappings where each key is the same as the one in the [PARSER] section of parsers.conf file       | `[]`                            |
-| `config.extraOutputs`    | Definition of extras fluent bit outputs. See [Official Fluent Bit documentation](https://docs.fluentbit.io/manual/pipeline/outputs/). The format is a sequence of mappings where each key is the same as the one in the [OUTPUT]                                | `[]`                            |
+| `config.inputs`          | Definition of extra fluent bit inputs. See [Official Fluent Bit documentation](https://docs.fluentbit.io/manual/pipeline/inputs).   | |
+| `config.parsers`         | Definition of extra fluent bit parsers. See [Official Fluent Bit documentation](https://docs.fluentbit.io/manual/pipeline/parsers). | |
+| `config.filters`         | Definition of extra fluent bit filters. See [Official Fluent Bit documentation](https://docs.fluentbit.io/manual/pipeline/filters). | |
+| `config.outputs`         | Definition of extra fluent bit outputs. See [Official Fluent Bit documentation](https://docs.fluentbit.io/manual/pipeline/outputs). | |
 | `affinity`               | [affinity][affinity] settings for pod assignment                                                   | `{}`                             |
 | `annotations`            | Annotations to add to Kubernetes resources.                                                        | `{}`                             |
 | `deploymentStrategy`     | The deployment strategy to use with the daemonset                                                  | `RollingUpdate`                  |

--- a/charts/fluent-bit/templates/configmap.yaml
+++ b/charts/fluent-bit/templates/configmap.yaml
@@ -25,6 +25,7 @@ data:
         Parser         docker
         DB             /run/fluent-bit/flb_kube.db
         Mem_Buf_Limit  {{ .Values.config.memBufLimit }}
+    {{- (tpl .Values.config.inputs $) | nindent 4 }}
     [FILTER]
         Name           kubernetes
         Match          kube.*
@@ -32,6 +33,7 @@ data:
         Merge_Log On
         K8S-Logging.Exclude {{ .Values.config.k8sLoggingExclude }}
         K8S-Logging.Parser {{ .Values.config.k8sLoggingParser }}
+    {{- (tpl .Values.config.filters $) | nindent 4 }}
     [Output]
         Name grafana-loki
         Match *
@@ -49,24 +51,14 @@ data:
         LabelMapPath /fluent-bit/etc/labelmap.json
         LineFormat {{ .Values.config.lineFormat }}
         LogLevel {{ .Values.config.loglevel }}
-    {{- range $extraOutput := .Values.config.extraOutputs }}
-    [OUTPUT]
-    {{- range $key,$value := $extraOutput }}
-        {{ $key }} {{ $value }}
-    {{- end }}
-    {{- end }}
+    {{- (tpl .Values.config.outputs $) | nindent 4 }}
   parsers.conf: |-
     [PARSER]
         Name        docker
         Format      json
         Time_Key    time
         Time_Format %Y-%m-%dT%H:%M:%S.%L
-    {{- range $parser:= .Values.config.parsers }}
-    [PARSER]
-    {{- range $key,$value := $parser }}
-        {{ $key }} {{ $value }}
-    {{- end }}
-    {{- end }}
+    {{- (tpl .Values.config.parsers $) | nindent 4 }}
 
   labelmap.json: |-
     {{- .Values.config.labelMap | toPrettyJson | nindent 4}}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -31,16 +31,57 @@ config:
       container_name: container
       pod_name: instance
     stream: stream
-  # parsers: # Allow to define custom parsers. The key here is the same as the one in the [PARSER] section of parsers.conf file.
-  #  - Name: json
-  #    Format: json
-  #    Time_Key: time
-  #    Time_Format: "%d/%b/%Y:%H:%M:%S %z"
-
-  # extraOutputs: # Allow to define extra outputs in addition to the one automatically created
-  #   - Name: stdout
-  #     Format: json
-  #     json_date_format: time
+#  Custom inputs
+#  ## https://docs.fluentbit.io/manual/pipeline/inputs
+  inputs: |
+#      [INPUT]
+#          Name tail
+#          Path /var/log/containers/*.log
+#          Parser docker
+#          Tag custom.*
+#          Mem_Buf_Limit 5MB
+#          Skip_Long_Lines On
+#      [INPUT]
+#          Name systemd
+#          Tag host.*
+#          Systemd_Filter _SYSTEMD_UNIT=kubelet.service
+#          Read_From_Tail On
+#  Custom filters
+#  ## https://docs.fluentbit.io/manual/pipeline/filters
+  filters: |
+#      [FILTER]
+#          Name geoip2
+#          Match netty.accessLog
+#          Database /opt/geoip/GeoLite2-City.mmdb
+#          Lookup_key ip.remoteAddress
+#          Record ip.country     ip.remoteAddress %{country.names.en}
+#          Record ip.countryIso  ip.remoteAddress %{country.iso_code}
+#          Record ip.city        ip.remoteAddress %{city.names.en}
+#          Record ip.latitude    ip.remoteAddress %{location.latitude}
+#          Record ip.longitude   ip.remoteAddress %{location.longitude}
+#  Custom outputs
+#  ## https://docs.fluentbit.io/manual/pipeline/outputs
+  outputs: |
+#      [OUTPUT]
+#          Name es
+#          Match kube.*
+#          Host elasticsearch-master
+#          Logstash_Format On
+#          Retry_Limit False
+#      [OUTPUT]
+#          Name es
+#          Match host.*
+#          Host elasticsearch-master
+#          Logstash_Format On
+#          Logstash_Prefix node
+#          Retry_Limit False
+#  Custom parsers
+#  ## https://docs.fluentbit.io/manual/pipeline/parsers
+  parsers: |
+#      [PARSER]
+#          Name json_no_time
+#          Format json
+#          Time_Keep Off
 
 affinity: {}
 


### PR DESCRIPTION
## Overview 

#### Features
- Customise pipelines using fluent bit DSL
- Define custom filters and inputs

#### Breaking changes
- Breaks existing `parsers` configuration format
- Rename `extraOutputs` -> `outputs` for consistency 

## Reasoning
- Cannot currently add custom `[FILTER]`s or `[INPUT]`s easily
- Existing config format has a limitation - you cannot define the following parser with multiple decoders as it contains a duplicate `Decode_Field_As` key, although it is valid:

```yaml
config: 
  parsers: 
    - Name:  json_with_decoder
       Format: json
       Time_Key: time
       Time_Format: %Y-%m-%dT%H:%M:%S.%LZ
       Time_Keep: On
       Decode_Field_As: escaped    log    do_next
       Decode_Field_As: json       log    # <--- INVALID - duplicate Decode_Field_As key
```

```yaml
config: 
  parsers: |
    [PARSER]
        Name             json_with_decoder
        Format           json
        Time_Key         time
        Time_Format      %Y-%m-%dT%H:%M:%S.%LZ
        Time_Keep        On
        Decode_Field_As  escaped    log    do_next
        Decode_Field_As  json       log 
```

- It makes sense to use the helm `tpl` function for all custom pipeline components to avoid this limitation in the future.
- Default values allow for better IDE support

Inspiration taken from the Fluent Bit [helm chart](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/templates/configmap.yaml)


Many thanks!