### PR TITLE
[tempo] Enabled the opencensus receive in the default Helm template for Tempo

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 0.7.4
+version: 0.7.5
 appVersion: v1.0.1
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.1](https://img.shields.io/badge/AppVersion-v1.0.1-informational?style=flat-square)
+![Version: 0.7.5](https://img.shields.io/badge/Version-0.7.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.1](https://img.shields.io/badge/AppVersion-v1.0.1-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 
@@ -40,6 +40,7 @@ Grafana Tempo Single Binary Mode
 | tempo.receivers.jaeger.protocols.thrift_binary.endpoint | string | `"0.0.0.0:6832"` |  |
 | tempo.receivers.jaeger.protocols.thrift_compact.endpoint | string | `"0.0.0.0:6831"` |  |
 | tempo.receivers.jaeger.protocols.thrift_http.endpoint | string | `"0.0.0.0:14268"` |  |
+| tempo.receivers.opencensus | string | `nil` |  |
 | tempo.repository | string | `"grafana/tempo"` |  |
 | tempo.resources | object | `{}` |  |
 | tempo.retention | string | `"24h"` |  |

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -63,6 +63,7 @@ tempo:
           endpoint: 0.0.0.0:6831
         thrift_http:
           endpoint: 0.0.0.0:14268
+    opencensus:
   ## Additional container arguments
   extraArgs: {}
   # -- Environment variables to add


### PR DESCRIPTION
In the Tempo values file it is mentioned that all ports and protocols that Tempo supports are enabled. However not all of them actually are enabled. I added opencensus, there are more like Zipkin that I could add but I haven't tested them personally. I did test Opencensus and that works.