### PR TITLE
[tempo] Fix podLabels

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 0.8.0
+version: 0.8.1
 appVersion: 1.1.0
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 
@@ -21,6 +21,7 @@ Grafana Tempo Single Binary Mode
 | persistence.enabled | bool | `false` |  |
 | persistence.size | string | `"10Gi"` |  |
 | podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
 | replicas | int | `1` |  |
 | service.annotations | object | `{}` |  |
 | service.labels | object | `{}` |  |

--- a/charts/tempo/templates/statefulset.yaml
+++ b/charts/tempo/templates/statefulset.yaml
@@ -20,7 +20,7 @@ spec:
       labels:
         {{- include "tempo.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
-          {{ toYaml . | indent 8 }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
         {{- with .Values.podAnnotations }}

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -136,6 +136,9 @@ persistence:
 ## Pod Annotations
 podAnnotations: {}
 
+## Pod (extra) Labels
+podLabels: {}
+
 # -- Volumes to add
 extraVolumes: []
 


### PR DESCRIPTION
Hi there!

Just did a small fix concerning `podLabels` in the `tempo` chart. Before, when using `podLabels`, rendering the chart resulted in such output:

```
Error: YAML parse error on tempo/templates/statefulset.yaml: error converting YAML to JSON: yaml: line 24: mapping values are not allowed in this context

Use --debug flag to render out invalid YAML
```

I aligned the templating to the way it is done for annotations and also added an explicit `podLabels` default value in `values.yaml`.

Signed-off-by: Joshua Mühlfort <muehlfort@gonicus.de>