### PR TITLE
[tempo-distributed] Add option to disable tempo-query sidecar

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.9.12
+version: 0.9.13
 appVersion: 1.0.1
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -170,7 +170,7 @@ The memcached default args are removed and should be provided manually. The sett
 | queryFrontend.podAnnotations | object | `{}` | Annotations for query-frontend pods |
 | queryFrontend.priorityClassName | string | `nil` | The name of the PriorityClass for query-frontend pods |
 | queryFrontend.query.config | string | `"backend: 127.0.0.1:3100\n"` |  |
-| queryFrontend.query.enabled | bool | `true` |  |
+| queryFrontend.query.enabled | bool | `true` | Required for grafana version <7.5 for compatibility with jaeger-ui. Doesn't work on ARM arch |
 | queryFrontend.query.extraArgs | list | `[]` | Additional CLI args for tempo-query pods |
 | queryFrontend.query.extraEnv | list | `[]` | Environment variables to add to the tempo-query pods |
 | queryFrontend.query.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the tempo-query pods |

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.9.12](https://img.shields.io/badge/Version-0.9.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
+![Version: 0.9.13](https://img.shields.io/badge/Version-0.9.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -170,6 +170,7 @@ The memcached default args are removed and should be provided manually. The sett
 | queryFrontend.podAnnotations | object | `{}` | Annotations for query-frontend pods |
 | queryFrontend.priorityClassName | string | `nil` | The name of the PriorityClass for query-frontend pods |
 | queryFrontend.query.config | string | `"backend: 127.0.0.1:3100\n"` |  |
+| queryFrontend.query.enabled | bool | `true` |  |
 | queryFrontend.query.extraArgs | list | `[]` | Additional CLI args for tempo-query pods |
 | queryFrontend.query.extraEnv | list | `[]` | Environment variables to add to the tempo-query pods |
 | queryFrontend.query.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the tempo-query pods |

--- a/charts/tempo-distributed/templates/query-frontend/deployment-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/deployment-query-frontend.yaml
@@ -64,6 +64,7 @@ spec:
             {{- with .Values.queryFrontend.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+        {{- if .Values.queryFrontend.query.enabled }}
         - args:
             - --query.base-path=/
             - --grpc-storage-plugin.configuration-file=/conf/tempo-query.yaml
@@ -95,6 +96,7 @@ spec:
             {{- with .Values.queryFrontend.query.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+      {{- end}}
       {{- with .Values.queryFrontend.affinity }}
       affinity:
         {{- tpl . $ | nindent 8 }}

--- a/charts/tempo-distributed/templates/query-frontend/service-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/service-query-frontend.yaml
@@ -19,11 +19,5 @@ spec:
       port: 9095
       protocol: TCP
       targetPort: 9095
-    - name: tempo-query-jaeger-ui
-      port: 16686
-      targetPort: 16686
-    - name: tempo-query-metrics
-      port: 16687
-      targetPort: jaeger-metrics
   selector:
     {{- include "tempo.queryFrontendSelectorLabels" . | nindent 4 }}

--- a/charts/tempo-distributed/templates/query-frontend/service-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/service-query-frontend.yaml
@@ -19,5 +19,13 @@ spec:
       port: 9095
       protocol: TCP
       targetPort: 9095
+    {{- if .Values.queryFrontend.query.enabled }}
+    - name: tempo-query-jaeger-ui
+      port: 16686
+      targetPort: 16686
+    - name: tempo-query-metrics
+      port: 16687
+      targetPort: jaeger-metrics
+    {{- end }}
   selector:
     {{- include "tempo.queryFrontendSelectorLabels" . | nindent 4 }}

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -241,7 +241,7 @@ querier:
 # Configuration for the query-frontend
 queryFrontend:
   query:
-    enabled: false # required for grafana version <7.5 for compatibility with jaeger-ui. Doesn't work on ARM arch
+    enabled: true # required for grafana version <7.5 for compatibility with jaeger-ui. Doesn't work on ARM arch
     image:
       # -- The Docker registry for the query-frontend image. Overrides `tempo.image.registry`
       registry: null

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -241,7 +241,8 @@ querier:
 # Configuration for the query-frontend
 queryFrontend:
   query:
-    enabled: true # required for grafana version <7.5 for compatibility with jaeger-ui. Doesn't work on ARM arch
+    # -- Required for grafana version <7.5 for compatibility with jaeger-ui. Doesn't work on ARM arch
+    enabled: true
     image:
       # -- The Docker registry for the query-frontend image. Overrides `tempo.image.registry`
       registry: null

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -241,6 +241,7 @@ querier:
 # Configuration for the query-frontend
 queryFrontend:
   query:
+    enabled: false # required for grafana version <7.5 for compatibility with jaeger-ui. Doesn't work on ARM arch
     image:
       # -- The Docker registry for the query-frontend image. Overrides `tempo.image.registry`
       registry: null


### PR DESCRIPTION
This also add to fully arm64 compatibility, tempo-query is not needed  for grafana > 7.5