### PR TITLE
[grafana] chore: grafana: remove namespace from podsecuritypolicy

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.13.6
+version: 6.13.7
 appVersion: 8.0.3
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/podsecuritypolicy.yaml
+++ b/charts/grafana/templates/podsecuritypolicy.yaml
@@ -3,7 +3,6 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "grafana.fullname" . }}
-  namespace: {{ template "grafana.namespace" . }}
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
   annotations:

--- a/charts/grafana/templates/tests/test-podsecuritypolicy.yaml
+++ b/charts/grafana/templates/tests/test-podsecuritypolicy.yaml
@@ -3,7 +3,6 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "grafana.fullname" . }}-test
-  namespace: {{ template "grafana.namespace" . }}
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
> A Pod Security Policy is a cluster-level resource that controls security sensitive aspects of the pod specification.


https://kubernetes.io/docs/concepts/policy/pod-security-policy/#what-is-a-pod-security-policy