### PR TITLE
[grafana] Enable multiple files in values.yaml for datasources / notifiers / dashboardProviders

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.16.3
+version: 6.16.4
 appVersion: 8.1.2
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -260,19 +260,25 @@ containers:
 {{- end }}
 {{- end }}
 {{- if .Values.datasources }}
+{{- range (keys .Values.datasources | sortAlpha) }}
       - name: config
-        mountPath: "/etc/grafana/provisioning/datasources/datasources.yaml"
-        subPath: datasources.yaml
+        mountPath: "/etc/grafana/provisioning/datasources/{{ . }}"
+        subPath: {{ . | quote }}
+{{- end }}
 {{- end }}
 {{- if .Values.notifiers }}
+{{- range (keys .Values.notifiers | sortAlpha) }}
       - name: config
-        mountPath: "/etc/grafana/provisioning/notifiers/notifiers.yaml"
-        subPath: notifiers.yaml
+        mountPath: "/etc/grafana/provisioning/notifiers/{{ . }}"
+        subPath: {{ . | quote }}
+{{- end }}
 {{- end }}
 {{- if .Values.dashboardProviders }}
+{{- range (keys .Values.dashboardProviders | sortAlpha) }}
       - name: config
-        mountPath: "/etc/grafana/provisioning/dashboards/dashboardproviders.yaml"
-        subPath: dashboardproviders.yaml
+        mountPath: "/etc/grafana/provisioning/dashboards/{{ . }}"
+        subPath: {{ . | quote }}
+{{- end }}
 {{- end }}
 {{- if .Values.sidecar.dashboards.enabled }}
       - name: sc-dashboard-volume


### PR DESCRIPTION
https://github.com/grafana/helm-charts/blob/main/charts/grafana/templates/configmap.yaml#L30-L50 allows for multiple provider files to be specified, but only `datasources.yaml` `notifiers.yaml` and `dashboardproviders.yaml` were ever mounted.

Having the ability to specify several files is especially useful when using tiered values.yaml files (global, product, environment) that might want to add e.g. notifiers.

I consider this a bugfix rather than a feature as I couldn't find in the documentation that this was desired and specifying any other filenames than the ones mentioned above means they were ignored and when the ones mentioned above were missing this would lead to runtime errors.

The change is backward compatible (as long as you used the expected filenames there is no effective change in the template).