### PR TITLE
[enterprise-metrics] Remove livenessProbe configuration

### DIFF
--- a/charts/enterprise-metrics/CHANGELOG.md
+++ b/charts/enterprise-metrics/CHANGELOG.md
@@ -12,6 +12,10 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## Unreleased
 
+## 1.4.4
+
+* [CHANGE] Removed livenessProbe configuration as it can often be more detrimental than having none. Users can still configure livenessProbes with the per App configuration hooks. #594
+
 ## 1.4.3
 
 * [ENHANCEMENT] Added values files for installations that require setting resource limits. #583

--- a/charts/enterprise-metrics/Chart.yaml
+++ b/charts/enterprise-metrics/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.4.3
+version: 1.4.4
 appVersion: v1.4.2
 description: 'Grafana Enterprise Metrics'
 engine: gotpl

--- a/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-admin-api.yaml
+++ b/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-admin-api.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-admin-api
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-admin-api
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-admin-api
         gossip_ring_member: "true"
@@ -46,11 +46,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ready
-            port: http-metrics
-          initialDelaySeconds: 45
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-distributor.yaml
+++ b/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-distributor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-distributor
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-distributor
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-distributor
         gossip_ring_member: "true"
@@ -55,11 +55,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ready
-            port: http-metrics
-          initialDelaySeconds: 45
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-gateway.yaml
+++ b/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-gateway
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-gateway
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-gateway
         name: gateway
@@ -53,11 +53,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ready
-            port: http-metrics
-          initialDelaySeconds: 45
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-querier.yaml
+++ b/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-querier.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-querier
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-querier
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-querier
         gossip_ring_member: "true"
@@ -64,11 +64,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ready
-            port: http-metrics
-          initialDelaySeconds: 45
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-query-frontend.yaml
+++ b/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-query-frontend.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-query-frontend
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-query-frontend
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-query-frontend
         name: query-frontend
@@ -55,11 +55,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ready
-            port: http-metrics
-          initialDelaySeconds: 45
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-ruler.yaml
+++ b/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-ruler.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-ruler
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-ruler
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-ruler
         gossip_ring_member: "true"
@@ -59,11 +59,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ready
-            port: http-metrics
-          initialDelaySeconds: 45
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/default/apps-v1.StatefulSet-enterprise-metrics-alertmanager.yaml
+++ b/charts/enterprise-metrics/exports/default/apps-v1.StatefulSet-enterprise-metrics-alertmanager.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-alertmanager
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-alertmanager
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-alertmanager
         gossip_ring_member: "true"
@@ -48,11 +48,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ready
-            port: http-metrics
-          initialDelaySeconds: 45
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/default/apps-v1.StatefulSet-enterprise-metrics-compactor.yaml
+++ b/charts/enterprise-metrics/exports/default/apps-v1.StatefulSet-enterprise-metrics-compactor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-compactor
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-compactor
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-compactor
         gossip_ring_member: "true"
@@ -58,16 +58,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          failureThreshold: 20
-          httpGet:
-            path: /ready
-            port: http-metrics
-            scheme: HTTP
-          initialDelaySeconds: 180
-          periodSeconds: 30
-          successThreshold: 1
-          timeoutSeconds: 1
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/default/apps-v1.StatefulSet-enterprise-metrics-ingester.yaml
+++ b/charts/enterprise-metrics/exports/default/apps-v1.StatefulSet-enterprise-metrics-ingester.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-ingester
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-ingester
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-ingester
         gossip_ring_member: "true"
@@ -56,16 +56,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          failureThreshold: 20
-          httpGet:
-            path: /ready
-            port: http-metrics
-            scheme: HTTP
-          initialDelaySeconds: 180
-          periodSeconds: 30
-          successThreshold: 1
-          timeoutSeconds: 1
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/default/apps-v1.StatefulSet-enterprise-metrics-store-gateway.yaml
+++ b/charts/enterprise-metrics/exports/default/apps-v1.StatefulSet-enterprise-metrics-store-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-store-gateway
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-store-gateway
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-store-gateway
         gossip_ring_member: "true"
@@ -56,16 +56,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          failureThreshold: 20
-          httpGet:
-            path: /ready
-            port: http-metrics
-            scheme: HTTP
-          initialDelaySeconds: 180
-          periodSeconds: 30
-          successThreshold: 1
-          timeoutSeconds: 1
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/default/batch-v1.Job-enterprise-metrics-tokengen.yaml
+++ b/charts/enterprise-metrics/exports/default/batch-v1.Job-enterprise-metrics-tokengen.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: enterprise-metrics-tokengen
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-tokengen

--- a/charts/enterprise-metrics/exports/default/policy-v1beta1.PodSecurityPolicy-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/default/policy-v1beta1.PodSecurityPolicy-enterprise-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/default/rbac.authorization.k8s.io-v1.Role-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/default/rbac.authorization.k8s.io-v1.Role-enterprise-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/default/rbac.authorization.k8s.io-v1.RoleBinding-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/default/rbac.authorization.k8s.io-v1.RoleBinding-enterprise-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/default/v1.ConfigMap-enterprise-metrics-runtime.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.ConfigMap-enterprise-metrics-runtime.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-runtime

--- a/charts/enterprise-metrics/exports/default/v1.Secret-enterprise-metrics-license.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Secret-enterprise-metrics-license.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: enterprise-metrics-license
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-license

--- a/charts/enterprise-metrics/exports/default/v1.Secret-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Secret-enterprise-metrics.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-admin-api.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-admin-api.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-admin-api
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-admin-api

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-alertmanager-headless.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-alertmanager-headless.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-alertmanager
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-alertmanager-headless

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-alertmanager.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-alertmanager.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-alertmanager
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-alertmanager

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-distributor.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-distributor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-distributor
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-distributor

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-gateway.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-gateway
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-gateway

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-gossip-ring.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-gossip-ring.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-gossip-ring
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-gossip-ring

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-ingester.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-ingester.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-ingester
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-ingester

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-querier.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-querier.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-querier
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-querier

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-query-frontend-headless.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-query-frontend-headless.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-query-frontend
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-query-frontend-headless

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-query-frontend.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-query-frontend.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-query-frontend
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-query-frontend

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-ruler.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-ruler.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-ruler
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-ruler

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-store-gateway.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-store-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-store-gateway
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-store-gateway

--- a/charts/enterprise-metrics/exports/default/v1.ServiceAccount-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.ServiceAccount-enterprise-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-admin-api.yaml
+++ b/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-admin-api.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-admin-api
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-admin-api
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-admin-api
         gossip_ring_member: "true"
@@ -40,11 +40,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ready
-            port: http-metrics
-          initialDelaySeconds: 45
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-distributor.yaml
+++ b/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-distributor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-distributor
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-distributor
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-distributor
         gossip_ring_member: "true"
@@ -49,11 +49,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ready
-            port: http-metrics
-          initialDelaySeconds: 45
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-gateway.yaml
+++ b/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-gateway
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-gateway
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-gateway
         name: gateway
@@ -47,11 +47,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ready
-            port: http-metrics
-          initialDelaySeconds: 45
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-querier.yaml
+++ b/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-querier.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-querier
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-querier
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-querier
         gossip_ring_member: "true"
@@ -56,11 +56,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ready
-            port: http-metrics
-          initialDelaySeconds: 45
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-query-frontend.yaml
+++ b/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-query-frontend.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-query-frontend
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-query-frontend
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-query-frontend
         name: query-frontend
@@ -49,11 +49,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ready
-            port: http-metrics
-          initialDelaySeconds: 45
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-ruler.yaml
+++ b/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-ruler.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-ruler
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-ruler
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-ruler
         gossip_ring_member: "true"
@@ -44,11 +44,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ready
-            port: http-metrics
-          initialDelaySeconds: 45
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/large/apps-v1.StatefulSet-enterprise-metrics-alertmanager.yaml
+++ b/charts/enterprise-metrics/exports/large/apps-v1.StatefulSet-enterprise-metrics-alertmanager.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-alertmanager
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-alertmanager
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-alertmanager
         gossip_ring_member: "true"
@@ -39,11 +39,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ready
-            port: http-metrics
-          initialDelaySeconds: 45
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/large/apps-v1.StatefulSet-enterprise-metrics-compactor.yaml
+++ b/charts/enterprise-metrics/exports/large/apps-v1.StatefulSet-enterprise-metrics-compactor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-compactor
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-compactor
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-compactor
         gossip_ring_member: "true"
@@ -47,16 +47,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          failureThreshold: 20
-          httpGet:
-            path: /ready
-            port: http-metrics
-            scheme: HTTP
-          initialDelaySeconds: 180
-          periodSeconds: 30
-          successThreshold: 1
-          timeoutSeconds: 1
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/large/apps-v1.StatefulSet-enterprise-metrics-ingester.yaml
+++ b/charts/enterprise-metrics/exports/large/apps-v1.StatefulSet-enterprise-metrics-ingester.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-ingester
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-ingester
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-ingester
         gossip_ring_member: "true"
@@ -45,16 +45,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          failureThreshold: 20
-          httpGet:
-            path: /ready
-            port: http-metrics
-            scheme: HTTP
-          initialDelaySeconds: 180
-          periodSeconds: 30
-          successThreshold: 1
-          timeoutSeconds: 1
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/large/apps-v1.StatefulSet-enterprise-metrics-store-gateway.yaml
+++ b/charts/enterprise-metrics/exports/large/apps-v1.StatefulSet-enterprise-metrics-store-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-store-gateway
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-store-gateway
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-store-gateway
         gossip_ring_member: "true"
@@ -54,16 +54,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          failureThreshold: 20
-          httpGet:
-            path: /ready
-            port: http-metrics
-            scheme: HTTP
-          initialDelaySeconds: 180
-          periodSeconds: 30
-          successThreshold: 1
-          timeoutSeconds: 1
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/large/batch-v1.Job-enterprise-metrics-tokengen.yaml
+++ b/charts/enterprise-metrics/exports/large/batch-v1.Job-enterprise-metrics-tokengen.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: enterprise-metrics-tokengen
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-tokengen

--- a/charts/enterprise-metrics/exports/large/policy-v1beta1.PodSecurityPolicy-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/large/policy-v1beta1.PodSecurityPolicy-enterprise-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/large/rbac.authorization.k8s.io-v1.Role-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/large/rbac.authorization.k8s.io-v1.Role-enterprise-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/large/rbac.authorization.k8s.io-v1.RoleBinding-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/large/rbac.authorization.k8s.io-v1.RoleBinding-enterprise-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/large/v1.ConfigMap-enterprise-metrics-runtime.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.ConfigMap-enterprise-metrics-runtime.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-runtime

--- a/charts/enterprise-metrics/exports/large/v1.Secret-enterprise-metrics-license.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Secret-enterprise-metrics-license.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: enterprise-metrics-license
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-license

--- a/charts/enterprise-metrics/exports/large/v1.Secret-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Secret-enterprise-metrics.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-admin-api.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-admin-api.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-admin-api
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-admin-api

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-alertmanager-headless.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-alertmanager-headless.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-alertmanager
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-alertmanager-headless

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-alertmanager.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-alertmanager.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-alertmanager
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-alertmanager

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-distributor.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-distributor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-distributor
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-distributor

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-gateway.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-gateway
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-gateway

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-gossip-ring.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-gossip-ring.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-gossip-ring
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-gossip-ring

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-ingester.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-ingester.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-ingester
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-ingester

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-querier.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-querier.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-querier
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-querier

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-query-frontend-headless.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-query-frontend-headless.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-query-frontend
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-query-frontend-headless

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-query-frontend.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-query-frontend.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-query-frontend
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-query-frontend

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-ruler.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-ruler.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-ruler
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-ruler

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-store-gateway.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-store-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-store-gateway
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-store-gateway

--- a/charts/enterprise-metrics/exports/large/v1.ServiceAccount-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.ServiceAccount-enterprise-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-admin-api.yaml
+++ b/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-admin-api.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-admin-api
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-admin-api
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-admin-api
         gossip_ring_member: "true"
@@ -40,11 +40,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ready
-            port: http-metrics
-          initialDelaySeconds: 45
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-distributor.yaml
+++ b/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-distributor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-distributor
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-distributor
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-distributor
         gossip_ring_member: "true"
@@ -49,11 +49,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ready
-            port: http-metrics
-          initialDelaySeconds: 45
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-gateway.yaml
+++ b/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-gateway
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-gateway
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-gateway
         name: gateway
@@ -47,11 +47,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ready
-            port: http-metrics
-          initialDelaySeconds: 45
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-querier.yaml
+++ b/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-querier.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-querier
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-querier
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-querier
         gossip_ring_member: "true"
@@ -56,11 +56,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ready
-            port: http-metrics
-          initialDelaySeconds: 45
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-query-frontend.yaml
+++ b/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-query-frontend.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-query-frontend
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-query-frontend
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-query-frontend
         name: query-frontend
@@ -49,11 +49,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ready
-            port: http-metrics
-          initialDelaySeconds: 45
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-ruler.yaml
+++ b/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-ruler.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-ruler
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-ruler
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-ruler
         gossip_ring_member: "true"
@@ -44,11 +44,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ready
-            port: http-metrics
-          initialDelaySeconds: 45
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/small/apps-v1.StatefulSet-enterprise-metrics-alertmanager.yaml
+++ b/charts/enterprise-metrics/exports/small/apps-v1.StatefulSet-enterprise-metrics-alertmanager.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-alertmanager
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-alertmanager
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-alertmanager
         gossip_ring_member: "true"
@@ -39,11 +39,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ready
-            port: http-metrics
-          initialDelaySeconds: 45
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/small/apps-v1.StatefulSet-enterprise-metrics-compactor.yaml
+++ b/charts/enterprise-metrics/exports/small/apps-v1.StatefulSet-enterprise-metrics-compactor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-compactor
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-compactor
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-compactor
         gossip_ring_member: "true"
@@ -47,16 +47,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          failureThreshold: 20
-          httpGet:
-            path: /ready
-            port: http-metrics
-            scheme: HTTP
-          initialDelaySeconds: 180
-          periodSeconds: 30
-          successThreshold: 1
-          timeoutSeconds: 1
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/small/apps-v1.StatefulSet-enterprise-metrics-ingester.yaml
+++ b/charts/enterprise-metrics/exports/small/apps-v1.StatefulSet-enterprise-metrics-ingester.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-ingester
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-ingester
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-ingester
         gossip_ring_member: "true"
@@ -45,16 +45,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          failureThreshold: 20
-          httpGet:
-            path: /ready
-            port: http-metrics
-            scheme: HTTP
-          initialDelaySeconds: 180
-          periodSeconds: 30
-          successThreshold: 1
-          timeoutSeconds: 1
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/small/apps-v1.StatefulSet-enterprise-metrics-store-gateway.yaml
+++ b/charts/enterprise-metrics/exports/small/apps-v1.StatefulSet-enterprise-metrics-store-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-store-gateway
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-store-gateway
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 434c92b03ccf1c245b5dedb36537e504ad5e9d81d8a06a3d52a099120a93e971
+        checksum/config: 03de6b95c20694aa7dff4cafe198d5c24585af0f4978295ea7a6b85657c431c0
       labels:
         app: enterprise-metrics-store-gateway
         gossip_ring_member: "true"
@@ -54,16 +54,7 @@ spec:
         env: null
         image: grafana/metrics-enterprise:v1.4.2
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          failureThreshold: 20
-          httpGet:
-            path: /ready
-            port: http-metrics
-            scheme: HTTP
-          initialDelaySeconds: 180
-          periodSeconds: 30
-          successThreshold: 1
-          timeoutSeconds: 1
+        livenessProbe: null
         name: enterprise-metrics
         ports:
         - containerPort: 8080

--- a/charts/enterprise-metrics/exports/small/batch-v1.Job-enterprise-metrics-tokengen.yaml
+++ b/charts/enterprise-metrics/exports/small/batch-v1.Job-enterprise-metrics-tokengen.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: enterprise-metrics-tokengen
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-tokengen

--- a/charts/enterprise-metrics/exports/small/policy-v1beta1.PodSecurityPolicy-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/small/policy-v1beta1.PodSecurityPolicy-enterprise-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/small/rbac.authorization.k8s.io-v1.Role-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/small/rbac.authorization.k8s.io-v1.Role-enterprise-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/small/rbac.authorization.k8s.io-v1.RoleBinding-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/small/rbac.authorization.k8s.io-v1.RoleBinding-enterprise-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/small/v1.ConfigMap-enterprise-metrics-runtime.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.ConfigMap-enterprise-metrics-runtime.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-runtime

--- a/charts/enterprise-metrics/exports/small/v1.Secret-enterprise-metrics-license.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Secret-enterprise-metrics-license.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: enterprise-metrics-license
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-license

--- a/charts/enterprise-metrics/exports/small/v1.Secret-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Secret-enterprise-metrics.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-admin-api.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-admin-api.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-admin-api
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-admin-api

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-alertmanager-headless.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-alertmanager-headless.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-alertmanager
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-alertmanager-headless

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-alertmanager.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-alertmanager.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-alertmanager
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-alertmanager

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-distributor.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-distributor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-distributor
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-distributor

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-gateway.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-gateway
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-gateway

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-gossip-ring.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-gossip-ring.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-gossip-ring
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-gossip-ring

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-ingester.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-ingester.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-ingester
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-ingester

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-querier.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-querier.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-querier
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-querier

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-query-frontend-headless.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-query-frontend-headless.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-query-frontend
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-query-frontend-headless

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-query-frontend.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-query-frontend.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-query-frontend
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-query-frontend

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-ruler.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-ruler.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-ruler
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-ruler

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-store-gateway.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-store-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-store-gateway
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-store-gateway

--- a/charts/enterprise-metrics/exports/small/v1.ServiceAccount-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.ServiceAccount-enterprise-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.4.3
+    chart: enterprise-metrics-1.4.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/values.yaml
+++ b/charts/enterprise-metrics/values.yaml
@@ -206,11 +206,6 @@ admin_api:
   persistence:
     subPath:
 
-  livenessProbe:
-    httpGet:
-      path: /ready
-      port: http-metrics
-    initialDelaySeconds: 45
   readinessProbe:
     httpGet:
       path: /ready
@@ -291,11 +286,6 @@ alertmanager:
     #
     # storageClass: "-"
 
-  livenessProbe:
-    httpGet:
-      path: /ready
-      port: http-metrics
-    initialDelaySeconds: 45
   readinessProbe:
     httpGet:
       path: /ready
@@ -402,11 +392,6 @@ distributor:
   persistence:
     subPath:
 
-  livenessProbe:
-    httpGet:
-      path: /ready
-      port: http-metrics
-    initialDelaySeconds: 45
   readinessProbe:
     httpGet:
       path: /ready
@@ -459,11 +444,6 @@ gateway:
   persistence:
     subPath:
 
-  livenessProbe:
-    httpGet:
-      path: /ready
-      port: http-metrics
-    initialDelaySeconds: 45
   readinessProbe:
     httpGet:
       path: /ready
@@ -556,16 +536,6 @@ ingester:
     #
     # storageClass: "-"
 
-  livenessProbe:
-    failureThreshold: 20  # 10 minutes failure threshold
-    httpGet:
-      path: /ready
-      port: http-metrics
-      scheme: HTTP
-    initialDelaySeconds: 180
-    periodSeconds: 30
-    successThreshold: 1
-    timeoutSeconds: 1
   readinessProbe:
     httpGet:
       path: /ready
@@ -621,11 +591,6 @@ ruler:
   persistence:
     subPath:
 
-  livenessProbe:
-    httpGet:
-      path: /ready
-      port: http-metrics
-    initialDelaySeconds: 45
   readinessProbe:
     httpGet:
       path: /ready
@@ -690,11 +655,6 @@ querier:
   persistence:
     subPath:
 
-  livenessProbe:
-    httpGet:
-      path: /ready
-      port: http-metrics
-    initialDelaySeconds: 45
   readinessProbe:
     httpGet:
       path: /ready
@@ -759,11 +719,6 @@ query_frontend:
   persistence:
     subPath:
 
-  livenessProbe:
-    httpGet:
-      path: /ready
-      port: http-metrics
-    initialDelaySeconds: 45
   readinessProbe:
     httpGet:
       path: /ready
@@ -860,16 +815,6 @@ store_gateway:
     #
     # storageClass: "-"
 
-  livenessProbe:
-    failureThreshold: 20  # 10 minutes failure threshold
-    httpGet:
-      path: /ready
-      port: http-metrics
-      scheme: HTTP
-    initialDelaySeconds: 180
-    periodSeconds: 30
-    successThreshold: 1
-    timeoutSeconds: 1
   readinessProbe:
     httpGet:
       path: /ready
@@ -966,16 +911,6 @@ compactor:
     #
     # storageClass: "-"
 
-  livenessProbe:
-    failureThreshold: 20  # 10 minutes failure threshold
-    httpGet:
-      path: /ready
-      port: http-metrics
-      scheme: HTTP
-    initialDelaySeconds: 180
-    periodSeconds: 30
-    successThreshold: 1
-    timeoutSeconds: 1
   readinessProbe:
     httpGet:
       path: /ready


### PR DESCRIPTION
Fixes #593 

Leaves configuration hooks in place so that users can still include
them if they wish.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>