### PR TITLE
[tempo] Allow custom configuration of Tempo server

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 0.10.0
+version: 0.10.1
 appVersion: 1.2.0
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 0.10.1
+version: 0.11.0
 appVersion: 1.2.0
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 
@@ -52,7 +52,7 @@ Grafana Tempo Single Binary Mode
 | tempo.resources | object | `{}` |  |
 | tempo.retention | string | `"24h"` |  |
 | tempo.searchEnabled | bool | `false` | If true, enables Tempo's native search |
-| tempo.server.httpListenPort | int | `3100` |  |
+| tempo.server.http_listen_port | int | `3100` | HTTP server listen port |
 | tempo.storage.trace.backend | string | `"local"` |  |
 | tempo.storage.trace.local.path | string | `"/var/tempo/traces"` |  |
 | tempo.storage.trace.wal.path | string | `"/var/tempo/wal"` |  |

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.1](https://img.shields.io/badge/AppVersion-1.2.1-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 

--- a/charts/tempo/templates/configmap-tempo.yaml
+++ b/charts/tempo/templates/configmap-tempo.yaml
@@ -18,8 +18,8 @@ data:
       receivers:
         {{- toYaml .Values.tempo.receivers | nindent 8 }}
     ingester:
-       {{- toYaml .Values.tempo.ingester | nindent 6 }}
+      {{- toYaml .Values.tempo.ingester | nindent 6 }}
     server:
-      http_listen_port: {{ .Values.tempo.server.httpListenPort }}
+      {{- toYaml .Values.tempo.server | nindent 6 }}
     storage:
       {{- toYaml .Values.tempo.storage | nindent 6 }}

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -1,8 +1,8 @@
 # -- Overrides the chart's name
-nameOverride: ""
+nameOverride: ''
 
 # -- Overrides the chart's computed fullname
-fullnameOverride: ""
+fullnameOverride: ''
 
 replicas: 1
 tempo:
@@ -31,8 +31,11 @@ tempo:
   searchEnabled: false
   ingester: {}
   retention: 24h
+
+  # Tempo server configuration
+  # Refers to https://grafana.com/docs/tempo/latest/configuration/#server
   server:
-    httpListenPort: 3100
+    http_listen_port: 3100
   # tempo storage backend
   # refer https://github.com/grafana/tempo/tree/master/docs/tempo/website/configuration
   ## Use s3 for example
@@ -69,9 +72,9 @@ tempo:
     otlp:
       protocols:
         grpc:
-          endpoint: "0.0.0.0:4317"
+          endpoint: '0.0.0.0:4317'
         http:
-          endpoint: "0.0.0.0:4318"
+          endpoint: '0.0.0.0:4318'
 
   ## Additional container arguments
   extraArgs: {}
@@ -123,7 +126,7 @@ service:
 
 serviceMonitor:
   enabled: false
-  interval: ""
+  interval: ''
   additionalLabels: {}
   annotations: {}
   # scrapeTimeout: 10s

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -1,8 +1,8 @@
 # -- Overrides the chart's name
-nameOverride: ''
+nameOverride: ""
 
 # -- Overrides the chart's computed fullname
-fullnameOverride: ''
+fullnameOverride: ""
 
 replicas: 1
 tempo:
@@ -35,6 +35,7 @@ tempo:
   # Tempo server configuration
   # Refers to https://grafana.com/docs/tempo/latest/configuration/#server
   server:
+    # -- HTTP server listen port
     http_listen_port: 3100
   # tempo storage backend
   # refer https://github.com/grafana/tempo/tree/master/docs/tempo/website/configuration
@@ -72,9 +73,9 @@ tempo:
     otlp:
       protocols:
         grpc:
-          endpoint: '0.0.0.0:4317'
+          endpoint: "0.0.0.0:4317"
         http:
-          endpoint: '0.0.0.0:4318'
+          endpoint: "0.0.0.0:4318"
 
   ## Additional container arguments
   extraArgs: {}
@@ -126,7 +127,7 @@ service:
 
 serviceMonitor:
   enabled: false
-  interval: ''
+  interval: ""
   additionalLabels: {}
   annotations: {}
   # scrapeTimeout: 10s


### PR DESCRIPTION
As described in issue [#487](https://github.com/grafana/helm-charts/issues/487) it would be nice to be able to provide some custom configuration to Tempo server in the single binary chart.

In order to solve that we can use a similar approach to what is already available for other Tempo sub components (like ingester) so a `.Values.tempo.server ` could be used to provide YAML configuration to the server.

Note: to make this change consistent the previous value `httpListenPort: 3100` is modified to be set as any other server configuration.