### PR TITLE
[grafana] Bump up tag image

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.17.3
-appVersion: 8.2.1
+version: 6.17.4
+appVersion: 8.2.2
 kubeVersion: '^1.8.0-0'
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -59,8 +59,8 @@ This version requires Helm >= 3.1.0.
 | `securityContext`                         | Deployment securityContext                    | `{"runAsUser": 472, "runAsGroup": 472, "fsGroup": 472}`  |
 | `priorityClassName`                       | Name of Priority Class to assign pods         | `nil`                                                   |
 | `image.repository`                        | Image repository                              | `grafana/grafana`                                       |
-| `image.tag`                               | Image tag (`Must be >= 5.0.0`)                | `8.0.3`                                                 |
-| `image.sha`                               | Image sha (optional)                          | `80c6d6ac633ba5ab3f722976fb1d9a138f87ca6a9934fcd26a5fc28cbde7dbfa` |
+| `image.tag`                               | Image tag (`Must be >= 5.0.0`)                | `8.2.2`                                                 |
+| `image.sha`                               | Image sha (optional)                          | `7f4be45518fd94dcbb0d5926d26eb5aaca86af0950a8e97cb90e166185730c42` |
 | `image.pullPolicy`                        | Image pull policy                             | `IfNotPresent`                                          |
 | `image.pullSecrets`                       | Image pull secrets                            | `{}`                                                    |
 | `service.enabled`                         | Enable grafana service                        | `true`                                                  |

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -70,7 +70,7 @@ livenessProbe:
 
 image:
   repository: grafana/grafana
-  tag: 8.2.1
+  tag: 8.2.2
   sha: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Bump up image tag grafana


Update image tag in chart. It is actually 8.2.2
https://github.com/grafana/grafana/releases/tag/v8.2.2


PR Checklist
- [x] Chart Version bumped
- [x] Variables and other changes are documented in the README.md