### PR TITLE
[loki-stack] update prometheus version

### DIFF
--- a/charts/loki-stack/requirements.yaml
+++ b/charts/loki-stack/requirements.yaml
@@ -17,7 +17,7 @@ dependencies:
   repository:  "https://grafana.github.io/helm-charts"
 - name: "prometheus"
   condition: prometheus.enabled
-  version: "~11.16.0"
+  version: "~14.11.1"
   repository:  "https://prometheus-community.github.io/helm-charts"
 - name: "filebeat"
   condition: filebeat.enabled


### PR DESCRIPTION
This brings prometheus up to date. The existing version is breaking as it doesn't support ClusterBindings. v14 works

Signed-off-by: Ryan 