### PR TITLE
[loki-stack] Bump Grafana chart version to v6.15.0

### DIFF
--- a/charts/loki-stack/Chart.yaml
+++ b/charts/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 2.4.1
+version: 2.5.0
 appVersion: v2.1.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki-stack/requirements.yaml
+++ b/charts/loki-stack/requirements.yaml
@@ -13,7 +13,7 @@ dependencies:
   version: "^2.2.0"
 - name: "grafana"
   condition: grafana.enabled
-  version: "~5.7.0"
+  version: "~6.15.0"
   repository:  "https://grafana.github.io/helm-charts"
 - name: "prometheus"
   condition: prometheus.enabled

--- a/charts/loki-stack/values.yaml
+++ b/charts/loki-stack/values.yaml
@@ -13,7 +13,7 @@ grafana:
     datasources:
       enabled: true
   image:
-    tag: 7.5.0
+    tag: 8.1.0
 
 prometheus:
   enabled: false


### PR DESCRIPTION
Signed-off-by: Andres Alvarez <kir4h.gh@gmail.com>

This PR Bumps Grafana Chart version to the latest one.

I am also bumping grafana version to the one defaulted by this new version (not sure if there is a reason for this chart to keep them different)