### PR TITLE
[grafana] Fix the image tag in the grafana chart

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.16.8
+version: 6.16.9
 appVersion: 8.1.5
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -70,7 +70,7 @@ livenessProbe:
 
 image:
   repository: grafana/grafana
-  tag: 8.1.2
+  tag: 8.1.5
   sha: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Signed-off-by: Maarten De Wispelaere <maarten@bitprocessor.be>

The grafana chart isn't using the `appVersion` from the Chart.yaml as image tag. 
The previous 2 changes only changed the appVersion, not the `image.tag` in the values.yaml.
This commit fixes that.