### PR TITLE
[tempo] Fix podAnnotations

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 0.7.6
+version: 0.7.7
 appVersion: 1.1.0
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 0.7.6](https://img.shields.io/badge/Version-0.7.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.7.7](https://img.shields.io/badge/Version-0.7.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 
@@ -20,7 +20,7 @@ Grafana Tempo Single Binary Mode
 | persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | persistence.enabled | bool | `false` |  |
 | persistence.size | string | `"10Gi"` |  |
-| podAnnotations | list | `[]` |  |
+| podAnnotations | object | `{}` |  |
 | replicas | int | `1` |  |
 | service.annotations | object | `{}` |  |
 | service.labels | object | `{}` |  |

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -120,7 +120,7 @@ persistence:
   size: 10Gi
 
 ## Pod Annotations
-podAnnotations: []
+podAnnotations: {}
 
 # -- Volumes to add
 extraVolumes: []


### PR DESCRIPTION
When you install the tempo Helm Chart, you get the following warnings:

```
coalesce.go:163: warning: skipped value for podAnnotations: Not a table.
coalesce.go:163: warning: skipped value for podAnnotations: Not a table.
coalesce.go:163: warning: skipped value for podAnnotations: Not a table.
```

This PR solves this by changing the podAnnotations from an empty list to an empty object.