### PR TITLE
[grafana] Optionally automount SA token

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.13.10
+version: 6.14.0
 appVersion: 8.0.5
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -175,6 +175,7 @@ This version requires Helm >= 3.1.0.
 | `admin.existingSecret`                    | The name of an existing secret containing the admin credentials. | `""`                                 |
 | `admin.userKey`                           | The key in the existing admin secret containing the username. | `"admin-user"`                          |
 | `admin.passwordKey`                       | The key in the existing admin secret containing the password. | `"admin-password"`                      |
+| `serviceAccount.autoMount`                | Automount the service account token in the pod| `false`                                                 |
 | `serviceAccount.annotations`              | ServiceAccount annotations                    |                                                         |
 | `serviceAccount.create`                   | Create service account                        | `true`                                                  |
 | `serviceAccount.name`                     | Service account name to use, when empty will be set to created account if `serviceAccount.create` is set else to `default` | `` |

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -4,6 +4,7 @@
 schedulerName: "{{ .Values.schedulerName }}"
 {{- end }}
 serviceAccountName: {{ template "grafana.serviceAccountName" . }}
+automountServiceAccountToken: {{ .Values.serviceAccount.autoMount }}
 {{- if .Values.securityContext }}
 securityContext:
 {{ toYaml .Values.securityContext | indent 2 }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -19,6 +19,7 @@ serviceAccount:
   nameTest:
 #  annotations:
 #    eks.amazonaws.com/role-arn: arn:aws:iam::123456789000:role/iam-role-name-here
+  autoMount: false
 
 replicas: 1
 


### PR DESCRIPTION
**Description of the change**
It disables the automounting of the service account token in the pod. Grafana does not need this by itself. This commit disables it by default, but leaves it configurable if anyone needs to use it.

**Benefits**
By disabling the automount, potential attackers cannot access the Kubernetes API on behalf/through the pod.

**Possible drawbacks**
In the unlikely event that anyone is using some sidecar or plugin to access the Kubernetes API, they will have to explicitly enable the mounting of the SA token in the values.

**Applicable issues**
If raising an issue is required or helpful, please tell me and I'd be glad to do so.