### PR TITLE
[loki] Make entire tmp dir writable

### DIFF
--- a/charts/loki/templates/statefulset.yaml
+++ b/charts/loki/templates/statefulset.yaml
@@ -71,7 +71,7 @@ spec:
               subPath: {{ .Values.persistence.subPath }}
             {{- if gt (len .Values.alerting_groups) 0 }}
             - name: scratch
-              mountPath: /tmp/scratch
+              mountPath: /tmp
             - name: rules
               mountPath: /rules
             {{- end }}


### PR DESCRIPTION
Because `securityContext.readOnlyRootFilesystem: true` boltdb cannot write to `tmp` which it seems to do to update its markers. The log if filled with errors that it cannot perform a write operation in `tmp`. By changing the scratch directory to the entire `tmp` folder, the problem is fixed because the empty folder is writable by the loki user.