### PR TITLE
Added elif check for .Values.image.noTag 

### DIFF
--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -208,6 +208,8 @@ containers:
   - name: {{ .Chart.Name }}
     {{- if .Values.image.sha }}
     image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}@sha256:{{ .Values.image.sha }}"
+    {{- else if .Values.image.noTag }}
+    image: "{{ .Values.image.repository }}"
     {{- else }}
     image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
     {{- end }}


### PR DESCRIPTION
Allows use of only .Values.image.repository as image value
Issue discovered during the use of devspace (https://devspace.sh/) and attempting to create a new image with custom tag. image value uses ends up appending the image.tag to image.repository and if the original:
{{ .Values.image.repository }}:{{ .Values.image.tag }}"
is used, leaves an extra : at the end
Signed-off-by: Brandon Ojeda <brandon.ojeda@acretivetg.com>