### PR TITLE
[promtail] Introduce .Release.Namespace in objects meta

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.2.1
-version: 3.6.0
+version: 3.6.1
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 3.6.0](https://img.shields.io/badge/Version-3.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
+![Version: 3.6.1](https://img.shields.io/badge/Version-3.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/templates/daemonset.yaml
+++ b/charts/promtail/templates/daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "promtail.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
   {{- with .Values.annotations }}

--- a/charts/promtail/templates/networkpolicy.yaml
+++ b/charts/promtail/templates/networkpolicy.yaml
@@ -4,6 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ template "promtail.name" . }}-namespace-only
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
 spec:
@@ -24,6 +25,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ template "promtail.name" . }}-egress-dns
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
 spec:
@@ -44,6 +46,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ template "promtail.name" . }}-egress-k8s-api
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
 spec:
@@ -69,6 +72,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ template "promtail.name" . }}-ingress-metrics
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
 spec:
@@ -103,6 +107,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ template "promtail.name" . }}-egress-extra-ports
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
 spec:

--- a/charts/promtail/templates/role.yaml
+++ b/charts/promtail/templates/role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "promtail.fullname" . }}-psp
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
 rules:

--- a/charts/promtail/templates/rolebinding.yaml
+++ b/charts/promtail/templates/rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "promtail.fullname" . }}-psp
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
 roleRef:

--- a/charts/promtail/templates/secret.yaml
+++ b/charts/promtail/templates/secret.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "promtail.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
 stringData:

--- a/charts/promtail/templates/service-extra.yaml
+++ b/charts/promtail/templates/service-extra.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "promtail.fullname" $ }}-{{ $key | lower }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "promtail.labels" $ | nindent 4 }}
     {{- with .labels }}

--- a/charts/promtail/templates/service-extra.yaml
+++ b/charts/promtail/templates/service-extra.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "promtail.fullname" $ }}-{{ $key | lower }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "promtail.labels" $ | nindent 4 }}
     {{- with .labels }}

--- a/charts/promtail/templates/service-metrics.yaml
+++ b/charts/promtail/templates/service-metrics.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "promtail.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
 spec:

--- a/charts/promtail/templates/serviceaccount.yaml
+++ b/charts/promtail/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "promtail.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/promtail/templates/servicemonitor.yaml
+++ b/charts/promtail/templates/servicemonitor.yaml
@@ -3,8 +3,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "promtail.fullname" $ }}
-  {{- with .Values.serviceMonitor.namespace }}
-  namespace: {{ . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
   {{- end }}
   {{- with .Values.serviceMonitor.annotations }}
   annotations:


### PR DESCRIPTION
Description of the change

This PR adds .Release.Namespace to objects meta for promtail chart. Related to discussion in this [issue](https://github.com/bitnami/charts/issues/2006).

Benefits

Ability to use the helm chart when having declarative definition of all cluster objects rendered using helm template.

Possible drawbacks

I don't see any, it will work as previously for helm install

Signed-off-by: Mariusz Waligóra <mariusz@piwik.pro>