### PR TITLE
[loki-distributed] gateway: verboseLogging flag

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.3.0
-version: 0.37.3
+version: 0.37.4
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.37.3](https://img.shields.io/badge/Version-0.37.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
+![Version: 0.37.4](https://img.shields.io/badge/Version-0.37.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 
@@ -151,6 +151,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | gateway.service.type | string | `"ClusterIP"` | Type of the gateway service |
 | gateway.terminationGracePeriodSeconds | int | `30` | Grace period to allow the gateway to shutdown before it is killed |
 | gateway.tolerations | list | `[]` | Tolerations for gateway pods |
+| gateway.verboseLogs | bool | `false` | Enable logging of 2xx and 3xx HTTP requests |
 | global.clusterDomain | string | `"cluster.local"` | configures cluster domain ("cluster.local" by default) |
 | global.dnsNamespace | string | `"kube-system"` | configures DNS service namespace |
 | global.dnsService | string | `"kube-dns"` | configures DNS service name |

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -151,7 +151,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | gateway.service.type | string | `"ClusterIP"` | Type of the gateway service |
 | gateway.terminationGracePeriodSeconds | int | `30` | Grace period to allow the gateway to shutdown before it is killed |
 | gateway.tolerations | list | `[]` | Tolerations for gateway pods |
-| gateway.verboseLogs | bool | `false` | Enable logging of 2xx and 3xx HTTP requests |
+| gateway.verboseLogging | bool | `false` | Enable logging of 2xx and 3xx HTTP requests |
 | global.clusterDomain | string | `"cluster.local"` | configures cluster domain ("cluster.local" by default) |
 | global.dnsNamespace | string | `"kube-system"` | configures DNS service namespace |
 | global.dnsService | string | `"kube-dns"` | configures DNS service name |

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -543,7 +543,7 @@ gateway:
   # -- Number of replicas for the gateway
   replicas: 1
   # -- Enable logging of 2xx and 3xx HTTP requests
-  verboseLogs: false
+  verboseLogging: false
   autoscaling:
     # -- Enable autoscaling for the gateway
     enabled: false
@@ -709,7 +709,7 @@ gateway:
         default_type application/octet-stream;
         log_format   {{ .Values.gateway.nginxConfig.logFormat }}
 
-        {{- if .Values.gateway.verboseLogs }}
+        {{- if .Values.gateway.verboseLogging }}
         access_log   /dev/stderr  main;
         {{- else }}
 

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -542,6 +542,8 @@ gateway:
   enabled: true
   # -- Number of replicas for the gateway
   replicas: 1
+  # -- Enable logging of 2xx and 3xx HTTP requests
+  verboseLogs: false
   autoscaling:
     # -- Enable autoscaling for the gateway
     enabled: false
@@ -706,7 +708,18 @@ gateway:
 
         default_type application/octet-stream;
         log_format   {{ .Values.gateway.nginxConfig.logFormat }}
+
+        {{- if .Values.gateway.verboseLogs }}
         access_log   /dev/stderr  main;
+        {{- else }}
+
+        map $status $loggable {
+          ~^[23]  0;
+          default 1;
+        }
+        access_log   /dev/stderr  main  if=$loggable;
+        {{- end }}
+
         sendfile     on;
         tcp_nopush   on;
         resolver {{ .Values.global.dnsService }}.{{ .Values.global.dnsNamespace }}.svc.{{ .Values.global.clusterDomain }};


### PR DESCRIPTION
Signed-off-by: Maarten De Wispelaere <maarten@bitprocessor.be>

Enable a flag to enable/disable verbose logging on the gateway. 
Today, the gateway (Nginx) logs thousands of useless HTTP requests, such as: 
```
10.2.74.12 - - [28/Sep/2021:14:05:52 +0000]  204 "POST /loki/api/v1/push HTTP/1.1" 0 "-" "GrafanaAgent/v0.18.3" "10.2.124.218"
10.2.74.12 - - [28/Sep/2021:14:05:52 +0000]  204 "POST /loki/api/v1/push HTTP/1.1" 0 "-" "GrafanaAgent/v0.18.3" "10.3.66.230"
10.2.143.173 - - [28/Sep/2021:14:05:52 +0000]  204 "POST /loki/api/v1/push HTTP/1.1" 0 "-" "GrafanaAgent/v0.18.3" "10.3.160.238"
10.2.176.2 - - [28/Sep/2021:14:05:52 +0000]  204 "POST /loki/api/v1/push HTTP/1.1" 0 "-" "GrafanaAgent/v0.18.3" "10.1.37.151"
10.2.176.2 - - [28/Sep/2021:14:05:52 +0000]  204 "POST /loki/api/v1/push HTTP/1.1" 0 "-" "GrafanaAgent/v0.18.3" "10.3.123.19"
10.2.74.12 - - [28/Sep/2021:14:05:52 +0000]  204 "POST /loki/api/v1/push HTTP/1.1" 0 "-" "GrafanaAgent/v0.18.3" "10.2.78.103"
10.2.176.2 - - [28/Sep/2021:14:05:52 +0000]  204 "POST /loki/api/v1/push HTTP/1.1" 0 "-" "GrafanaAgent/v0.18.3" "10.2.47.218"
10.2.74.12 - - [28/Sep/2021:14:05:52 +0000]  204 "POST /loki/api/v1/push HTTP/1.1" 0 "-" "GrafanaAgent/v0.18.3" "10.1.168.55"
10.2.143.173 - - [28/Sep/2021:14:05:52 +0000]  204 "POST /loki/api/v1/push HTTP/1.1" 0 "-" "GrafanaAgent/v0.18.3" "10.2.26.243"
```

The flag should disable logging of 2xx and 3xx http requests