### PR TITLE
[loki-distributed] Fix automountServiceAccountToken for compactor

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.4.1
-version: 0.39.3
+version: 0.39.4
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.39.3](https://img.shields.io/badge/Version-0.39.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.1](https://img.shields.io/badge/AppVersion-2.4.1-informational?style=flat-square)
+![Version: 0.39.4](https://img.shields.io/badge/Version-0.39.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.1](https://img.shields.io/badge/AppVersion-2.4.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/templates/compactor/serviceaccount-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/serviceaccount-compactor.yaml
@@ -9,8 +9,8 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- with .Values.compactor.serviceAccount.imagePullSecrets }}
 automountServiceAccountToken: {{ .Values.compactor.serviceAccount.automountServiceAccountToken }}
+{{- with .Values.compactor.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Ankit Mehta <ankit.mehta@appian.com>

Similar to https://github.com/grafana/helm-charts/pull/538, fixing the service account for compactor so it can add the automountServiceAccountToken to the SA.