### PR TITLE
ci: run only one concurrent release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
 
+concurrency: release
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Ensures that only one concurrent `release` workflow is running at the moment to prevent race condition when updating Helm repository index file.

Fixes https://github.com/grafana/helm-charts/issues/783.