### PR TITLE
[promtail] support extraRelabelConfigs in config.snippets

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.3.0
-version: 3.7.0
+version: 3.8.0
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 3.7.0](https://img.shields.io/badge/Version-3.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
+![Version: 3.8.0](https://img.shields.io/badge/Version-3.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 
@@ -73,6 +73,7 @@ The new release which will pick up again from the existing `positions.yaml`.
 | config.serverPort | int | `3101` | The port of the Promtail server Must be reference in `config.file` to configure `server.http_listen_port` See default config in `values.yaml` |
 | config.snippets | object | See `values.yaml` | A section of reusable snippets that can be reference in `config.file`. Custom snippets may be added in order to reduce redundancy. This is especially helpful when multiple `kubernetes_sd_configs` are use which usually have large parts in common. |
 | config.snippets.extraClientConfigs | string | empty | You can put here any keys that will be directly added to the config file's 'client' block. |
+| config.snippets.extraRelabelConfigs | list | `[]` | You can put here any additional relabel_configs to "kubernetes-pods" job |
 | config.snippets.extraScrapeConfigs | string | empty | You can put here any additional scrape configs you want to add to the config file. |
 | containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The security context for containers |
 | defaultVolumeMounts | list | See `values.yaml` | Default volume mounts. Corresponds to `volumes`. |

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -295,151 +295,33 @@ config:
 
     scrapeConfigs: |
       # See also https://github.com/grafana/loki/blob/master/production/ksonnet/promtail/scrape_config.libsonnet for reference
-
-      # Pods with a label 'app.kubernetes.io/name'
-      - job_name: kubernetes-pods-app-kubernetes-io-name
+      - job_name: kubernetes-pods
         pipeline_stages:
           {{- toYaml .Values.config.snippets.pipelineStages | nindent 4 }}
         kubernetes_sd_configs:
           - role: pod
         relabel_configs:
-          - action: replace
-            source_labels:
-              - __meta_kubernetes_pod_label_app_kubernetes_io_name
-            target_label: app
-          - action: drop
-            regex: ''
-            source_labels:
-              - app
-          - action: replace
-            source_labels:
-              - __meta_kubernetes_pod_label_app_kubernetes_io_component
-            target_label: component
-          {{- if .Values.config.snippets.addScrapeJobLabel }}
-          - action: replace
-            replacement: kubernetes-pods-app-kubernetes-io-name
-            target_label: scrape_job
-          {{- end }}
-          {{- toYaml .Values.config.snippets.common | nindent 4 }}
-
-      # Pods with a label 'app'
-      - job_name: kubernetes-pods-app
-        pipeline_stages:
-          {{- toYaml .Values.config.snippets.pipelineStages | nindent 4 }}
-        kubernetes_sd_configs:
-          - role: pod
-        relabel_configs:
-          # Drop pods with label 'app.kubernetes.io/name'. They are already considered above
-          - action: drop
-            regex: .+
-            source_labels:
-              - __meta_kubernetes_pod_label_app_kubernetes_io_name
-          - action: replace
-            source_labels:
-              - __meta_kubernetes_pod_label_app
-            target_label: app
-          - action: drop
-            regex: ''
-            source_labels:
-              - app
-          - action: replace
-            source_labels:
-              - __meta_kubernetes_pod_label_component
-            target_label: component
-          {{- if .Values.config.snippets.addScrapeJobLabel }}
-          - action: replace
-            replacement: kubernetes-pods-app
-            target_label: scrape_job
-          {{- end }}
-          {{- toYaml .Values.config.snippets.common | nindent 4 }}
-
-      # Pods with direct controllers, such as StatefulSet
-      - job_name: kubernetes-pods-direct-controllers
-        pipeline_stages:
-          {{- toYaml .Values.config.snippets.pipelineStages | nindent 4 }}
-        kubernetes_sd_configs:
-          - role: pod
-        relabel_configs:
-          # Drop pods with label 'app.kubernetes.io/name' or 'app'. They are already considered above
-          - action: drop
-            regex: .+
-            separator: ''
-            source_labels:
+          - source_labels:
+              - __meta_kubernetes_pod_controller_name
+            regex: ([0-9a-z-.]+?)(-[0-9a-f]{8,10})?
+            action: replace
+            target_label: __tmp_controller_name
+          - source_labels:
               - __meta_kubernetes_pod_label_app_kubernetes_io_name
               - __meta_kubernetes_pod_label_app
-          - action: drop
-            regex: '[0-9a-z-.]+-[0-9a-f]{8,10}'
-            source_labels:
-              - __meta_kubernetes_pod_controller_name
-          - action: replace
-            source_labels:
-              - __meta_kubernetes_pod_controller_name
-            target_label: app
-          {{- if .Values.config.snippets.addScrapeJobLabel }}
-          - action: replace
-            replacement: kubernetes-pods-direct-controllers
-            target_label: scrape_job
-          {{- end }}
-          {{- toYaml .Values.config.snippets.common | nindent 4 }}
-
-      # Pods with indirect controllers, such as Deployment
-      - job_name: kubernetes-pods-indirect-controller
-        pipeline_stages:
-          {{- toYaml .Values.config.snippets.pipelineStages | nindent 4 }}
-        kubernetes_sd_configs:
-          - role: pod
-        relabel_configs:
-          # Drop pods with label 'app.kubernetes.io/name' or 'app'. They are already considered above
-          - action: drop
-            regex: .+
-            separator: ''
-            source_labels:
-              - __meta_kubernetes_pod_label_app_kubernetes_io_name
-              - __meta_kubernetes_pod_label_app
-          - action: keep
-            regex: '[0-9a-z-.]+-[0-9a-f]{8,10}'
-            source_labels:
-              - __meta_kubernetes_pod_controller_name
-          - action: replace
-            regex: '([0-9a-z-.]+)-[0-9a-f]{8,10}'
-            source_labels:
-              - __meta_kubernetes_pod_controller_name
-            target_label: app
-          {{- if .Values.config.snippets.addScrapeJobLabel }}
-          - action: replace
-            replacement: kubernetes-pods-indirect-controller
-            target_label: scrape_job
-          {{- end }}
-          {{- toYaml .Values.config.snippets.common | nindent 4 }}
-      # All remaining pods not yet covered
-      - job_name: kubernetes-other
-        pipeline_stages:
-          {{- toYaml .Values.config.snippets.pipelineStages | nindent 4 }}
-        kubernetes_sd_configs:
-          - role: pod
-        relabel_configs:
-          # Drop what has already been covered
-          - action: drop
-            regex: .+
-            separator: ''
-            source_labels:
-              - __meta_kubernetes_pod_label_app_kubernetes_io_name
-              - __meta_kubernetes_pod_label_app
-          - action: drop
-            regex: .+
-            source_labels:
-              - __meta_kubernetes_pod_controller_name
-          - action: replace
-            source_labels:
+              - __tmp_controller_name
               - __meta_kubernetes_pod_name
+            regex: ^;*([^;]+)(;.*)?$
+            action: replace
             target_label: app
-          - action: replace
-            source_labels:
+          - source_labels:
+              - __meta_kubernetes_pod_label_app_kubernetes_io_component
               - __meta_kubernetes_pod_label_component
+            regex: ^;*([^;]+)(;.*)?$
+            action: replace
             target_label: component
           {{- if .Values.config.snippets.addScrapeJobLabel }}
-          - action: replace
-            replacement: kubernetes-other
+          - replacement: kubernetes-pods
             target_label: scrape_job
           {{- end }}
           {{- toYaml .Values.config.snippets.common | nindent 4 }}

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -293,6 +293,9 @@ config:
     # @default -- empty
     extraScrapeConfigs: ""
 
+    # -- You can put here any additional relabel_configs to "kubernetes-pods" job
+    extraRelabelConfigs: []
+
     scrapeConfigs: |
       # See also https://github.com/grafana/loki/blob/master/production/ksonnet/promtail/scrape_config.libsonnet for reference
       - job_name: kubernetes-pods
@@ -325,6 +328,9 @@ config:
             target_label: scrape_job
           {{- end }}
           {{- toYaml .Values.config.snippets.common | nindent 4 }}
+          {{- with .Values.config.snippets.extraRelabelConfigs }}
+          {{- toYaml . | nindent 4 }}
+          {{- end }}
 
   # -- Config file contents for Promtail.
   # Must be configured as string.


### PR DESCRIPTION
Hello grafana & loki community

I use `promtail` to scrape logs from my Kubernetes cluster which mainly used to run Spark Applications via [spark-operator](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator).
So, it would be nice if loki logs stream have labels to distinguish between SparkApp. In this case is 2 lables bellow:
![Screenshot from 2021-08-12 20-29-41](https://user-images.githubusercontent.com/6848311/129205725-0ca3405c-3127-4b3e-8855-609a18bee745.png)
Up until now, the only way to do this is override the hold `scrapeConfigs` snippet, which show that is very complication.
So, with this PR, it's possible to end-users add `extraRelabelConfigs` only. For example in my case:
```yaml
config:
  snippets:
    extraRelabelConfigs:
      - source_labels: [__meta_kubernetes_pod_label_spark_role]
        target_label: spark_role
      - source_labels: [__meta_kubernetes_pod_label_sparkoperator_k8s_io_app_name]
        target_label: spark_app
```

And while doing this task, `scrapeConfigs` has 5 jobs. It's quite long and hard to extends. So I did a little cleanup by merge them into single `kubernetes-pods` job (no functional change).