### PR TITLE
fix: loki-distributed headless service port name to memberlist

### DIFF
--- a/charts/loki-distributed/templates/service-memberlist.yaml
+++ b/charts/loki-distributed/templates/service-memberlist.yaml
@@ -8,7 +8,7 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: http
+    - name: memberlist
       port: 7946
       targetPort: http-memberlist
       protocol: TCP


### PR DESCRIPTION
The loki-distributed headless service memberlist port name is set to `http` which causes conflicts with Istio. https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/