### PR TITLE
[loki] fixes broken link to alerting/rules page for loki chart

### DIFF
--- a/charts/loki/README.md
+++ b/charts/loki/README.md
@@ -67,4 +67,4 @@ spec:
 
 You can add your own alerting rules with `alerting_groups` in `values.yaml`. This will create a ConfigMap with your rules and additional volumes and mounts for Loki.
 
-This does **not** enable the Loki `ruler` component which does the evaluation of your rules. The `values.yaml` file does contain a simple example. For more details take a look at the official [alerting docs](https://grafana.com/docs/loki/latest/alerting/).
+This does **not** enable the Loki `ruler` component which does the evaluation of your rules. The `values.yaml` file does contain a simple example. For more details take a look at the official [alerting docs](https://grafana.com/docs/loki/latest/rules/).


### PR DESCRIPTION
Fixes broken link in the Loki helm chart.

Old link: https://grafana.com/docs/loki/latest/alerting/
New link: https://grafana.com/docs/loki/latest/rules/

Signed-off-by: Rune Nielsen <runenielsen@runbox.com>