### PR TITLE
[loki-distributed] Switch metric list order in HPAs

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.4.1
-version: 0.39.1
+version: 0.39.2
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.39.1](https://img.shields.io/badge/Version-0.39.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.1](https://img.shields.io/badge/AppVersion-2.4.1-informational?style=flat-square)
+![Version: 0.39.2](https://img.shields.io/badge/Version-0.39.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.1](https://img.shields.io/badge/AppVersion-2.4.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/templates/distributor/hpa.yaml
+++ b/charts/loki-distributed/templates/distributor/hpa.yaml
@@ -13,16 +13,16 @@ spec:
   minReplicas: {{ .Values.distributor.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.distributor.autoscaling.maxReplicas }}
   metrics:
-  {{- with .Values.distributor.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: {{ . }}
-  {{- end }}
   {{- with .Values.distributor.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
+        targetAverageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.distributor.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
         targetAverageUtilization: {{ . }}
   {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/gateway/hpa.yaml
+++ b/charts/loki-distributed/templates/gateway/hpa.yaml
@@ -13,16 +13,16 @@ spec:
   minReplicas: {{ .Values.gateway.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.gateway.autoscaling.maxReplicas }}
   metrics:
-  {{- with .Values.gateway.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: {{ . }}
-  {{- end }}
   {{- with .Values.gateway.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
+        targetAverageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.gateway.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
         targetAverageUtilization: {{ . }}
   {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/querier/hpa.yaml
+++ b/charts/loki-distributed/templates/querier/hpa.yaml
@@ -13,16 +13,16 @@ spec:
   minReplicas: {{ .Values.querier.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.querier.autoscaling.maxReplicas }}
   metrics:
-  {{- with .Values.querier.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: {{ . }}
-  {{- end }}
   {{- with .Values.querier.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
+        targetAverageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.querier.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
         targetAverageUtilization: {{ . }}
   {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/query-frontend/hpa.yaml
+++ b/charts/loki-distributed/templates/query-frontend/hpa.yaml
@@ -13,16 +13,16 @@ spec:
   minReplicas: {{ .Values.queryFrontend.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.queryFrontend.autoscaling.maxReplicas }}
   metrics:
-  {{- with .Values.queryFrontend.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: {{ . }}
-  {{- end }}
   {{- with .Values.queryFrontend.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
+        targetAverageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.queryFrontend.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
         targetAverageUtilization: {{ . }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
What this PR does / why we need it:

Reorders the list in `spec.metrics` for all components' HPAs in order to circumvent issue kubernetes/kubernetes#74099. Without this change, GitOps style CD tools such as Argo will consider the HPAs permanently out of sync due to the following discrepancy:

![image](https://user-images.githubusercontent.com/54322109/138904176-5998bbfa-d587-487a-89ff-2becda691c0b.png)

