### PR TITLE
[loki-distributed] allow configuring storage backend with chart values

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.4.2
-version: 0.40.0
+version: 0.41.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.40.0](https://img.shields.io/badge/Version-0.40.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
+![Version: 0.41.0](https://img.shields.io/badge/Version-0.41.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 
@@ -213,6 +213,8 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | loki.readinessProbe.initialDelaySeconds | int | `30` |  |
 | loki.readinessProbe.timeoutSeconds | int | `1` |  |
 | loki.revisionHistoryLimit | int | `10` | The number of old ReplicaSets to retain to allow rollback |
+| loki.schemaConfig | object | `{"configs":[{"from":"2020-09-07","index":{"period":"24h","prefix":"loki_index_"},"object_store":"filesystem","schema":"v11","store":"boltdb-shipper"}]}` | Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas |
+| loki.storageConfig | object | `{"boltdb_shipper":{"active_index_directory":"/var/loki/index","cache_location":"/var/loki/cache","cache_ttl":"168h","shared_store":"filesystem"},"filesystem":{"directory":"/var/loki/chunks"}}` | Check https://grafana.com/docs/loki/latest/configuration/#storage_config for more info on how to configure storages |
 | memcached.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The SecurityContext for memcached containers |
 | memcached.image.pullPolicy | string | `"IfNotPresent"` | Memcached Docker image pull policy |
 | memcached.image.registry | string | `"docker.io"` | The Docker registry for the memcached |

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -93,28 +93,18 @@ loki:
       reject_old_samples_max_age: 168h
       max_cache_freshness_per_query: 10m
 
+    {{- if .Values.loki.schemaConfig}}
     schema_config:
-      configs:
-        - from: 2020-09-07
-          store: boltdb-shipper
-          object_store: filesystem
-          schema: v11
-          index:
-            prefix: loki_index_
-            period: 24h
-
+    {{- toYaml .Values.loki.schemaConfig | nindent 2}}
+    {{- end}}
+    {{- if .Values.loki.storageConfig}}
     storage_config:
-      boltdb_shipper:
-        shared_store: filesystem
-        active_index_directory: /var/loki/index
-        cache_location: /var/loki/cache
-        cache_ttl: 168h
-        {{- if .Values.indexGateway.enabled }}
-        index_gateway_client:
-          server_address: dns:///{{ include "loki.indexGatewayFullname" . }}:9095
-        {{- end }}
-      filesystem:
-        directory: /var/loki/chunks
+    {{- toYaml .Values.loki.storageConfig | nindent 2}}
+    {{- if .Values.indexGateway.enabled}}
+      index_gateway_client:
+        server_address: dns:///{{ include "loki.indexGatewayFullname" . }}:9095
+    {{- end}}
+    {{- end}}
 
     chunk_store_config:
       max_look_back_period: 0s
@@ -157,6 +147,32 @@ loki:
       rule_path: /tmp/loki/scratch
       alertmanager_url: https://alertmanager.xx
       external_url: https://alertmanager.xx
+
+  # -- Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas
+  schemaConfig:
+    configs:
+    - from: 2020-09-07
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: loki_index_
+        period: 24h
+
+  # -- Check https://grafana.com/docs/loki/latest/configuration/#storage_config for more info on how to configure storages
+  storageConfig:
+    boltdb_shipper:
+      shared_store: filesystem
+      active_index_directory: /var/loki/index
+      cache_location: /var/loki/cache
+      cache_ttl: 168h
+    filesystem:
+      directory: /var/loki/chunks
+# -- Uncomment to configure each storage individually
+#   azure: {}
+#   gcs: {}
+#   s3: {}
+#   boltdb: {}
 
 serviceAccount:
   # -- Specifies whether a ServiceAccount should be created


### PR DESCRIPTION
Hi!

This is the second time I'll try to merge this PR, sorry for the insistence, but I think it is a very useful way to configure the backend storage without needing to rewrite the whole config, I've been using a fork for a long time and if this was finally merged it would be great. Since my first PR, another one was made and accepted but never got merged (https://github.com/grafana/helm-charts/pull/521).

The helm chart of tempo-distributed already implements a similar approach.


I've added `schemaConfig ` and `storageConfig ` to allow us to configure different storages without needing to overwrite the whole config string that is used to create the config map.

The default behaviour is still using the same values:

```
loki:
  schemaConfig:
    configs:
      - from: 2020-09-07
        store: boltdb-shipper
        object_store: filesystem
        schema: v11
        index:
          prefix: loki_index_
          period: 24h

  storageConfig:
    boltdb_shipper:
      shared_store: filesystem
      active_index_directory: /var/loki/index
      cache_location: /var/loki/cache
      cache_ttl: 168h
    filesystem:
      directory: /var/loki/chunks
```

but we can now overwrite it with each specific storage, e.g., azure:

```
loki:
  schemaConfig:
    configs:
    - from: "2018-04-15"
      index:
        period: 168h
        prefix: index_
      object_store: filesystem
      schema: v9
      store: boltdb
    - from: "2020-09-28"
      store: boltdb-shipper
      object_store: azure
      schema: v11
      index:
        prefix: loki_index_
        period: 24h

  storageConfig:
    boltdb:
      directory: /var/loki/index
    filesystem:
      directory: /var/loki/chunks
    azure:
      container_name: <REDACTED>
      account_name: <REDACTED>
      account_key: <REDACTED>
      request_timeout: 0
    boltdb_shipper:
      active_index_directory: /var/loki/index
      shared_store: azure
      cache_location: /var/loki/cache
```

Thanks!

Signed-off-by: Marco Amador <amador.marco@gmail.com>