### PR TITLE
[grafana] Fix default for automounting of SA token

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.14.0
+version: 6.14.1
 appVersion: 8.0.5
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -175,7 +175,7 @@ This version requires Helm >= 3.1.0.
 | `admin.existingSecret`                    | The name of an existing secret containing the admin credentials. | `""`                                 |
 | `admin.userKey`                           | The key in the existing admin secret containing the username. | `"admin-user"`                          |
 | `admin.passwordKey`                       | The key in the existing admin secret containing the password. | `"admin-password"`                      |
-| `serviceAccount.autoMount`                | Automount the service account token in the pod| `false`                                                 |
+| `serviceAccount.autoMount`                | Automount the service account token in the pod| `true`                                                  |
 | `serviceAccount.annotations`              | ServiceAccount annotations                    |                                                         |
 | `serviceAccount.create`                   | Create service account                        | `true`                                                  |
 | `serviceAccount.name`                     | Service account name to use, when empty will be set to created account if `serviceAccount.create` is set else to `default` | `` |

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -19,7 +19,7 @@ serviceAccount:
   nameTest:
 #  annotations:
 #    eks.amazonaws.com/role-arn: arn:aws:iam::123456789000:role/iam-role-name-here
-  autoMount: false
+  autoMount: true
 
 replicas: 1
 


### PR DESCRIPTION
In #571 / b6015e2 an option was introduced to optionally automount the serviceaccount token. Due to an oversight at my part, I missed the fact that [a lot of people (including myself) use side cars for dashboards/datasource discovery from K8S configmaps](https://github.com/grafana/helm-charts/pull/571#issuecomment-882704321). So the default should be to **enable** the automount of the SA token, to keep these sidecars working.