### PR TITLE
[grafana] fix grafana image tag

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.16.8
+version: 6.16.9
 appVersion: 8.1.5
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -207,9 +207,9 @@ containers:
 {{- end}}
   - name: {{ .Chart.Name }}
     {{- if .Values.image.sha }}
-    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}@sha256:{{ .Values.image.sha }}"
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}@sha256:{{ .Values.image.sha }}"
     {{- else }}
-    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
     {{- end }}
     imagePullPolicy: {{ .Values.image.pullPolicy }}
   {{- if .Values.command }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -70,7 +70,7 @@ livenessProbe:
 
 image:
   repository: grafana/grafana
-  tag: 8.1.2
+  tag: ""
   sha: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
A version different from the grafana image tag set in Chart.yaml is distributed.
Change it so that the same version is deployed.
