### PR TITLE
[grafana] bump kiwigrid/k8s-sidecar to v1.12.3, chart to 6.16.0

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.15.0
+version: 6.16.0
 appVersion: 8.1.0
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -137,7 +137,7 @@ This version requires Helm >= 3.1.0.
 | `podLabels`                               | Pod labels                                    | `{}`                                                    |
 | `podPortName`                             | Name of the grafana port on the pod           | `grafana`                                               |
 | `sidecar.image.repository`                | Sidecar image repository                      | `quay.io/kiwigrid/k8s-sidecar`                          |
-| `sidecar.image.tag`                       | Sidecar image tag                             | `1.12.2`                                                |
+| `sidecar.image.tag`                       | Sidecar image tag                             | `1.12.3`                                                |
 | `sidecar.image.sha`                       | Sidecar image sha (optional)                  | `""`                                                    |
 | `sidecar.imagePullPolicy`                 | Sidecar image pull policy                     | `IfNotPresent`                                          |
 | `sidecar.resources`                       | Sidecar resources                             | `{}`                                                    |

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -608,7 +608,7 @@ smtp:
 sidecar:
   image:
     repository: quay.io/kiwigrid/k8s-sidecar
-    tag: 1.12.2
+    tag: 1.12.3
     sha: ""
   imagePullPolicy: IfNotPresent
   resources: {}


### PR DESCRIPTION
Hi folks

The currently reference kiwigri/k8s-sidecar version 1.12.2 [contained some CVEs which were fixed in 1.12.3](https://github.com/kiwigrid/k8s-sidecar/issues/137) - this PR updates the reference to it.

This PR is very similar to https://github.com/grafana/helm-charts/pull/501, so I also bumped the grafana chart minor version.