### PR TITLE
Prevent concurrent execution of release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
 
+concurrency: release
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should prevent the issue that one pipeline creates a release, while the next execution which is happening in parallel is removing it again.

This issue can be seen in:
- https://github.com/grafana/helm-charts/commit/3d615d4e3fd4bd787006106d21af04a771645301
  where loki-distributed 2.4.1 was added
- https://github.com/grafana/helm-charts/commit/36ff520bca9142f52a1b087528f8b93898b7fce0
  where promtail 2.4.1 was added, but loki-distributed 2.4.1 removed again

> When a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be pending. Any previously pending job or workflow in the concurrency group will be canceled.
https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency

This behavior is not ideal as previously pending jobs will be canceled.
In that case no release will be created for it. I hope that we are able to re-run the jobs to trigger a release. So this is not a final solution.

It favors not releasing something over removing already release things.