### PR TITLE
[enterprise-logs] Bump enterprise-logs version to 1.3.0

### DIFF
--- a/charts/enterprise-logs/CHANGELOG.md
+++ b/charts/enterprise-logs/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## 1.3.0
+
+- [CHANGE] Bump GEL version to v1.2.0
+
 ## 1.2.1
 
 - [BUGFIX] Fixed the dev cluster MinIO endpoints in the default configuration. #826

--- a/charts/enterprise-logs/Chart.yaml
+++ b/charts/enterprise-logs/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: "v2"
 name: "enterprise-logs"
 type: application
-version: "1.2.1"
-appVersion: "v1.1.0"
+version: "1.3.0"
+appVersion: "v1.2.0"
 kubeVersion: "^1.10.0-0"
 description: "Grafana Enterprise Logs"
 home: "https://grafana.com/products/enterprise/logs/"


### PR DESCRIPTION
This version bump is necessay, because in a recent change (commit
1428e05458fb8f180b9d71199d4fa916ea0ff0cb) the GEL image version was
bumped to v1.2.0 by accident.

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>