### PR TITLE
[tempo-distributed] Add relabeling configuration to ServiceMonitors

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.11.0
+version: 0.11.1
 appVersion: 1.2.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 0.11.1](https://img.shields.io/badge/Version-0.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -243,6 +243,7 @@ The memcached default args are removed and should be provided manually. The sett
 | serviceMonitor.labels | object | `{}` | Additional ServiceMonitor labels |
 | serviceMonitor.namespace | string | `nil` | Alternative namespace for ServiceMonitor resources |
 | serviceMonitor.namespaceSelector | object | `{}` | Namespace selector for ServiceMonitor resources |
+| serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig |
 | serviceMonitor.scheme | string | `"http"` | ServiceMonitor will use http by default, but you can pick https as well |
 | serviceMonitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | serviceMonitor.tlsConfig | string | `nil` | ServiceMonitor will use these tlsConfig settings to make the health check requests |

--- a/charts/tempo-distributed/templates/compactor/servicemonitor-compactor.yaml
+++ b/charts/tempo-distributed/templates/compactor/servicemonitor-compactor.yaml
@@ -32,6 +32,10 @@ spec:
       {{- with .scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+      {{- with .relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/tempo-distributed/templates/distributor/servicemonitor-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/servicemonitor-distributor.yaml
@@ -32,6 +32,10 @@ spec:
       {{- with .scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+      {{- with .relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/tempo-distributed/templates/ingester/servicemonitor-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/servicemonitor-ingester.yaml
@@ -32,6 +32,10 @@ spec:
       {{- with .scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+      {{- with .relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/tempo-distributed/templates/memcached/servicemonitor-memcached.yaml
+++ b/charts/tempo-distributed/templates/memcached/servicemonitor-memcached.yaml
@@ -33,6 +33,10 @@ spec:
       {{- with .scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+      {{- with .relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/querier/servicemonitor-querier.yaml
+++ b/charts/tempo-distributed/templates/querier/servicemonitor-querier.yaml
@@ -32,6 +32,10 @@ spec:
       {{- with .scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+      {{- with .relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/tempo-distributed/templates/query-frontend/servicemonitor-jaeger-query.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/servicemonitor-jaeger-query.yaml
@@ -32,6 +32,10 @@ spec:
       {{- with .scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+      {{- with .relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/tempo-distributed/templates/query-frontend/servicemonitor-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/servicemonitor-query-frontend.yaml
@@ -32,6 +32,10 @@ spec:
       {{- with .scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+      {{- with .relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -536,6 +536,9 @@ serviceMonitor:
   interval: null
   # -- ServiceMonitor scrape timeout in Go duration format (e.g. 15s)
   scrapeTimeout: null
+  # -- ServiceMonitor relabel configs to apply to samples before scraping
+  # https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+  relabelings: []
   # -- ServiceMonitor will use http by default, but you can pick https as well
   scheme: http
   # -- ServiceMonitor will use these tlsConfig settings to make the health check requests


### PR DESCRIPTION
Similar to https://github.com/grafana/helm-charts/pull/452, this adds support for configuring a ServiceMonitor's relabelling behaviour. This is especially useful for anyone who uses Grafana's various mixins for dashboards, as these expect a job dimension that includes the namespace (see https://github.com/grafana/helm-charts/pull/452 for a sample `relabelings` config that achieves this).

This also needs to be done for the Promtail chart, but there is an existing open PR for this - https://github.com/grafana/helm-charts/pull/766.