### PR TITLE
[enterprise-logs] Add GEL helm chart

### DIFF
--- a/charts/enterprise-logs/Chart.yaml
+++ b/charts/enterprise-logs/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: "v2"
+name: enterprise-logs
+version: 0.1.0
+appVersion: v2.2.1
+kubeVersion: "^1.10.0-0"
+description: "Grafana Enterprise Logs"
+home: https://grafana.com/products/enterprise/logs/
+dependencies:
+- name: "loki-distributed"
+  repository: "https://grafana.github.io/helm-charts"
+  version: "^0.35.2"
+  alias: lokidistributed
+- name: minio
+  alias: minio
+  version: 8.0.9
+  repository: https://helm.min.io/
+  condition: minio.enabled

--- a/charts/enterprise-logs/small.yaml
+++ b/charts/enterprise-logs/small.yaml
@@ -1,0 +1,101 @@
+# These values configure the Grafana Enterprise Logs cluster to
+# handle production ingestion of ~11MiB/s
+
+# Query requirements can vary dramatically depending on query rate and query
+# ranges. The values here satisfy a "usual" query load as seen from our
+# production clusters at this scale.
+
+
+admin_api:
+  replicas: 3
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+
+compactor:
+  replicas: 1
+  persistentVolume:
+    size: 100Gi
+  resources:
+    limits:
+      cpu: 4
+      memory: 2Gi
+    requests:
+      cpu: 2
+      memory: 1Gi
+
+distributor:
+  replicas: 3
+  resources:
+    limits:
+      memory: 1Gi
+    requests:
+      cpu: 0.5
+      memory: 500Mi
+
+gateway:
+  replicas: 3
+  resources:
+    requests:
+      cpu: 1
+      memory: 384Mi
+
+ingester:
+  persistentVolume:
+    size: 50Gi
+  replicas: 4
+  resources:
+    limits:
+      cpu: 2
+      memory: 14Gi
+    requests:
+      cpu: 1
+      memory: 7Gi
+
+memcached:
+  enabled: true
+  replicaCount: 2
+
+memcached-queries:
+  enabled: true
+  replicaCount: 3
+
+memcached-metadata:
+  enabled: true
+
+minio:
+  enabled: false
+
+querier:
+  replicas: 8
+  resources:
+    limits:
+      cpu: 7
+      memory: 16Gi
+    requests:
+      cpu: 4
+      memory: 6Gi
+
+query_frontend:
+  replicas: 2
+  resources:
+    limits:
+      cpu: 3
+      memory: 10Gi
+    requests:
+      cpu: 2
+      memory: 5Gi
+
+ruler:
+  replicas: 2
+  resources:
+    limits:
+      cpu: 7
+      memory: 16Gi
+    requests:
+      cpu: 2
+      memory: 6Gi

--- a/charts/enterprise-logs/templates/_helpers.tpl
+++ b/charts/enterprise-logs/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "enterprise-logs.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "enterprise-logs.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "enterprise-logs.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account
+*/}}
+{{- define "enterprise-logs.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "enterprise-logs.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the app name of enterprise-logs clients. Defaults to the same logic as "enterprise-logs.fullname", and default client expects "prometheus".
+*/}}
+{{- define "client.name" -}}
+{{- if .Values.client.name -}}
+{{- .Values.client.name -}}
+{{- else if .Values.client.fullnameOverride -}}
+{{- .Values.client.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "prometheus" .Values.client.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/enterprise-logs/templates/admin-api-dep.yaml
+++ b/charts/enterprise-logs/templates/admin-api-dep.yaml
@@ -1,0 +1,163 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    {{- toYaml .Values.admin_api.annotations | nindent 4 }}
+  labels:
+    app: {{ template "enterprise-logs.name" . }}-admin-api
+    chart: {{ template "enterprise-logs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "enterprise-logs.fullname" . }}-admin-api
+spec:
+  replicas: {{ .Values.admin_api.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "enterprise-logs.name" . }}-admin-api
+      release: {{ .Release.Name }}
+  strategy:
+    {{- toYaml .Values.admin_api.strategy | nindent 4 }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "enterprise-logs.name" . }}-admin-api
+        name: admin-api
+        gossip_ring_member: "true"
+        target: admin-api
+        release: {{ .Release.Name }}
+        {{- with .Values.admin_api.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- if .Values.useExternalConfig }}
+        checksum/config: {{ .Values.externalConfigVersion }}
+        {{- else }}
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end}}
+        {{- with .Values.admin_api.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "enterprise-logs.serviceAccountName" . }}
+      {{- if .Values.admin_api.priorityClassName }}
+      priorityClassName: {{ .Values.admin_api.priorityClassName }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.admin_api.securityContext | nindent 8 }}
+      initContainers:
+      {{- if .Values.minio.enabled }}
+        - name: minio-mc
+          image: "{{ .Values.minio.mcImage.repository }}:{{ .Values.minio.mcImage.tag }}"
+          imagePullPolicy: {{ .Values.minio.mcImage.pullPolicy }}
+          command: ["/bin/sh", "/config/initialize"]
+          env:
+            - name: MINIO_ENDPOINT
+              value: {{ .Release.Name }}-minio
+            - name: MINIO_PORT
+              value: {{ .Values.minio.service.port | quote }}
+          volumeMounts:
+            - name: minio-configuration
+              mountPath: /config
+          {{- if .Values.minio.tls.enabled }}
+            - name: cert-secret-volume-mc
+              mountPath: {{ .Values.minio.configPathmc }}certs
+          {{ end }}
+        {{- end }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "-target=admin-api"
+            - "-config.file=/etc/loki/config/config.yaml"
+            - "-memberlist.join={{ template "enterprise-logs.fullname" . }}-gossip-ring"
+            {{- if .Values.minio.enabled }}
+            - -admin.client.backend-type=s3
+            - -admin.client.s3.endpoint={{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000
+            - -admin.client.s3.bucket-name=enterprise-logs-admin
+            - -admin.client.s3.access-key-id=enterprise-logs
+            - -admin.client.s3.secret-access-key=supersecret
+            - -admin.client.s3.insecure=true
+            {{- end }}
+            {{- range $key, $value := .Values.admin_api.extraArgs }}
+            - "-{{ $key }}={{ $value }}"
+            {{- end }}
+          volumeMounts:
+            {{- if .Values.admin_api.extraVolumeMounts }}
+              {{ toYaml .Values.admin_api.extraVolumeMounts | nindent 12}}
+            {{- end }}
+            - name: config
+              mountPath: /etc/loki/config
+            - name: license
+              mountPath: /license
+            - name: storage
+              mountPath: "/data"
+              subPath: {{ .Values.admin_api.persistence.subPath }}
+          ports:
+            - name: http-metrics
+              containerPort: {{ .Values.config.server.http_listen_port }}
+              protocol: TCP
+            - name: grpc
+              containerPort: {{ .Values.config.server.grpc_listen_port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.admin_api.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.admin_api.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.admin_api.resources | nindent 12 }}
+          securityContext:
+            readOnlyRootFilesystem: true
+          env:
+            {{- if .Values.admin_api.env }}
+            {{ toYaml .Values.admin_api.env | nindent 12 }}
+            {{- end }}
+        {{- with .Values.admin_api.extraContainers }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+      nodeSelector:
+        {{- toYaml .Values.admin_api.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.admin_api.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.admin_api.tolerations | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.admin_api.terminationGracePeriodSeconds }}
+      volumes:
+        - name: config
+          secret:
+          {{- if .Values.useExternalConfig }}
+            secretName: {{ .Values.externalConfigSecretName }}
+          {{- else }}
+            secretName: {{ template "enterprise-logs.fullname" . }}
+          {{- end }}
+        {{- if .Values.admin_api.extraVolumes }}
+        {{ toYaml .Values.admin_api.extraVolumes | nindent 8}}
+        {{- end }}
+        - name: license
+          secret:
+            secretName: {{ .Values.license.secretName }}
+        - name: storage
+          emptyDir: {}
+        {{- if .Values.minio.enabled }}
+        - name: minio-configuration
+          projected:
+            sources:
+            - configMap:
+                name: {{ .Release.Name }}-minio
+            - secret:
+                name: {{ .Release.Name }}-minio
+        {{- if .Values.minio.tls.enabled }}
+        - name: cert-secret-volume-mc
+          secret:
+            secretName: {{ .Values.minio.tls.certSecret }}
+            items:
+            - key: {{ .Values.minio.tls.publicCrt }}
+              path: CAs/public.crt
+        {{- end }}
+        {{- end }}

--- a/charts/enterprise-logs/templates/admin-api-svc.yaml
+++ b/charts/enterprise-logs/templates/admin-api-svc.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "enterprise-logs.fullname" . }}-admin-api
+  labels:
+    app: {{ template "enterprise-logs.name" . }}-admin-api
+    chart: {{ template "enterprise-logs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- with .Values.admin_api.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- toYaml .Values.admin_api.annotations | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.config.server.http_listen_port }}
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: {{ .Values.config.server.grpc_listen_port }}
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app: {{ template "enterprise-logs.name" . }}-admin-api
+    release: {{ .Release.Name }}

--- a/charts/enterprise-logs/templates/compactor-statefulset.yaml
+++ b/charts/enterprise-logs/templates/compactor-statefulset.yaml
@@ -1,0 +1,157 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "enterprise-logs.fullname" . }}-compactor
+  labels:
+    app: {{ template "enterprise-logs.name" . }}-compactor
+    chart: {{ template "enterprise-logs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- toYaml .Values.compactor.annotations | nindent 4 }}
+spec:
+  replicas: {{ .Values.compactor.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "enterprise-logs.name" . }}-compactor
+      release: {{ .Release.Name }}
+  updateStrategy:
+    {{- toYaml .Values.compactor.strategy | nindent 4 }}
+  serviceName: {{ template "enterprise-logs.fullname" . }}-compactor
+  {{- if .Values.compactor.persistentVolume.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+        {{- if .Values.compactor.persistentVolume.annotations }}
+        annotations:
+          {{ toYaml .Values.compactor.persistentVolume.annotations | nindent 10 }}
+        {{- end }}
+      spec:
+        {{- if .Values.compactor.persistentVolume.storageClass }}
+        {{- if (eq "-" .Values.compactor.persistentVolume.storageClass) }}
+        storageClassName: ""
+        {{- else }}
+        storageClassName: "{{ .Values.compactor.persistentVolume.storageClass }}"
+        {{- end }}
+        {{- end }}
+        accessModes:
+          {{ toYaml .Values.compactor.persistentVolume.accessModes | nindent 10 }}
+        resources:
+          requests:
+            storage: "{{ .Values.compactor.persistentVolume.size }}"
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "enterprise-logs.name" . }}-compactor
+        # The name label is important for cortex-mixin compatibility which expects certain names for services.
+        name: compactor
+        gossip_ring_member: "true"
+        target: compactor
+        release: {{ .Release.Name }}
+        {{- with .Values.compactor.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- if .Values.useExternalConfig }}
+        checksum/config: {{ .Values.externalConfigVersion }}
+        {{- else }}
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.compactor.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "enterprise-logs.serviceAccountName" . }}
+      {{- if .Values.compactor.priorityClassName }}
+      priorityClassName: {{ .Values.compactor.priorityClassName }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.compactor.securityContext | nindent 8 }}
+      initContainers:
+        {{- toYaml .Values.compactor.initContainers | nindent 8 }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      nodeSelector:
+        {{- toYaml .Values.compactor.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.compactor.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.compactor.tolerations | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.compactor.terminationGracePeriodSeconds }}
+      volumes:
+        - name: config
+          secret:
+            {{- if .Values.useExternalConfig }}
+            secretName: {{ .Values.externalConfigSecretName }}
+            {{- else }}
+            secretName: {{ template "enterprise-logs.fullname" . }}
+            {{- end }}
+        - name: license
+          secret:
+            secretName: {{ .Values.license.secretName }}
+        {{- if not .Values.compactor.persistentVolume.enabled }}
+        - name: storage
+          emptyDir: {}
+        {{- end }}
+        {{- if .Values.compactor.extraVolumes }}
+        {{ toYaml .Values.compactor.extraVolumes | nindent 8 }}
+        {{- end }}
+      containers:
+        {{- if .Values.compactor.extraContainers }}
+        {{ toYaml .Values.compactor.extraContainers | nindent 8 }}
+        {{- end }}
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "-target=compactor"
+            - "-config.file=/etc/loki/config/config.yaml"
+            - "-memberlist.join={{ template "enterprise-logs.fullname" . }}-gossip-ring"
+            {{- if .Values.minio.enabled }}
+            - -admin.client.backend-type=s3
+            - -admin.client.s3.endpoint={{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000
+            - -admin.client.s3.bucket-name=enterprise-logs-admin
+            - -admin.client.s3.access-key-id=enterprise-logs
+            - -admin.client.s3.secret-access-key=supersecret
+            - -admin.client.s3.insecure=true
+            {{- end }}
+            {{- range $key, $value := .Values.compactor.extraArgs }}
+            - "-{{ $key }}={{ $value }}"
+            {{- end }}
+          volumeMounts:
+            {{- if .Values.compactor.extraVolumeMounts }}
+            {{ toYaml .Values.compactor.extraVolumeMounts | nindent 12}}
+            {{- end }}
+            - name: config
+              mountPath: /etc/loki/config
+            - name: license
+              mountPath: /license
+            - name: storage
+              mountPath: "/data"
+              {{- if .Values.compactor.persistentVolume.subPath }}
+              subPath: {{ .Values.compactor.persistentVolume.subPath }}
+              {{- end }}
+          ports:
+            - name: http-metrics
+              containerPort: {{ .Values.config.server.http_listen_port }}
+              protocol: TCP
+            - name: grpc
+              containerPort: {{ .Values.config.server.grpc_listen_port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.compactor.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.compactor.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.compactor.resources | nindent 12 }}
+          securityContext:
+            readOnlyRootFilesystem: true
+          env:
+            {{- if .Values.compactor.env }}
+              {{- toYaml .Values.compactor.env | nindent 12 }}
+            {{- end }}

--- a/charts/enterprise-logs/templates/gateway-dep.yaml
+++ b/charts/enterprise-logs/templates/gateway-dep.yaml
@@ -1,0 +1,133 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    {{- toYaml .Values.gateway.annotations | nindent 4 }}
+  labels:
+    app: {{ template "enterprise-logs.name" . }}-gateway
+    chart: {{ template "enterprise-logs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "enterprise-logs.fullname" . }}-gateway
+spec:
+  replicas: {{ .Values.gateway.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "enterprise-logs.name" . }}-gateway
+      release: {{ .Release.Name }}
+  strategy:
+    {{- toYaml .Values.gateway.strategy | nindent 4 }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "enterprise-logs.name" . }}-gateway
+        # The name label is important for cortex-mixin compatibility which expects certain names for services.
+        name: gateway
+        target: gateway
+        release: {{ .Release.Name }}
+        {{- with .Values.gateway.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- if .Values.useExternalConfig }}
+        checksum/config: {{ .Values.externalConfigVersion }}
+        {{- else }}
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end}}
+        {{- with .Values.gateway.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "enterprise-logs.serviceAccountName" . }}
+      {{- if .Values.gateway.priorityClassName }}
+      priorityClassName: {{ .Values.gateway.priorityClassName }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.gateway.securityContext | nindent 8 }}
+      initContainers:
+        {{- toYaml .Values.gateway.initContainers | nindent 8 }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "-target=gateway"
+            - "-config.file=/etc/loki/config/config.yaml"
+            {{- if .Values.minio.enabled }}
+            - -admin.client.backend-type=s3
+            - -admin.client.s3.endpoint={{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000
+            - -admin.client.s3.bucket-name=enterprise-logs-admin
+            - -admin.client.s3.access-key-id=enterprise-logs
+            - -admin.client.s3.secret-access-key=supersecret
+            - -admin.client.s3.insecure=true
+            {{- end }}
+            {{- if .Values.gateway.useDefaultProxyURLs }}
+            - -gateway.proxy.default.url=http://{{ template "enterprise-logs.fullname" . }}-admin-api.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
+            - -gateway.proxy.admin-api.url=http://{{ template "enterprise-logs.fullname" . }}-admin-api.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
+            - -gateway.proxy.distributor.url=http://{{ template "enterprise-logs.fullname" . }}-distributor.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
+            - -gateway.proxy.ingester.url=http://{{ template "enterprise-logs.fullname" . }}-ingester.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
+            - -gateway.proxy.query-frontend.url=http://{{ template "enterprise-logs.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
+            - -gateway.proxy.ruler.url=http://{{ template "enterprise-logs.fullname" . }}-ruler.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
+            {{- end }}
+            {{- range $key, $value := .Values.gateway.extraArgs }}
+            - "-{{ $key }}={{ $value }}"
+            {{- end }}
+          volumeMounts:
+            {{- if .Values.gateway.extraVolumeMounts }}
+              {{ toYaml .Values.gateway.extraVolumeMounts | nindent 12}}
+            {{- end }}
+            - name: config
+              mountPath: /etc/loki/config
+            - name: license
+              mountPath: /license
+            - name: storage
+              mountPath: "/data"
+              subPath: {{ .Values.gateway.persistence.subPath }}
+          ports:
+            - name: http-metrics
+              containerPort: {{ .Values.config.server.http_listen_port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.gateway.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.gateway.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.gateway.resources | nindent 12 }}
+          securityContext:
+            readOnlyRootFilesystem: true
+          env:
+            {{- if .Values.gateway.env }}
+            {{ toYaml .Values.gateway.env | nindent 12 }}
+            {{- end }}
+        {{- with .Values.gateway.extraContainers }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+      nodeSelector:
+        {{- toYaml .Values.gateway.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.gateway.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.gateway.tolerations | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.gateway.terminationGracePeriodSeconds }}
+      volumes:
+        - name: config
+          secret:
+          {{- if .Values.useExternalConfig }}
+            secretName: {{ .Values.externalConfigSecretName }}
+          {{- else }}
+            secretName: {{ template "enterprise-logs.fullname" . }}
+          {{- end }}
+        {{- if .Values.gateway.extraVolumes }}
+        {{ toYaml .Values.gateway.extraVolumes | nindent 8}}
+        {{- end }}
+        - name: license
+          secret:
+            secretName: {{ .Values.license.secretName }}
+        - name: storage
+          emptyDir: {}

--- a/charts/enterprise-logs/templates/gateway-svc.yaml
+++ b/charts/enterprise-logs/templates/gateway-svc.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "enterprise-logs.fullname" . }}-gateway
+  labels:
+    app: {{ template "enterprise-logs.name" . }}-gateway
+    chart: {{ template "enterprise-logs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- with .Values.gateway.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- toYaml .Values.gateway.annotations | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.config.server.http_listen_port }}
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+  selector:
+    app: {{ template "enterprise-logs.name" . }}-gateway
+    release: {{ .Release.Name }}

--- a/charts/enterprise-logs/templates/license-secret.yaml
+++ b/charts/enterprise-logs/templates/license-secret.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.license.external }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.license.secretName }}
+  labels:
+    app: {{ .Values.license.secretName }}
+    chart: {{ template "enterprise-logs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  license.jwt: {{ .Values.license.contents | b64enc }}
+{{- end }}

--- a/charts/enterprise-logs/templates/podsecuritypolicy.yaml
+++ b/charts/enterprise-logs/templates/podsecuritypolicy.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "enterprise-logs.fullname" . }}
+  labels:
+    app: {{ template "enterprise-logs.name" . }}
+    chart: {{ template "enterprise-logs.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'persistentVolumeClaim'
+    - 'secret'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+    - ALL
+{{- end }}

--- a/charts/enterprise-logs/templates/role.yaml
+++ b/charts/enterprise-logs/templates/role.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "enterprise-logs.fullname" . }}
+  labels:
+    app: {{ template "enterprise-logs.name" . }}
+    chart: {{ template "enterprise-logs.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- if .Values.rbac.pspEnabled }}
+rules:
+- apiGroups:      ['extensions']
+  resources:      ['podsecuritypolicies']
+  verbs:          ['use']
+  resourceNames:  [{{ template "enterprise-logs.fullname" . }}]
+{{- end }}
+{{- end }}

--- a/charts/enterprise-logs/templates/rolebinding.yaml
+++ b/charts/enterprise-logs/templates/rolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "enterprise-logs.fullname" . }}
+  labels:
+    app: {{ template "enterprise-logs.name" . }}
+    chart: {{ template "enterprise-logs.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "enterprise-logs.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "enterprise-logs.serviceAccountName" . }}
+{{- end }}

--- a/charts/enterprise-logs/templates/secret.yaml
+++ b/charts/enterprise-logs/templates/secret.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.useExternalConfig }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "enterprise-logs.fullname" . }}
+  labels:
+    app: {{ template "enterprise-logs.name" . }}
+    chart: {{ template "enterprise-logs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  config.yaml: |
+    {{- tpl .Values.lokidistributed.loki.config . | b64enc | nindent 4 }}
+{{- end }}

--- a/charts/enterprise-logs/templates/serviceaccount.yaml
+++ b/charts/enterprise-logs/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "enterprise-logs.name" . }}
+    chart: {{ template "enterprise-logs.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  annotations:
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  name: {{ template "enterprise-logs.serviceAccountName" . }}
+{{- end }}

--- a/charts/enterprise-logs/templates/tokengen-job.yaml
+++ b/charts/enterprise-logs/templates/tokengen-job.yaml
@@ -1,0 +1,88 @@
+{{ if .Values.tokengenJob.enable }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "enterprise-logs.fullname" . }}-tokengen
+  labels:
+    app: {{ template "enterprise-logs.name" . }}-tokengen
+    chart: {{ template "enterprise-logs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- if .Values.tokengenJob.annotations }}
+    {{- toYaml .Values.tokengenJob.annotations | nindent 4 }}
+    {{- end }}
+    "helm.sh/hook": post-install
+spec:
+  backoffLimit: 6
+  completions: 1
+  parallelism: 1
+  selector:
+  template:
+    metadata:
+      labels:
+        app: {{ template "enterprise-logs.name" . }}-tokengen
+        name: tokengen
+        target: tokengen
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ template "enterprise-logs.serviceAccountName" . }}
+      {{- if .Values.tokengenJob.priorityClassName }}
+      priorityClassName: {{ .Values.tokengenJob.priorityClassName }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.tokengenJob.securityContext | nindent 8 }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "-target=tokengen"
+            - "-config.file=/etc/loki/config/config.yaml"
+            {{- if .Values.minio.enabled }}
+            - -admin.client.backend-type=s3
+            - -admin.client.s3.endpoint={{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000
+            - -admin.client.s3.bucket-name=enterprise-logs-admin
+            - -admin.client.s3.access-key-id=enterprise-logs
+            - -admin.client.s3.secret-access-key=supersecret
+            - -admin.client.s3.insecure=true
+            {{- end }}
+            {{- range $key, $value := .Values.tokengenJob.extraArgs }}
+            - "-{{ $key }}={{ $value }}"
+            {{- end }}
+          volumeMounts:
+            {{- if .Values.tokengenJob.extraVolumeMounts }}
+              {{ toYaml .Values.tokengenJob.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+            - name: config
+              mountPath: /etc/loki/config
+            - name: license
+              mountPath: /license
+          env:
+            {{- if .Values.tokengenJob.env }}
+              {{ toYaml .Values.tokengenJob.env | nindent 12 }}
+            {{- end }}
+      restartPolicy: OnFailure
+      volumes:
+        - name: config
+          secret:
+          {{- if .Values.useExternalConfig }}
+            secretName: {{ .Values.externalConfigSecretName }}
+          {{- else }}
+            secretName: {{ template "enterprise-logs.fullname" . }}
+          {{- end }}
+        {{- if .Values.tokengenJob.extraVolumes }}
+        {{ toYaml .Values.tokengenJob.extraVolumes | nindent 8 }}
+        {{- end }}
+        - name: license
+          secret:
+            secretName: {{ .Values.license.secretName }}
+        - name: storage
+          emptyDir: {}
+{{- end }}

--- a/charts/enterprise-logs/values.yaml
+++ b/charts/enterprise-logs/values.yaml
@@ -1,0 +1,389 @@
+# The default values specified in this file are enough to deploy all of the
+# Grafana Enterprise Logs microservices but are not suitable for production
+# load.
+# To configure the resources for production load, refer to the the small.yaml or
+# large.yaml values files.
+
+# Container image settings.
+# Since the image is unique for all microservices, so are image settings.
+image:
+  repository: grafana/enterprise-logs
+  tag: v1.1.0
+  pullPolicy: IfNotPresent
+  # Optionally specify an array of imagePullSecrets.
+  # Secrets must be manually created in the namespace.
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  # pullSecrets:
+  #   - myRegistryKeySecretName
+
+serviceAccount:
+  create: true
+  name:
+  annotations: {}
+
+useExternalConfig: false
+externalConfigSecretName: 'enterprise-logs-config'
+externalConfigVersion: '0'
+
+# In order to use Grafana Enterprise Logs features, you will need to provide the contents of your Grafana Enterprise Logs
+# license, either by providing the contents of the license.jwt, or the name Kubernetes Secret that contains your license.jwt.
+# To set the license contents, use the flag `--set-file 'license.contents=./license.jwt'`
+# To use your own Kubernetes Secret, `--set license.external=true`.
+useExternalLicense: false
+license:
+  contents: "NOTAVALIDLICENSE"
+  external: false
+  secretName: 'enterprise-logs-license'
+
+tokengenJob:
+  enable: true
+  extraArgs: {}
+  env: []
+  annotations: {}
+
+config:
+  server:
+    http_listen_port: 3100
+    grpc_listen_port: 9095
+
+runtimeConfig: {}
+
+rbac:
+  create: true
+  pspEnabled: true
+
+admin_api:
+  replicas: 1
+
+  annotations: {}
+  service:
+    annotations: {}
+    labels: {}
+
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+
+  podLabels: {}
+  podAnnotations: {}
+
+  securityContext: {}
+
+  extraArgs: {}
+
+  persistence:
+    subPath:
+
+  livenessProbe:
+    httpGet:
+      path: /ready
+      port: http-metrics
+    initialDelaySeconds: 45
+  readinessProbe:
+    httpGet:
+      path: /ready
+      port: http-metrics
+    initialDelaySeconds: 45
+
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+
+  extraContainers: []
+  extraVolumes: []
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  terminationGracePeriodSeconds: 60
+
+gateway:
+  # If you want to use your own proxy URLs, set this to false.
+  useDefaultProxyURLs: true
+  replicas: 1
+
+  annotations: {}
+  service:
+    annotations: {}
+    labels: {}
+
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+
+  podLabels: {}
+  podAnnotations: {}
+
+  securityContext: {}
+  initContainers: []
+
+  extraArgs: {}
+
+  persistence:
+    subPath:
+
+  livenessProbe:
+    httpGet:
+      path: /ready
+      port: http-metrics
+    initialDelaySeconds: 45
+  readinessProbe:
+    httpGet:
+      path: /ready
+      port: http-metrics
+    initialDelaySeconds: 45
+
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+
+  extraContainers: []
+  extraVolumes: []
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  terminationGracePeriodSeconds: 60
+
+
+compactor:
+  replicas: 1
+
+  service:
+    annotations: {}
+    labels: {}
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+
+  # Additional Grafana Enterprise Metrics container arguments, e.g. log level (debug, info, warn, error)
+  extraArgs: {}
+
+  # Pod Labels
+  podLabels: {}
+
+  # Pod Annotations
+  podAnnotations: {}
+
+  nodeSelector: {}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: target
+                  operator: In
+                  values:
+                    - compactor
+            topologyKey: 'kubernetes.io/hostname'
+
+  annotations: {}
+
+  persistentVolume:
+    # If true compactor will create/use a Persistent Volume Claim
+    # If false, use emptyDir
+    #
+    enabled: true
+
+    # compactor data Persistent Volume Claim annotations
+    #
+    annotations: {}
+
+    # compactor data Persistent Volume access modes
+    # Must match those of existing PV or dynamic provisioner
+    # Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    #
+    accessModes:
+      - ReadWriteOnce
+
+    # compactor data Persistent Volume size
+    #
+    size: 2Gi
+
+    # Subdirectory of compactor data Persistent Volume to mount
+    # Useful if the volume's root directory is not empty
+    #
+    subPath: ''
+
+
+    # compactor data Persistent Volume Storage Class
+    # If defined, storageClassName: <storageClass>
+    # If set to "-", storageClassName: "", which disables dynamic provisioning
+    # If undefined (the default) or set to null, no storageClassName spec is
+    #   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    #   GKE, AWS & OpenStack)
+    #
+    # storageClass: "-"
+
+  livenessProbe:
+    failureThreshold: 20  # 10 minutes failure threshold
+    httpGet:
+      path: /ready
+      port: http-metrics
+      scheme: HTTP
+    initialDelaySeconds: 180
+    periodSeconds: 30
+    successThreshold: 1
+    timeoutSeconds: 1
+  readinessProbe:
+    httpGet:
+      path: /ready
+      port: http-metrics
+    initialDelaySeconds: 60
+
+  securityContext: {}
+
+  strategy:
+    type: RollingUpdate
+
+  terminationGracePeriodSeconds: 240
+
+  tolerations: []
+  podDisruptionBudget: {}
+  initContainers: []
+  extraContainers: []
+  extraVolumes: []
+  extraVolumeMounts: []
+  extraPorts: []
+  env: []
+
+
+minio:
+  enabled: true
+  accessKey: enterprise-logs
+  buckets:
+    - name: enterprise-logs-tsdb
+      policy: none
+      purge: false
+    - name: enterprise-logs-admin
+      policy: none
+      purge: false
+    - name: enterprise-logs-ruler
+      policy: none
+      purge: false
+  persistence:
+    size: 5Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  secretKey: supersecret
+
+lokidistributed:
+  gateway:
+    enabled: false
+  compactor:
+    enabled: false
+  loki:
+    image:
+      repository: grafana/enterprise-logs
+      tag: v1.1.0
+    # this config is also used for Admin API and Gateway. I can't tell the subchart to look in gel so I'm telling gel to look here
+    config: |
+      auth_enabled: true
+
+      auth:
+        type: enterprise
+      
+      cluster_name: enterprise-logs-test-fixture
+
+      admin_client:
+        storage:
+          type: s3
+
+
+      compactor:
+        shared_store: s3
+        working_directory: /data/boltdb-shipper-compactor
+
+
+      license:
+        path: "/license/license.jwt"
+
+      ingester:
+        lifecycler:
+          num_tokens: 512
+          ring:
+            replication_factor: 3
+            kvstore:
+              store: memberlist
+
+      limits_config:
+        reject_old_samples: true
+        reject_old_samples_max_age: 168h
+
+      server:
+        http_listen_port: 3100
+        grpc_listen_port: 9095
+
+      ingester_client:
+        grpc_client_config:
+          max_recv_msg_size: 104857600
+          max_send_msg_size: 104857600
+
+      memberlist:
+        abort_if_cluster_join_fails: false
+        bind_port: 7946
+        join_members:
+          - gel-lokidistributed-memberlist
+
+      distributor:
+        ring:
+          kvstore:
+            store: memberlist
+
+      querier:
+        query_ingesters_within: 12h
+
+      query_range:
+        split_queries_by_interval: 24h
+        align_queries_with_step: true
+        cache_results: true
+        results_cache:
+          cache:
+            memcached:
+              expiration: 1h
+            memcached_client:
+              timeout: 1s
+
+      schema_config:
+        configs:
+          - from: 2021-01-01
+            store: boltdb-shipper
+            object_store: aws
+            schema: v11
+            index:
+              prefix: index_
+              period: 24h
+
+      storage_config:
+        aws:
+          s3: http://enterprise-logs:supersecret@gel-minio:9000
+          bucketnames: enterprise-logs-tsdb
+          s3forcepathstyle: true
+          insecure: true
+        boltdb_shipper:
+          active_index_directory: /var/loki/index
+          cache_location: /var/loki/cache
+          cache_ttl: 24h
+          shared_store: s3
+
+      ruler:
+        enable_alertmanager_discovery: false
+        enable_api: true
+        enable_sharding: true
+        ring:
+          kvstore:
+            store: memberlist
+        rule_path: '/var/loki'
+
+      frontend:
+        log_queries_longer_than: 10s


### PR DESCRIPTION
Here's the bones of a GEL helm chart. It uses loki-distributed as a dependency and borrows Admin API, Gateway, and Compactor from the GEM chart.

Both the new templates and the loki-distributed chart use the same config file so the loki-distributed chart became the lowest common denominator.

I kept the service account stuff since it had to do with PSPs. I don't know if anyone cares about PSPs anymore. Perhaps they can be removed.

Current issues I'm aware of:

1. There is a config file issue I can't figure out. It only affects distributor, querier, and frontend. I suspect it's something small and not related to the structure of the chart.
2. The loki-distributed Pods are still named loki-distributed. I had an alias in Chart.yaml that fixed that but it was making the work harder to reason about so I removed it. It can probably be added back in.
3. There is no large.yaml for sizing the cluster. I used the values given to me by JenV for the small.yaml file.
4. I. 'm not really sure what the clients section of the helpers file is for. It's still in the file.
5. I had to have to remove the runtime config section of the config file since it was incompatible with loki-distributed. This could be fixed at the loki-distributed chart.
6. I had to duplicate a very small section of the config file in a config: block like the GEM chart. It only has the server ports in it. They are used by some of the templates so I couldn't remove them.