### PR TITLE
[loki-distributed] Add 'grpclb' port to query-frontend service

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.4.1
-version: 0.39.2
+version: 0.39.3
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.39.2](https://img.shields.io/badge/Version-0.39.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.1](https://img.shields.io/badge/AppVersion-2.4.1-informational?style=flat-square)
+![Version: 0.39.3](https://img.shields.io/badge/Version-0.39.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.1](https://img.shields.io/badge/AppVersion-2.4.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/templates/query-frontend/service-query-frontend.yaml
+++ b/charts/loki-distributed/templates/query-frontend/service-query-frontend.yaml
@@ -19,5 +19,9 @@ spec:
       port: 9095
       targetPort: grpc
       protocol: TCP
+    - name: grpclb
+      port: 9096
+      targetPort: grpc
+      protocol: TCP
   selector:
     {{- include "loki.queryFrontendSelectorLabels" . | nindent 4 }}


### PR DESCRIPTION
Fixes #801, albeit not necessarily the right way about it...

From a maintenance perspective it's fragile to just add a duplicate port like that, and from a BC perspective we can't necessarily just rename the old one either.

There's definitely something that needs to happen, but I'm not sure this is it, even though it does the trick.