### PR TITLE
[grafana] Bump Grafana to v8.0.5

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.13.8
-appVersion: 8.0.3
+version: 6.13.9
+appVersion: 8.0.5
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -69,7 +69,7 @@ livenessProbe:
 
 image:
   repository: grafana/grafana
-  tag: 8.0.3
+  tag: 8.0.5
   sha: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Bump app and image to Grafana v8.0.5
https://github.com/grafana/grafana/releases/tag/v8.0.5