### PR TITLE
[agent-operator] Fix agent-operator tests setting an empty MetricsInstance spec

### DIFF
--- a/charts/agent-operator/Chart.yaml
+++ b/charts/agent-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: grafana-agent-operator
 description: A Helm chart for Grafana Agent Operator
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "0.20.0"
 home: https://grafana.com/docs/agent/latest/
 icon: https://raw.githubusercontent.com/grafana/agent/v0.20.0/docs/assets/logo_and_name.png

--- a/charts/agent-operator/README.md
+++ b/charts/agent-operator/README.md
@@ -1,6 +1,6 @@
 # grafana-agent-operator
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.20.0](https://img.shields.io/badge/AppVersion-0.20.0-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.20.0](https://img.shields.io/badge/AppVersion-0.20.0-informational?style=flat-square)
 
 A Helm chart for Grafana Agent Operator
 

--- a/charts/agent-operator/templates/tests/test-grafanaagent.yaml
+++ b/charts/agent-operator/templates/tests/test-grafanaagent.yaml
@@ -6,6 +6,7 @@ metadata:
     app: grafana-agent-test
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
 spec:
   image: "{{ .Values.image.registry }}/grafana/agent:{{ .Values.image.tag }}"
   logLevel: info
@@ -23,6 +24,7 @@ metadata:
   name: grafana-agent-test-sa
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
 
 ---
 
@@ -32,6 +34,7 @@ metadata:
   name: grafana-agent-test-cr
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
 rules:
 - apiGroups:
   - ""
@@ -68,6 +71,7 @@ metadata:
   name: grafana-agent-test-crb
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -96,6 +100,7 @@ metadata:
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
 spec:
   containers:
   - name: busybox

--- a/charts/agent-operator/templates/tests/test-grafanaagent.yaml
+++ b/charts/agent-operator/templates/tests/test-grafanaagent.yaml
@@ -85,7 +85,7 @@ metadata:
   name: primary-test
   labels:
     agent: grafana-agent-test
-spec:
+spec: {}
 
 ---
 


### PR DESCRIPTION
Because:

* Having a null `spec:` definition in the agent-operator MetricsInstance
  used for test, causes the test to fail with the following error during
  the apply of the manifest: 'The MetricsInstance "primary" is invalid:
  spec: Invalid value: "null": spec in body must be of type object:
  "null"'

This commit:

* Sets the value to an empty object `spec: {}` rather than null

Signed-off-by: Tommaso Sardelli <lacapannadelloziotom@gmail.com>