### PR TITLE
agent-operator: add hyphenated resources to RBAC

### DIFF
--- a/charts/agent-operator/templates/operator-clusterrole.yaml
+++ b/charts/agent-operator/templates/operator-clusterrole.yaml
@@ -9,15 +9,21 @@ metadata:
 rules:
 - apiGroups: [monitoring.grafana.com]
   resources:
+  - grafana-agents
   - grafanaagents
-  - metricsinstances
+  - logs-instances
   - logsinstances
+  - metrics-instances
+  - metricsinstances
+  - pod-logs
   - podlogs
   verbs: [get, list, watch]
 - apiGroups: [monitoring.coreos.com]
   resources:
+  - pod-monitors
   - podmonitors
   - probes
+  - service-monitors
   - servicemonitors
   verbs: [get, list, watch]
 - apiGroups: [""]


### PR DESCRIPTION
Agent v0.19.0 still seems to be using hyphenated resources in its API
queries.

Should be reverted once https://github.com/grafana/agent/issues/1023
is fixed.