### PR TITLE
[loki-distributed] Swap inverted X boxes for red Xs in README

### DIFF
--- a/charts/loki-distributed/README.md.gotmpl
+++ b/charts/loki-distributed/README.md.gotmpl
@@ -59,18 +59,18 @@ The other components are optional.
 | Component | Optional | Enabled by default |
 | --- | --- | --- |
 | gateway |  ✅ |  ✅ |
-| ingester |  ❎ | n/a |
-| distributor |  ❎ | n/a |
-| querier |  ❎ | n/a |
-| query-frontend |  ❎ | n/a |
-| table-manager |  ✅ |  ❎ |
-| compactor |  ✅ |  ❎ |
-| ruler |  ✅ |  ❎ |
-| index-gateway |  ✅ |  ❎ |
-| memcached-chunks |  ✅ |  ❎ |
-| memcached-frontend |  ✅ |  ❎ |
-| memcached-index-queries |  ✅ |  ❎ |
-| memcached-index-writes |  ✅ |  ❎ |
+| ingester |  ❌ | n/a |
+| distributor |  ❌ | n/a |
+| querier |  ❌ | n/a |
+| query-frontend |  ❌ | n/a |
+| table-manager |  ✅ |  ❌ |
+| compactor |  ✅ |  ❌ |
+| ruler |  ✅ |  ❌ |
+| index-gateway |  ✅ |  ❌ |
+| memcached-chunks |  ✅ |  ❌ |
+| memcached-frontend |  ✅ |  ❌ |
+| memcached-index-queries |  ✅ |  ❌ |
+| memcached-index-writes |  ✅ |  ❌ |
 
 ## Configuration
 


### PR DESCRIPTION
Scanning the chart, it was difficult to differentiate between what was enabled by default or not given all of the boxes were green.