### PR TITLE
[grafana] Fix `imageRenderer.securityContext` indentation issue

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.13.7
+version: 6.13.8
 appVersion: 8.0.3
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/image-renderer-deployment.yaml
+++ b/charts/grafana/templates/image-renderer-deployment.yaml
@@ -45,11 +45,11 @@ spec:
       {{- end }}
       {{- if .Values.imageRenderer.securityContext }}
       securityContext:
-      {{ toYaml .Values.imageRenderer.securityContext | indent 2 }}
+        {{- toYaml .Values.imageRenderer.securityContext | nindent 8 }}
       {{- end }}
       {{- if .Values.imageRenderer.hostAliases }}
       hostAliases:
-      {{ toYaml .Values.imageRenderer.hostAliases | indent 2 }}
+        {{- toYaml .Values.imageRenderer.hostAliases | nindent 8 }}
       {{- end }}
       {{- if .Values.imageRenderer.priorityClassName }}
       priorityClassName: {{ .Values.imageRenderer.priorityClassName }}


### PR DESCRIPTION
https://github.com/grafana/helm-charts/pull/34 added the ability to configure a remote image rendering service. Unfortunately, when trying to set `imageRenderer.securityContext` or `imageRenderer.hostAliases`, the indentation breaks when the configuration contains more than one element. 

For example (`values.yaml`):
```yaml
imageRenderer:
  securityContext:
    runAsGroup: 200
    runAsUser: 100
```
results in:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: my-grafana-release-image-renderer
...
      securityContext:
        runAsGroup: 200
  runAsUser: 100
...
```

This pull requests fixes the issue by setting the correct indentation.