### PR TITLE
[grafana] Remove duplicate use of extraEmptyDirMounts

### DIFF
--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -120,7 +120,6 @@ This version requires Helm >= 3.1.0.
 | `extraSecretMounts`                       | Additional grafana server secret mounts       | `[]`                                                    |
 | `extraVolumeMounts`                       | Additional grafana server volume mounts       | `[]`                                                    |
 | `extraConfigmapMounts`                    | Additional grafana server configMap volume mounts | `[]`                                                |
-| `extraEmptyDirMounts`                     | Additional grafana server emptyDir volume mounts | `[]`                                                 |
 | `plugins`                                 | Plugins to be loaded along with Grafana       | `[]`                                                    |
 | `datasources`                             | Configure grafana datasources (passed through tpl) | `{}`                                               |
 | `notifiers`                               | Configure grafana notifiers                   | `{}`                                                    |

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -309,10 +309,6 @@ containers:
         subPath: {{ .subPath | default "" }}
         readOnly: {{ .readOnly }}
     {{- end }}
-    {{- range .Values.extraEmptyDirMounts }}
-      - name: {{ .name }}
-        mountPath: {{ .mountPath }}
-    {{- end }}
     ports:
       - name: {{ .Values.service.portName }}
         containerPort: {{ .Values.service.port }}
@@ -511,10 +507,6 @@ volumes:
     emptyDir: {}
     {{- end }}
 {{- end }}
-{{- range .Values.extraEmptyDirMounts }}
-  - name: {{ .name }}
-    emptyDir: {}
-{{- end -}}
 {{- if .Values.extraContainerVolumes }}
 {{ toYaml .Values.extraContainerVolumes | indent 2 }}
 {{- end }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -103,12 +103,6 @@ extraConfigmapMounts: []
   #   configMap: certs-configmap
   #   readOnly: true
 
-
-extraEmptyDirMounts: []
-  # - name: provisioning-notifiers
-  #   mountPath: /etc/grafana/provisioning/notifiers
-
-
 # Apply extra labels to common labels.
 extraLabels: {}
 


### PR DESCRIPTION
related to #362 
extraVolumeMounts contains extraEmptyDirMounts so extraEmptyDirMounts is unnecessary.

It's my first time to PR. Please tell me if there's anything against Contributing Guidelines.
