### PR TITLE
[tempo] Fix indentation of tempo annotations

### DIFF
--- a/charts/tempo/templates/service.yaml
+++ b/charts/tempo/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "tempo.labels" . | nindent 4 }}
   {{- with .Values.annotations }}
   annotations:
-    {{ toYaml . | indent 4 }}
+    {{- toYaml . | indent 4 }}
   {{- end }}
 spec:
 {{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}


### PR DESCRIPTION
Annotations were being indented incorrectly in the tempo service template for me.

For example this in `values.yaml`:

```yaml
annotations:
  prometheus.io/scheme: http
  prometheus.io/path: "/metrics"
  prometheus.io/port: "3100"
  prometheus.io/scrape: "true"
```

resulted in this output from the service.yaml template:

```yaml
    annotations:
          prometheus.io/path: /metrics
      prometheus.io/port: "3100"
      prometheus.io/scheme: http
      prometheus.io/scrape: "true"
```

The solution is to use the `-` modifier to remove whitespace at the start of the YAML so that it gets aligned correctly

---

I've never contributed here before, so let me know if there's any changes needed to get this merged!