### PR TITLE
[loki] fix: chart loki install on Kubernetes >= 1.22

### DIFF
--- a/charts/loki/templates/ingress.yaml
+++ b/charts/loki/templates/ingress.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "loki.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.Version -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.Version -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -31,15 +33,33 @@ spec:
   {{- end }}
 {{- end }}
   rules:
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
   {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+        {{- end }}
+  {{- end }}
+{{- else }}
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            pathType: Prefix
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+{{- end -}}
         {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Fix installation problem of chart loki on Kubernetes >= 1.22.

According to https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122, The networking.k8s.io/v1beta1 API versions of Ingress is no longer served as of Kubernetes v1.22.

Signed-off-by: Senorsen <senorsen.zhang@gmail.com>