### PR TITLE
[enterprise-metrics] Add compactor to gateway

### DIFF
--- a/charts/enterprise-metrics/CHANGELOG.md
+++ b/charts/enterprise-metrics/CHANGELOG.md
@@ -10,6 +10,11 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the Pull Request that introduced the change.
 
+## 1.5.4
+
+* [BUGFIX] Adds a `Service` resource for the Compactor Pods and adds Compactor to the default set of gateway proxy URLs. In previous chart versions the Compactor would not show up in the GEM plugin "Ring Health" tab because the gateway did not know how to reach Compactor.
+
+
 ## 1.5.3
 
 * [BUGFIX] This change does not affect single replica deployments of the

--- a/charts/enterprise-metrics/Chart.yaml
+++ b/charts/enterprise-metrics/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.5.3
+version: 1.5.4
 appVersion: v1.5.0
 description: 'Grafana Enterprise Metrics'
 engine: gotpl

--- a/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-admin-api.yaml
+++ b/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-admin-api.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-admin-api
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-admin-api
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-admin-api
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-distributor.yaml
+++ b/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-distributor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-distributor
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-distributor
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-distributor
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-gateway.yaml
+++ b/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-gateway
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-gateway
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-gateway
         name: gateway
@@ -50,6 +50,7 @@ spec:
         - -gateway.proxy.query-frontend.url=http://enterprise-metrics-query-frontend.enterprise-metrics.svc:8080
         - -gateway.proxy.ruler.url=http://enterprise-metrics-ruler.enterprise-metrics.svc:8080
         - -gateway.proxy.store-gateway.url=http://enterprise-metrics-store-gateway.enterprise-metrics.svc:8080
+        - -gateway.proxy.compactor.url=http://enterprise-metrics-compactor.enterprise-metrics.svc:8080
         env: null
         image: grafana/metrics-enterprise:v1.5.0
         imagePullPolicy: IfNotPresent

--- a/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-overrides-exporter.yaml
+++ b/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-overrides-exporter.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-overrides-exporter
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-overrides-exporter
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-overrides-exporter
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-querier.yaml
+++ b/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-querier.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-querier
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-querier
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-querier
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-query-frontend.yaml
+++ b/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-query-frontend.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-query-frontend
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-query-frontend
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-query-frontend
         name: query-frontend

--- a/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-ruler.yaml
+++ b/charts/enterprise-metrics/exports/default/apps-v1.Deployment-enterprise-metrics-ruler.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-ruler
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-ruler
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-ruler
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/default/apps-v1.StatefulSet-enterprise-metrics-alertmanager.yaml
+++ b/charts/enterprise-metrics/exports/default/apps-v1.StatefulSet-enterprise-metrics-alertmanager.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-alertmanager
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-alertmanager
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-alertmanager
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/default/apps-v1.StatefulSet-enterprise-metrics-compactor.yaml
+++ b/charts/enterprise-metrics/exports/default/apps-v1.StatefulSet-enterprise-metrics-compactor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-compactor
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-compactor
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-compactor
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/default/apps-v1.StatefulSet-enterprise-metrics-ingester.yaml
+++ b/charts/enterprise-metrics/exports/default/apps-v1.StatefulSet-enterprise-metrics-ingester.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-ingester
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-ingester
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-ingester
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/default/apps-v1.StatefulSet-enterprise-metrics-store-gateway.yaml
+++ b/charts/enterprise-metrics/exports/default/apps-v1.StatefulSet-enterprise-metrics-store-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-store-gateway
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-store-gateway
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-store-gateway
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/default/batch-v1.Job-enterprise-metrics-tokengen.yaml
+++ b/charts/enterprise-metrics/exports/default/batch-v1.Job-enterprise-metrics-tokengen.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: enterprise-metrics-tokengen
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-tokengen

--- a/charts/enterprise-metrics/exports/default/manifest.json
+++ b/charts/enterprise-metrics/exports/default/manifest.json
@@ -27,6 +27,7 @@
     "v1.Service-enterprise-metrics-admin-api.yaml": "environments/default/main.jsonnet",
     "v1.Service-enterprise-metrics-alertmanager-headless.yaml": "environments/default/main.jsonnet",
     "v1.Service-enterprise-metrics-alertmanager.yaml": "environments/default/main.jsonnet",
+    "v1.Service-enterprise-metrics-compactor.yaml": "environments/default/main.jsonnet",
     "v1.Service-enterprise-metrics-distributor.yaml": "environments/default/main.jsonnet",
     "v1.Service-enterprise-metrics-gateway.yaml": "environments/default/main.jsonnet",
     "v1.Service-enterprise-metrics-gossip-ring.yaml": "environments/default/main.jsonnet",

--- a/charts/enterprise-metrics/exports/default/policy-v1beta1.PodSecurityPolicy-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/default/policy-v1beta1.PodSecurityPolicy-enterprise-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/default/rbac.authorization.k8s.io-v1.Role-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/default/rbac.authorization.k8s.io-v1.Role-enterprise-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/default/rbac.authorization.k8s.io-v1.RoleBinding-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/default/rbac.authorization.k8s.io-v1.RoleBinding-enterprise-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/default/v1.ConfigMap-enterprise-metrics-runtime.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.ConfigMap-enterprise-metrics-runtime.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-runtime

--- a/charts/enterprise-metrics/exports/default/v1.Secret-enterprise-metrics-license.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Secret-enterprise-metrics-license.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: enterprise-metrics-license
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-license

--- a/charts/enterprise-metrics/exports/default/v1.Secret-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Secret-enterprise-metrics.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-admin-api.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-admin-api.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-admin-api
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-admin-api

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-alertmanager-headless.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-alertmanager-headless.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-alertmanager
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-alertmanager-headless

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-alertmanager.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-alertmanager.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-alertmanager
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-alertmanager

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-compactor.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-compactor.yaml
@@ -2,12 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: enterprise-metrics-ingester
+    app: enterprise-metrics-compactor
     app.kubernetes.io/managed-by: Helmraiser
     chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
-  name: enterprise-metrics-ingester
+  name: enterprise-metrics-compactor
   namespace: enterprise-metrics
 spec:
   ports:
@@ -20,6 +20,6 @@ spec:
     protocol: TCP
     targetPort: grpc
   selector:
-    app: enterprise-metrics-ingester
+    app: enterprise-metrics-compactor
     release: enterprise-metrics
   type: ClusterIP

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-distributor.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-distributor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-distributor
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-distributor

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-gateway.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-gateway
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-gateway

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-gossip-ring.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-gossip-ring.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-gossip-ring
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-gossip-ring

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-overrides-exporter.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-overrides-exporter.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-overrides-exporter
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-overrides-exporter

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-querier.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-querier.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-querier
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-querier

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-query-frontend-headless.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-query-frontend-headless.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-query-frontend
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-query-frontend-headless

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-query-frontend.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-query-frontend.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-query-frontend
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-query-frontend

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-ruler.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-ruler.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-ruler
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-ruler

--- a/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-store-gateway.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.Service-enterprise-metrics-store-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-store-gateway
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-store-gateway

--- a/charts/enterprise-metrics/exports/default/v1.ServiceAccount-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/default/v1.ServiceAccount-enterprise-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-admin-api.yaml
+++ b/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-admin-api.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-admin-api
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-admin-api
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-admin-api
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-distributor.yaml
+++ b/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-distributor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-distributor
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-distributor
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-distributor
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-gateway.yaml
+++ b/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-gateway
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-gateway
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-gateway
         name: gateway
@@ -44,6 +44,7 @@ spec:
         - -gateway.proxy.query-frontend.url=http://enterprise-metrics-query-frontend.enterprise-metrics.svc:8080
         - -gateway.proxy.ruler.url=http://enterprise-metrics-ruler.enterprise-metrics.svc:8080
         - -gateway.proxy.store-gateway.url=http://enterprise-metrics-store-gateway.enterprise-metrics.svc:8080
+        - -gateway.proxy.compactor.url=http://enterprise-metrics-compactor.enterprise-metrics.svc:8080
         env: null
         image: grafana/metrics-enterprise:v1.5.0
         imagePullPolicy: IfNotPresent

--- a/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-overrides-exporter.yaml
+++ b/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-overrides-exporter.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-overrides-exporter
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-overrides-exporter
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-overrides-exporter
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-querier.yaml
+++ b/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-querier.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-querier
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-querier
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-querier
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-query-frontend.yaml
+++ b/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-query-frontend.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-query-frontend
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-query-frontend
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-query-frontend
         name: query-frontend

--- a/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-ruler.yaml
+++ b/charts/enterprise-metrics/exports/large/apps-v1.Deployment-enterprise-metrics-ruler.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-ruler
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-ruler
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-ruler
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/large/apps-v1.StatefulSet-enterprise-metrics-alertmanager.yaml
+++ b/charts/enterprise-metrics/exports/large/apps-v1.StatefulSet-enterprise-metrics-alertmanager.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-alertmanager
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-alertmanager
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-alertmanager
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/large/apps-v1.StatefulSet-enterprise-metrics-compactor.yaml
+++ b/charts/enterprise-metrics/exports/large/apps-v1.StatefulSet-enterprise-metrics-compactor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-compactor
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-compactor
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-compactor
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/large/apps-v1.StatefulSet-enterprise-metrics-ingester.yaml
+++ b/charts/enterprise-metrics/exports/large/apps-v1.StatefulSet-enterprise-metrics-ingester.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-ingester
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-ingester
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-ingester
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/large/apps-v1.StatefulSet-enterprise-metrics-store-gateway.yaml
+++ b/charts/enterprise-metrics/exports/large/apps-v1.StatefulSet-enterprise-metrics-store-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-store-gateway
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-store-gateway
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-store-gateway
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/large/batch-v1.Job-enterprise-metrics-tokengen.yaml
+++ b/charts/enterprise-metrics/exports/large/batch-v1.Job-enterprise-metrics-tokengen.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: enterprise-metrics-tokengen
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-tokengen

--- a/charts/enterprise-metrics/exports/large/manifest.json
+++ b/charts/enterprise-metrics/exports/large/manifest.json
@@ -23,6 +23,7 @@
     "v1.Service-enterprise-metrics-admin-api.yaml": "environments/large/main.jsonnet",
     "v1.Service-enterprise-metrics-alertmanager-headless.yaml": "environments/large/main.jsonnet",
     "v1.Service-enterprise-metrics-alertmanager.yaml": "environments/large/main.jsonnet",
+    "v1.Service-enterprise-metrics-compactor.yaml": "environments/large/main.jsonnet",
     "v1.Service-enterprise-metrics-distributor.yaml": "environments/large/main.jsonnet",
     "v1.Service-enterprise-metrics-gateway.yaml": "environments/large/main.jsonnet",
     "v1.Service-enterprise-metrics-gossip-ring.yaml": "environments/large/main.jsonnet",

--- a/charts/enterprise-metrics/exports/large/policy-v1beta1.PodSecurityPolicy-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/large/policy-v1beta1.PodSecurityPolicy-enterprise-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/large/rbac.authorization.k8s.io-v1.Role-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/large/rbac.authorization.k8s.io-v1.Role-enterprise-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/large/rbac.authorization.k8s.io-v1.RoleBinding-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/large/rbac.authorization.k8s.io-v1.RoleBinding-enterprise-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/large/v1.ConfigMap-enterprise-metrics-runtime.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.ConfigMap-enterprise-metrics-runtime.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-runtime

--- a/charts/enterprise-metrics/exports/large/v1.Secret-enterprise-metrics-license.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Secret-enterprise-metrics-license.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: enterprise-metrics-license
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-license

--- a/charts/enterprise-metrics/exports/large/v1.Secret-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Secret-enterprise-metrics.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-admin-api.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-admin-api.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-admin-api
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-admin-api

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-alertmanager-headless.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-alertmanager-headless.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-alertmanager
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-alertmanager-headless

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-alertmanager.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-alertmanager.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-alertmanager
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-alertmanager

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-compactor.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-compactor.yaml
@@ -2,12 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: enterprise-metrics-ingester
+    app: enterprise-metrics-compactor
     app.kubernetes.io/managed-by: Helmraiser
     chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
-  name: enterprise-metrics-ingester
+  name: enterprise-metrics-compactor
   namespace: enterprise-metrics
 spec:
   ports:
@@ -20,6 +20,6 @@ spec:
     protocol: TCP
     targetPort: grpc
   selector:
-    app: enterprise-metrics-ingester
+    app: enterprise-metrics-compactor
     release: enterprise-metrics
   type: ClusterIP

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-distributor.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-distributor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-distributor
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-distributor

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-gateway.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-gateway
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-gateway

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-gossip-ring.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-gossip-ring.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-gossip-ring
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-gossip-ring

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-ingester.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-ingester.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-ingester
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-ingester

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-overrides-exporter.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-overrides-exporter.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-overrides-exporter
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-overrides-exporter

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-querier.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-querier.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-querier
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-querier

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-query-frontend-headless.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-query-frontend-headless.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-query-frontend
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-query-frontend-headless

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-query-frontend.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-query-frontend.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-query-frontend
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-query-frontend

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-ruler.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-ruler.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-ruler
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-ruler

--- a/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-store-gateway.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.Service-enterprise-metrics-store-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-store-gateway
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-store-gateway

--- a/charts/enterprise-metrics/exports/large/v1.ServiceAccount-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/large/v1.ServiceAccount-enterprise-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-admin-api.yaml
+++ b/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-admin-api.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-admin-api
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-admin-api
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-admin-api
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-distributor.yaml
+++ b/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-distributor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-distributor
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-distributor
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-distributor
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-gateway.yaml
+++ b/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-gateway
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-gateway
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-gateway
         name: gateway
@@ -44,6 +44,7 @@ spec:
         - -gateway.proxy.query-frontend.url=http://enterprise-metrics-query-frontend.enterprise-metrics.svc:8080
         - -gateway.proxy.ruler.url=http://enterprise-metrics-ruler.enterprise-metrics.svc:8080
         - -gateway.proxy.store-gateway.url=http://enterprise-metrics-store-gateway.enterprise-metrics.svc:8080
+        - -gateway.proxy.compactor.url=http://enterprise-metrics-compactor.enterprise-metrics.svc:8080
         env: null
         image: grafana/metrics-enterprise:v1.5.0
         imagePullPolicy: IfNotPresent

--- a/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-overrides-exporter.yaml
+++ b/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-overrides-exporter.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-overrides-exporter
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-overrides-exporter
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-overrides-exporter
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-querier.yaml
+++ b/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-querier.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-querier
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-querier
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-querier
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-query-frontend.yaml
+++ b/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-query-frontend.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-query-frontend
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-query-frontend
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-query-frontend
         name: query-frontend

--- a/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-ruler.yaml
+++ b/charts/enterprise-metrics/exports/small/apps-v1.Deployment-enterprise-metrics-ruler.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-ruler
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-ruler
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-ruler
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/small/apps-v1.StatefulSet-enterprise-metrics-alertmanager.yaml
+++ b/charts/enterprise-metrics/exports/small/apps-v1.StatefulSet-enterprise-metrics-alertmanager.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-alertmanager
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-alertmanager
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-alertmanager
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/small/apps-v1.StatefulSet-enterprise-metrics-compactor.yaml
+++ b/charts/enterprise-metrics/exports/small/apps-v1.StatefulSet-enterprise-metrics-compactor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-compactor
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-compactor
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-compactor
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/small/apps-v1.StatefulSet-enterprise-metrics-ingester.yaml
+++ b/charts/enterprise-metrics/exports/small/apps-v1.StatefulSet-enterprise-metrics-ingester.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-ingester
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-ingester
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-ingester
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/small/apps-v1.StatefulSet-enterprise-metrics-store-gateway.yaml
+++ b/charts/enterprise-metrics/exports/small/apps-v1.StatefulSet-enterprise-metrics-store-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-store-gateway
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-store-gateway
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93cf89a64608de5bc05baa30b88909afef562ee4b581fd2f3aed3dafc266dc64
+        checksum/config: dcd1d2d2eb8582155a10a02bd431b2c8762d76d73c9ea4ba4db9ce459135cea9
       labels:
         app: enterprise-metrics-store-gateway
         gossip_ring_member: "true"

--- a/charts/enterprise-metrics/exports/small/batch-v1.Job-enterprise-metrics-tokengen.yaml
+++ b/charts/enterprise-metrics/exports/small/batch-v1.Job-enterprise-metrics-tokengen.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: enterprise-metrics-tokengen
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-tokengen

--- a/charts/enterprise-metrics/exports/small/manifest.json
+++ b/charts/enterprise-metrics/exports/small/manifest.json
@@ -23,6 +23,7 @@
     "v1.Service-enterprise-metrics-admin-api.yaml": "environments/small/main.jsonnet",
     "v1.Service-enterprise-metrics-alertmanager-headless.yaml": "environments/small/main.jsonnet",
     "v1.Service-enterprise-metrics-alertmanager.yaml": "environments/small/main.jsonnet",
+    "v1.Service-enterprise-metrics-compactor.yaml": "environments/small/main.jsonnet",
     "v1.Service-enterprise-metrics-distributor.yaml": "environments/small/main.jsonnet",
     "v1.Service-enterprise-metrics-gateway.yaml": "environments/small/main.jsonnet",
     "v1.Service-enterprise-metrics-gossip-ring.yaml": "environments/small/main.jsonnet",

--- a/charts/enterprise-metrics/exports/small/policy-v1beta1.PodSecurityPolicy-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/small/policy-v1beta1.PodSecurityPolicy-enterprise-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/small/rbac.authorization.k8s.io-v1.Role-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/small/rbac.authorization.k8s.io-v1.Role-enterprise-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/small/rbac.authorization.k8s.io-v1.RoleBinding-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/small/rbac.authorization.k8s.io-v1.RoleBinding-enterprise-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/small/v1.ConfigMap-enterprise-metrics-runtime.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.ConfigMap-enterprise-metrics-runtime.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-runtime

--- a/charts/enterprise-metrics/exports/small/v1.Secret-enterprise-metrics-license.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Secret-enterprise-metrics-license.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: enterprise-metrics-license
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-license

--- a/charts/enterprise-metrics/exports/small/v1.Secret-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Secret-enterprise-metrics.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-admin-api.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-admin-api.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-admin-api
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-admin-api

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-alertmanager-headless.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-alertmanager-headless.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-alertmanager
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-alertmanager-headless

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-alertmanager.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-alertmanager.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-alertmanager
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-alertmanager

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-compactor.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-compactor.yaml
@@ -2,12 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: enterprise-metrics-ingester
+    app: enterprise-metrics-compactor
     app.kubernetes.io/managed-by: Helmraiser
     chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
-  name: enterprise-metrics-ingester
+  name: enterprise-metrics-compactor
   namespace: enterprise-metrics
 spec:
   ports:
@@ -20,6 +20,6 @@ spec:
     protocol: TCP
     targetPort: grpc
   selector:
-    app: enterprise-metrics-ingester
+    app: enterprise-metrics-compactor
     release: enterprise-metrics
   type: ClusterIP

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-distributor.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-distributor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-distributor
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-distributor

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-gateway.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-gateway
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-gateway

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-gossip-ring.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-gossip-ring.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-gossip-ring
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-gossip-ring

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-ingester.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-ingester.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-ingester
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-ingester

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-overrides-exporter.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-overrides-exporter.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-overrides-exporter
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-overrides-exporter

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-querier.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-querier.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-querier
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-querier

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-query-frontend-headless.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-query-frontend-headless.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-query-frontend
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-query-frontend-headless

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-query-frontend.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-query-frontend.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-query-frontend
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-query-frontend

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-ruler.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-ruler.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-ruler
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-ruler

--- a/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-store-gateway.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.Service-enterprise-metrics-store-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics-store-gateway
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics-store-gateway

--- a/charts/enterprise-metrics/exports/small/v1.ServiceAccount-enterprise-metrics.yaml
+++ b/charts/enterprise-metrics/exports/small/v1.ServiceAccount-enterprise-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: enterprise-metrics
     app.kubernetes.io/managed-by: Helmraiser
-    chart: enterprise-metrics-1.5.3
+    chart: enterprise-metrics-1.5.4
     heritage: Helm
     release: enterprise-metrics
   name: enterprise-metrics

--- a/charts/enterprise-metrics/templates/compactor-svc.yaml
+++ b/charts/enterprise-metrics/templates/compactor-svc.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "enterprise-metrics.fullname" . }}-compactor
+  labels:
+    app: {{ template "enterprise-metrics.name" . }}-compactor
+    chart: {{ template "enterprise-metrics.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- with .Values.compactor.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- toYaml .Values.compactor.service.annotations | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.config.server.http_listen_port }}
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: {{ .Values.config.server.grpc_listen_port }}
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app: {{ template "enterprise-metrics.name" . }}-compactor
+    release: {{ .Release.Name }}

--- a/charts/enterprise-metrics/templates/gateway-dep.yaml
+++ b/charts/enterprise-metrics/templates/gateway-dep.yaml
@@ -77,6 +77,7 @@ spec:
             - -gateway.proxy.query-frontend.url=http://{{ template "enterprise-metrics.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
             - -gateway.proxy.ruler.url=http://{{ template "enterprise-metrics.fullname" . }}-ruler.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
             - -gateway.proxy.store-gateway.url=http://{{ template "enterprise-metrics.fullname" . }}-store-gateway.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
+            - -gateway.proxy.compactor.url=http://{{ template "enterprise-metrics.fullname" . }}-compactor.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
             {{- end }}
             {{- range $key, $value := .Values.gateway.extraArgs }}
             - "-{{ $key }}={{ $value }}"


### PR DESCRIPTION
Before this PR the compactor showed as broken in the "Ring Health" tab of the GEM plugin. This was because the gateway did not have a compactor URL configured, and even if it did there was no Service in front of the compactor pods. 

This PR adds a Service for the compactor Pods and configures the gateway to use that Service to reach compactor.