### PR TITLE
[enterprise-logs] Fix dev cluster MinIO endpoints in default configuration.

### DIFF
--- a/charts/enterprise-logs/CHANGELOG.md
+++ b/charts/enterprise-logs/CHANGELOG.md
@@ -11,7 +11,7 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
-## Unreleased
+## 1.2.1
 
 - [BUGFIX] Fixed the dev cluster MinIO endpoints in the default configuration. #826
 

--- a/charts/enterprise-logs/CHANGELOG.md
+++ b/charts/enterprise-logs/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## Unreleased
+
+- [BUGFIX] Fixed the dev cluster MinIO endpoints in the default configuration. #826
+
 ## 1.2.0
 
 - [CHANGE] Removed unused deployment of `memcached-index-writes` StatefulSet when using `small.yaml` values file.

--- a/charts/enterprise-logs/Chart.yaml
+++ b/charts/enterprise-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v2"
 name: "enterprise-logs"
 type: application
-version: "1.2.0"
+version: "1.2.1"
 appVersion: "v1.1.0"
 kubeVersion: "^1.10.0-0"
 description: "Grafana Enterprise Logs"

--- a/charts/enterprise-logs/templates/_helpers.tpl
+++ b/charts/enterprise-logs/templates/_helpers.tpl
@@ -75,3 +75,10 @@ Create the app name of enterprise-logs clients. Defaults to the same logic as "e
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the service endpoint including port for MinIO.
+*/}}
+{{- define "enterprise-logs.minio" -}}
+{{- printf "%s-%s.%s.svc:%s" .Release.Name "minio" .Release.Namespace (.Values.minio.service.port | toString)  -}}
+{{- end -}}

--- a/charts/enterprise-logs/templates/admin-api/deployment-admin-api.yaml
+++ b/charts/enterprise-logs/templates/admin-api/deployment-admin-api.yaml
@@ -79,10 +79,10 @@ spec:
             - -config.file=/etc/loki/config/config.yaml
             {{- if .Values.minio.enabled }}
             - -admin.client.backend-type=s3
-            - -admin.client.s3.endpoint={{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000
+            - -admin.client.s3.endpoint={{ template "enterprise-logs.minio" . }}
             - -admin.client.s3.bucket-name=enterprise-logs-admin
-            - -admin.client.s3.access-key-id=enterprise-logs
-            - -admin.client.s3.secret-access-key=supersecret
+            - -admin.client.s3.access-key-id={{ .Values.minio.accessKey }}
+            - -admin.client.s3.secret-access-key={{ .Values.minio.secretKey }}
             - -admin.client.s3.insecure=true
             {{- end }}
             {{- range $key, $value := .Values.adminApi.extraArgs }}

--- a/charts/enterprise-logs/templates/compactor/statefulset-compactor.yaml
+++ b/charts/enterprise-logs/templates/compactor/statefulset-compactor.yaml
@@ -113,10 +113,10 @@ spec:
             - -config.file=/etc/loki/config/config.yaml
             {{- if .Values.minio.enabled }}
             - -admin.client.backend-type=s3
-            - -admin.client.s3.endpoint={{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000
+            - -admin.client.s3.endpoint={{ template "enterprise-logs.minio" . }}
             - -admin.client.s3.bucket-name=enterprise-logs-admin
-            - -admin.client.s3.access-key-id=enterprise-logs
-            - -admin.client.s3.secret-access-key=supersecret
+            - -admin.client.s3.access-key-id={{ .Values.minio.accessKey }}
+            - -admin.client.s3.secret-access-key={{ .Values.minio.secretKey }}
             - -admin.client.s3.insecure=true
             {{- end }}
             {{- range $key, $value := .Values.compactor.extraArgs }}

--- a/charts/enterprise-logs/templates/gateway/deployment-gateway.yaml
+++ b/charts/enterprise-logs/templates/gateway/deployment-gateway.yaml
@@ -58,10 +58,10 @@ spec:
             - -config.file=/etc/loki/config/config.yaml
             {{- if .Values.minio.enabled }}
             - -admin.client.backend-type=s3
-            - -admin.client.s3.endpoint={{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000
+            - -admin.client.s3.endpoint={{ template "enterprise-logs.minio" . }}
             - -admin.client.s3.bucket-name=enterprise-logs-admin
-            - -admin.client.s3.access-key-id=enterprise-logs
-            - -admin.client.s3.secret-access-key=supersecret
+            - -admin.client.s3.access-key-id={{ .Values.minio.accessKey }}
+            - -admin.client.s3.secret-access-key={{ .Values.minio.secretKey }}
             - -admin.client.s3.insecure=true
             {{- end }}
             {{- if .Values.gateway.useDefaultProxyURLs }}

--- a/charts/enterprise-logs/templates/tokengen/job-tokengen.yaml
+++ b/charts/enterprise-logs/templates/tokengen/job-tokengen.yaml
@@ -55,10 +55,10 @@ spec:
             - -target=tokengen
             {{- if .Values.minio.enabled }}
             - -admin.client.backend-type=s3
-            - -admin.client.s3.endpoint={{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000
+            - -admin.client.s3.endpoint={{ template "enterprise-logs.minio" . }}
             - -admin.client.s3.bucket-name=enterprise-logs-admin
-            - -admin.client.s3.access-key-id=enterprise-logs
-            - -admin.client.s3.secret-access-key=supersecret
+            - -admin.client.s3.access-key-id={{ .Values.minio.accessKey }}
+            - -admin.client.s3.secret-access-key={{ .Values.minio.secretKey }}
             - -admin.client.s3.insecure=true
             {{- end }}
             - -tokengen.token-file=/shared/admin-token

--- a/charts/enterprise-logs/values.yaml
+++ b/charts/enterprise-logs/values.yaml
@@ -17,7 +17,7 @@ image:
   # -- The image repository to use
   repository: grafana/enterprise-logs
   # -- The version of Grafana Enterprise Logs
-  tag: v1.1.0
+  tag: v1.2.0
   # -- Defines the policy how and when images are pulled
   pullPolicy: IfNotPresent
   # -- Additional image pull secrets
@@ -71,7 +71,7 @@ config:
     storage:
       type: s3
       s3:
-        endpoint: "{{ include \"loki.fullname\" . }}-minio:9000"
+        endpoint: "{{ include \"enterprise-logs.minio\" . }}"
         bucket_name: enterprise-logs-admin
         secret_access_key: supersecret
         access_key_id: enterprise-logs
@@ -147,7 +147,7 @@ config:
 
   storage_config:
     aws:
-      endpoint: "{{ include \"loki.fullname\" . }}-minio:9000"
+      endpoint: "{{ include \"enterprise-logs.minio\" . }}"
       bucketnames: enterprise-logs-tsdb
       access_key_id: enterprise-logs
       secret_access_key: supersecret
@@ -165,7 +165,7 @@ config:
     storage:
       type: s3
       s3:
-        endpoint: "{{ include \"loki.fullname\" . }}-minio:9000"
+        endpoint: "{{ include \"enterprise-logs.minio\" . }}"
         bucketnames: enterprise-logs-ruler
         access_key_id: enterprise-logs
         secret_access_key: supersecret


### PR DESCRIPTION
Services where incorrectly configured when using the default MinIO configuration,
which pointed to `{{ .Release.Name }}-enterprise-logs-minio` instead of `{{ .Release.Name }}-minio`.

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>