### PR TITLE
[agent-operator] Fix indentation on podAnnotations

### DIFF
--- a/charts/agent-operator/Chart.yaml
+++ b/charts/agent-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: grafana-agent-operator
 description: A Helm chart for Grafana Agent Operator
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "0.20.0"
 home: https://grafana.com/docs/agent/latest/
 icon: https://raw.githubusercontent.com/grafana/agent/v0.20.0/docs/assets/logo_and_name.png

--- a/charts/agent-operator/README.md
+++ b/charts/agent-operator/README.md
@@ -1,6 +1,6 @@
 # grafana-agent-operator
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.20.0](https://img.shields.io/badge/AppVersion-0.20.0-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.20.0](https://img.shields.io/badge/AppVersion-0.20.0-informational?style=flat-square)
 
 A Helm chart for Grafana Agent Operator
 

--- a/charts/agent-operator/templates/operator-deployment.yaml
+++ b/charts/agent-operator/templates/operator-deployment.yaml
@@ -20,7 +20,7 @@ spec:
 {{ include "ga-operator.labels" . | indent 8 }}
 {{- with .Values.podAnnotations }}
       annotations:
-{{ toYaml . | indent 6 }}
+{{ toYaml . | indent 8 }}
 {{- end }}
     spec:
       serviceAccountName: {{ template "ga-operator.serviceAccountName" . }}


### PR DESCRIPTION
`podAnnotations` was not indented enough, causing validation to fail when trying to deploy with `podAnnotations`.

Signed-off-by: Anders Østhus <anders.osthus@gmail.com>