### PR TITLE
[loki-simple-scalable] create loki-simple-scalable chart

### DIFF
--- a/charts/loki-simple-scalable/.helmignore
+++ b/charts/loki-simple-scalable/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+doc.yaml
+README.tpl

--- a/charts/loki-simple-scalable/Chart.yaml
+++ b/charts/loki-simple-scalable/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-simple-scalable
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.4.1
-version: 0.39.2
+version: 0.1.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-simple-scalable/Chart.yaml
+++ b/charts/loki-simple-scalable/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: loki-simple-scalable
+description: Helm chart for Grafana Loki in simple, scalable mode
+type: application
+appVersion: 2.4.1
+version: 0.39.2
+home: https://grafana.github.io/helm-charts
+sources:
+  - https://github.com/grafana/loki
+  - https://grafana.com/oss/loki/
+  - https://grafana.com/docs/loki/latest/
+icon: https://grafana.com/docs/loki/latest/logo_and_name.png
+maintainers:
+  - name: trevorwhitney

--- a/charts/loki-simple-scalable/README.md
+++ b/charts/loki-simple-scalable/README.md
@@ -1,6 +1,6 @@
 # loki-simple-scalable
 
-![Version: 0.39.2](https://img.shields.io/badge/Version-0.39.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.1](https://img.shields.io/badge/AppVersion-2.4.1-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.1](https://img.shields.io/badge/AppVersion-2.4.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 
@@ -14,7 +14,7 @@ Helm chart for Grafana Loki in simple, scalable mode
 
 Add the following repo to use the chart:
 
-```console
+```sh
 helm repo add grafana https://grafana.github.io/helm-charts
 ```
 

--- a/charts/loki-simple-scalable/README.md
+++ b/charts/loki-simple-scalable/README.md
@@ -1,0 +1,310 @@
+# loki-simple-scalable
+
+![Version: 0.39.2](https://img.shields.io/badge/Version-0.39.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.1](https://img.shields.io/badge/AppVersion-2.4.1-informational?style=flat-square)
+
+Helm chart for Grafana Loki in simple, scalable mode
+
+## Source Code
+
+* <https://github.com/grafana/loki>
+* <https://grafana.com/oss/loki/>
+* <https://grafana.com/docs/loki/latest/>
+
+## Chart Repo
+
+Add the following repo to use the chart:
+
+```console
+helm repo add grafana https://grafana.github.io/helm-charts
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| fullnameOverride | string | `nil` | Overrides the chart's computed fullname |
+| gateway.affinity | string | Hard node and soft zone anti-affinity | Affinity for gateway pods. Passed through `tpl` and, thus, to be configured as string |
+| gateway.autoscaling.enabled | bool | `false` | Enable autoscaling for the gateway |
+| gateway.autoscaling.maxReplicas | int | `3` | Maximum autoscaling replicas for the gateway |
+| gateway.autoscaling.minReplicas | int | `1` | Minimum autoscaling replicas for the gateway |
+| gateway.autoscaling.targetCPUUtilizationPercentage | int | `60` | Target CPU utilisation percentage for the gateway |
+| gateway.autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory utilisation percentage for the gateway |
+| gateway.basicAuth.enabled | bool | `false` | Enables basic authentication for the gateway |
+| gateway.basicAuth.existingSecret | string | `nil` | Existing basic auth secret to use. Must contain '.htpasswd' |
+| gateway.basicAuth.htpasswd | string | `"{{ htpasswd (required \"'gateway.basicAuth.username' is required\" .Values.gateway.basicAuth.username) (required \"'gateway.basicAuth.password' is required\" .Values.gateway.basicAuth.password) }}"` | Uses the specified username and password to compute a htpasswd using Sprig's `htpasswd` function. The value is templated using `tpl`. Override this to use a custom htpasswd, e.g. in case the default causes high CPU load. |
+| gateway.basicAuth.password | string | `nil` | The basic auth password for the gateway |
+| gateway.basicAuth.username | string | `nil` | The basic auth username for the gateway |
+| gateway.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The SecurityContext for gateway containers |
+| gateway.deploymentStrategy | object | `{"type":"RollingUpdate"}` | See `kubectl explain deployment.spec.strategy` for more -- ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |
+| gateway.enabled | bool | `true` | Specifies whether the gateway should be enabled |
+| gateway.extraArgs | list | `[]` | Additional CLI args for the gateway |
+| gateway.extraEnv | list | `[]` | Environment variables to add to the gateway pods |
+| gateway.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the gateway pods |
+| gateway.extraVolumeMounts | list | `[]` | Volume mounts to add to the gateway pods |
+| gateway.extraVolumes | list | `[]` | Volumes to add to the gateway pods |
+| gateway.image.pullPolicy | string | `"IfNotPresent"` | The gateway image pull policy |
+| gateway.image.registry | string | `"docker.io"` | The Docker registry for the gateway image |
+| gateway.image.repository | string | `"nginxinc/nginx-unprivileged"` | The gateway image repository |
+| gateway.image.tag | string | `"1.19-alpine"` | The gateway image tag |
+| gateway.ingress.annotations | object | `{}` | Ingress Class Name. MAY be required for Kubernetes versions >= 1.18 ingressClassName: nginx -- Annotations for the gateway ingress |
+| gateway.ingress.enabled | bool | `false` | Specifies whether an ingress for the gateway should be created |
+| gateway.ingress.hosts | list | `[{"host":"gateway.loki.example.com","paths":[{"path":"/"}]}]` | Hosts configuration for the gateway ingress |
+| gateway.ingress.tls | list | `[{"hosts":["gateway.loki.example.com"],"secretName":"loki-gateway-tls"}]` | TLS configuration for the gateway ingress |
+| gateway.nginxConfig.file | string | See values.yaml | Config file contents for Nginx. Passed through the `tpl` function to allow templating |
+| gateway.nginxConfig.httpSnippet | string | `""` | Allows appending custom configuration to the http block |
+| gateway.nginxConfig.logFormat | string | `"main '$remote_addr - $remote_user [$time_local]  $status '\n        '\"$request\" $body_bytes_sent \"$http_referer\" '\n        '\"$http_user_agent\" \"$http_x_forwarded_for\"';"` | NGINX log format |
+| gateway.nginxConfig.serverSnippet | string | `""` | Allows appending custom configuration to the server block |
+| gateway.nodeSelector | object | `{}` | Node selector for gateway pods |
+| gateway.podAnnotations | object | `{}` | Annotations for gateway pods |
+| gateway.podSecurityContext | object | `{"fsGroup":101,"runAsGroup":101,"runAsNonRoot":true,"runAsUser":101}` | The SecurityContext for gateway containers |
+| gateway.priorityClassName | string | `nil` | The name of the PriorityClass for gateway pods |
+| gateway.readinessProbe.httpGet.path | string | `"/"` |  |
+| gateway.readinessProbe.httpGet.port | string | `"http"` |  |
+| gateway.readinessProbe.initialDelaySeconds | int | `15` |  |
+| gateway.readinessProbe.timeoutSeconds | int | `1` |  |
+| gateway.replicas | int | `1` | Number of replicas for the gateway |
+| gateway.resources | object | `{}` | Resource requests and limits for the gateway |
+| gateway.service.annotations | object | `{}` | Annotations for the gateway service |
+| gateway.service.clusterIP | string | `nil` | ClusterIP of the gateway service |
+| gateway.service.labels | object | `{}` | Labels for gateway service |
+| gateway.service.loadBalancerIP | string | `nil` | Load balancer IPO address if service type is LoadBalancer |
+| gateway.service.nodePort | string | `nil` | Node port if service type is NodePort |
+| gateway.service.port | int | `80` | Port of the gateway service |
+| gateway.service.type | string | `"ClusterIP"` | Type of the gateway service |
+| gateway.terminationGracePeriodSeconds | int | `30` | Grace period to allow the gateway to shutdown before it is killed |
+| gateway.tolerations | list | `[]` | Tolerations for gateway pods |
+| gateway.verboseLogging | bool | `true` | Enable logging of 2xx and 3xx HTTP requests |
+| global.clusterDomain | string | `"cluster.local"` | configures cluster domain ("cluster.local" by default) |
+| global.dnsNamespace | string | `"kube-system"` | configures DNS service namespace |
+| global.dnsService | string | `"kube-dns"` | configures DNS service name |
+| global.image.registry | string | `nil` | Overrides the Docker registry globally for all images |
+| global.priorityClassName | string | `nil` | Overrides the priorityClassName for all pods |
+| imagePullSecrets | list | `[]` | Image pull secrets for Docker images |
+| loki.config | object | See values.yaml | Config file contents for Loki |
+| loki.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The SecurityContext for Loki containers |
+| loki.defaultStorageConfig | object | `{"filesystem":{"chunks_directory":"/var/loki/chunks,","rules_directory":"/var/loki/rules"}}` | Default storage config, used when no loki.storageConfig is provided. Required for CI, but queries will not work using these defaults. |
+| loki.existingSecretForConfig | string | `""` | Specify an existing secret containing loki configuration. If non-empty, overrides `loki.config` |
+| loki.image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
+| loki.image.registry | string | `"docker.io"` | The Docker registry |
+| loki.image.repository | string | `"grafana/loki"` | Docker image repository |
+| loki.image.tag | string | `nil` | Overrides the image tag whose default is the chart's appVersion |
+| loki.podAnnotations | object | `{}` | Common annotations for all pods |
+| loki.podSecurityContext | object | `{"fsGroup":10001,"runAsGroup":10001,"runAsNonRoot":true,"runAsUser":10001}` | The SecurityContext for Loki pods |
+| loki.readinessProbe.httpGet.path | string | `"/ready"` |  |
+| loki.readinessProbe.httpGet.port | string | `"http"` |  |
+| loki.readinessProbe.initialDelaySeconds | int | `30` |  |
+| loki.readinessProbe.timeoutSeconds | int | `1` |  |
+| loki.revisionHistoryLimit | int | `10` | The number of old ReplicaSets to retain to allow rollback |
+| loki.storageConfig | object | loki.defaultStorageConfig | Common storage config component of loki configuration file. The must be overriden with a valid object storage backend in order for queries to work. |
+| nameOverride | string | `nil` | Overrides the chart's name |
+| networkPolicy.alertmanager.namespaceSelector | object | `{}` | Specifies the namespace the alertmanager is running in |
+| networkPolicy.alertmanager.podSelector | object | `{}` | Specifies the alertmanager Pods. As this is cross-namespace communication, you also need the namespaceSelector. |
+| networkPolicy.alertmanager.port | int | `9093` | Specify the alertmanager port used for alerting |
+| networkPolicy.discovery.namespaceSelector | object | `{}` | Specifies the namespace the discovery Pods are running in |
+| networkPolicy.discovery.podSelector | object | `{}` | Specifies the Pods labels used for discovery. As this is cross-namespace communication, you also need the namespaceSelector. |
+| networkPolicy.discovery.port | string | `nil` | Specify the port used for discovery |
+| networkPolicy.enabled | bool | `false` | Specifies whether Network Policies should be created |
+| networkPolicy.externalStorage.cidrs | list | `[]` | Specifies specific network CIDRs you want to limit access to |
+| networkPolicy.externalStorage.ports | list | `[]` | Specify the port used for external storage, e.g. AWS S3 |
+| networkPolicy.ingress.namespaceSelector | object | `{}` | Specifies the namespaces which are allowed to access the http port |
+| networkPolicy.ingress.podSelector | object | `{}` | Specifies the Pods which are allowed to access the http port. As this is cross-namespace communication, you also need the namespaceSelector. |
+| networkPolicy.metrics.cidrs | list | `[]` | Specifies specific network CIDRs which are allowed to access the metrics port. In case you use namespaceSelector, you also have to specify your kubelet networks here. The metrics ports are also used for probes. |
+| networkPolicy.metrics.namespaceSelector | object | `{}` | Specifies the namespaces which are allowed to access the metrics port |
+| networkPolicy.metrics.podSelector | object | `{}` | Specifies the Pods which are allowed to access the metrics port. As this is cross-namespace communication, you also need the namespaceSelector. |
+| prometheusRule.annotations | object | `{}` | PrometheusRule annotations |
+| prometheusRule.enabled | bool | `false` | If enabled, a PrometheusRule resource for Prometheus Operator is created |
+| prometheusRule.groups | list | `[]` | Contents of Prometheus rules file |
+| prometheusRule.labels | object | `{}` | Additional PrometheusRule labels |
+| prometheusRule.namespace | string | `nil` | Alternative namespace for the PrometheusRule resource |
+| rbac.pspEnabled | bool | `false` | If enabled, a PodSecurityPolicy is created |
+| read.affinity | string | Hard node and soft zone anti-affinity | Affinity for read pods. Passed through `tpl` and, thus, to be configured as string |
+| read.autoscaling.enabled | bool | `false` | Enable autoscaling for the read, this is only used if `queryIndex.enabled: true` |
+| read.autoscaling.maxReplicas | int | `3` | Maximum autoscaling replicas for the read |
+| read.autoscaling.minReplicas | int | `1` | Minimum autoscaling replicas for the read |
+| read.autoscaling.targetCPUUtilizationPercentage | int | `60` | Target CPU utilisation percentage for the read |
+| read.autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory utilisation percentage for the read |
+| read.extraArgs | list | `[]` | Additional CLI args for the read |
+| read.extraEnv | list | `[]` | Environment variables to add to the read pods |
+| read.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the read pods |
+| read.extraVolumeMounts | list | `[]` | Volume mounts to add to the read pods |
+| read.extraVolumes | list | `[]` | Volumes to add to the read pods |
+| read.image.registry | string | `nil` | The Docker registry for the read image. Overrides `loki.image.registry` |
+| read.image.repository | string | `nil` | Docker image repository for the read image. Overrides `loki.image.repository` |
+| read.image.tag | string | `nil` | Docker image tag for the read image. Overrides `loki.image.tag` |
+| read.nodeSelector | object | `{}` | Node selector for read pods |
+| read.persistence.size | string | `"10Gi"` | Size of persistent disk |
+| read.persistence.storageClass | string | `nil` | Storage class to be used. If defined, storageClassName: <storageClass>. If set to "-", storageClassName: "", which disables dynamic provisioning. If empty or set to null, no storageClassName spec is set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack). |
+| read.podAnnotations | object | `{}` | Annotations for read pods |
+| read.priorityClassName | string | `nil` | The name of the PriorityClass for read pods |
+| read.replicas | int | `1` | Number of replicas for the read |
+| read.resources | object | `{}` | Resource requests and limits for the read |
+| read.serviceLabels | object | `{}` | Labels for read service |
+| read.terminationGracePeriodSeconds | int | `30` | Grace period to allow the read to shutdown before it is killed |
+| read.tolerations | list | `[]` | Tolerations for read pods |
+| serviceAccount.annotations | object | `{}` | Annotations for the service account |
+| serviceAccount.automountServiceAccountToken | bool | `true` | Set this toggle to false to opt out of automounting API credentials for the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a ServiceAccount should be created |
+| serviceAccount.imagePullSecrets | list | `[]` | Image pull secrets for the service account |
+| serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template |
+| serviceMonitor.annotations | object | `{}` | ServiceMonitor annotations |
+| serviceMonitor.enabled | bool | `false` | If enabled, ServiceMonitor resources for Prometheus Operator are created |
+| serviceMonitor.interval | string | `nil` | ServiceMonitor scrape interval |
+| serviceMonitor.labels | object | `{}` | Additional ServiceMonitor labels |
+| serviceMonitor.namespace | string | `nil` | Alternative namespace for ServiceMonitor resources |
+| serviceMonitor.namespaceSelector | object | `{}` | Namespace selector for ServiceMonitor resources |
+| serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig |
+| serviceMonitor.scheme | string | `"http"` | ServiceMonitor will use http by default, but you can pick https as well |
+| serviceMonitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
+| serviceMonitor.tlsConfig | string | `nil` | ServiceMonitor will use these tlsConfig settings to make the health check requests |
+| write.affinity | string | Hard node and soft zone anti-affinity | Affinity for write pods. Passed through `tpl` and, thus, to be configured as string |
+| write.extraArgs | list | `[]` | Additional CLI args for the write |
+| write.extraEnv | list | `[]` | Environment variables to add to the write pods |
+| write.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the write pods |
+| write.extraVolumeMounts | list | `[]` | Volume mounts to add to the write pods |
+| write.extraVolumes | list | `[]` | Volumes to add to the write pods |
+| write.image.registry | string | `nil` | The Docker registry for the write image. Overrides `loki.image.registry` |
+| write.image.repository | string | `nil` | Docker image repository for the write image. Overrides `loki.image.repository` |
+| write.image.tag | string | `nil` | Docker image tag for the write image. Overrides `loki.image.tag` |
+| write.nodeSelector | object | `{}` | Node selector for write pods |
+| write.persistence.size | string | `"10Gi"` | Size of persistent disk |
+| write.persistence.storageClass | string | `nil` | Storage class to be used. If defined, storageClassName: <storageClass>. If set to "-", storageClassName: "", which disables dynamic provisioning. If empty or set to null, no storageClassName spec is set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack). |
+| write.podAnnotations | object | `{}` | Annotations for write pods |
+| write.priorityClassName | string | `nil` | The name of the PriorityClass for write pods |
+| write.replicas | int | `1` | Number of replicas for the write |
+| write.resources | object | `{}` | Resource requests and limits for the write |
+| write.serviceLabels | object | `{}` | Labels for ingestor service |
+| write.terminationGracePeriodSeconds | int | `300` | Grace period to allow the write to shutdown before it is killed. Especially for the ingestor, this must be increased. It must be long enough so writes can be gracefully shutdown flushing/transferring all data and to successfully leave the member ring on shutdown. |
+| write.tolerations | list | `[]` | Tolerations for write pods |
+
+## Components
+
+The chart supports the components shown in the following table.
+Ingester, distributor, querier, and query-frontend are always installed.
+The other components are optional.
+
+| Component | Optional | Enabled by default |
+| --- | --- | --- |
+| gateway |  ✅ |  ✅ |
+| write |  ❎ | n/a |
+| read |  ❎ | n/a |
+
+## Configuration
+
+This chart configures Loki in simple, scalable mode.
+It has been tested to work with [boltdb-shipper](https://grafana.com/docs/loki/latest/operations/storage/boltdb-shipper/)
+and [memberlist](https://grafana.com/docs/loki/latest/configuration/#memberlist_config) while other storage and discovery options should work as well.
+However, the chart does not support setting up Consul or Etcd for discovery,
+and it is not intended to support these going forward.
+They would have to be set up separately.
+Instead, memberlist can be used which does not require a separate key/value store.
+The chart creates a headless service for the memberlist which read and write nodes are part of.
+
+----
+
+**NOTE:**
+In its default configuration, the chart uses `boltdb-shipper` and `filesystem` as storage.
+The reason for this is that the chart can be validated and installed in a CI pipeline.
+However, this setup is not fully functional.
+Querying will not be possible (or limited to the write nodes' in-memory caches) because that would otherwise require shared storage between read and write nodes
+which the chart does not support and would require a volume that supports `ReadWriteMany` access mode anyways.
+The recommendation is to use object storage, such as S3, GCS, MinIO, etc., or one of the other options documented at https://grafana.com/docs/loki/latest/storage/.
+In order to do this, please override the `loki.config` value with a valid object storage configuration. This means overriding
+the `common.storage` section, as well as the `object_store` in your `schema_config`. Please note that because of the way
+helm deep merges values, you will need to explicitly `null` out the default `filesystem` configuration.
+
+For exmaple, to use MinIO (deployed separately) as your backend, provide the following values when installing this chart:
+
+```yaml
+loki:
+  config:
+    common:
+      storage:
+        filesystem: null
+        s3:
+          endpoint: minio.minio.svc.cluster.local:9000
+          insecure: true
+          bucketnames: loki-data
+          access_key_id: loki
+          secret_access_key: supersecret
+          s3forcepathstyle: true
+    schema_config:
+      configs:
+        - from: "2020-09-07"
+          store: boltdb-shipper
+          object_store: s3
+          schema: v11
+          index:
+            period: 24h
+            prefix: loki_index_
+```
+
+Alternatively, in order to quickly test Loki using the filestore, the [single binary chart](https://github.com/grafana/helm-charts/tree/main/charts/loki) can be used.
+
+----
+
+### Directory and File Locations
+
+* Volumes are mounted to `/var/loki`. The various directories Loki needs should be configured as subdirectories (e. g. `/var/loki/index`, `/var/loki/cache`). Loki will create the directories automatically.
+  * Persistence is require to use this chart, and PVCs will be created and mapped to `/var/loki`
+* The config file is mounted to `/etc/loki/config/config.yaml` and passed as CLI arg.
+
+### Example configuration using memberlist, boltdb-shipper, and S3 for storage
+
+If using the default config values, queries will not work. At a minimum you need to provide:
+  * `loki.config.common.storage` (with `filesystem` set to `null`, and valid cloud storage provided)
+  * `loki.config.schema_config.configs` (with at least one config that has an `object_store` that matches the the `loki.config.common.storage` config)
+values, you must provide an entire `loki.config` value.
+
+`loki.config` is passed through the `tpl` function, meaning it is also possible to e.g. externalize S3 bucket names:
+
+```yaml
+loki:
+  config:
+    common:
+      storage:
+        s3:
+          s3: s3://eu-central-1
+          bucketnames: {{ .values.bucketnames }}
+```
+
+```console
+helm upgrade loki --install -f values.yaml --set bucketnames=my-loki-bucket
+```
+
+## Gateway
+
+By default and inspired by Grafana's [Tanka setup](https://github.com/grafana/loki/tree/master/production/ksonnet/loki), the chart installs the gateway component which is an NGINX that exposes Loki's API
+and automatically proxies requests to the correct Loki components (read or write).
+The gateway must be enabled if an Ingress is required, since the Ingress exposes the gateway only.
+If the gateway is enabled, Grafana and log shipping agents, such as Promtail, should be configured to use the gateway.
+If NetworkPolicies are enabled, they are more restrictive if the gateway is enabled.
+
+## Metrics
+
+Loki exposes Prometheus metrics.
+The chart can create ServiceMonitor objects for all Loki components.
+
+```yaml
+serviceMonitor:
+  enabled: true
+```
+
+Furthermore, it is possible to add Prometheus rules:
+
+```yaml
+prometheusRule:
+  enabled: true
+  groups:
+    - name: loki-rules
+      rules:
+        - record: job:loki_request_duration_seconds_bucket:sum_rate
+          expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, job)
+        - record: job_route:loki_request_duration_seconds_bucket:sum_rate
+          expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, job, route)
+        - record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
+          expr: sum(rate(container_cpu_usage_seconds_total[1m])) by (node, namespace, pod, container)
+```
+
+## Caching
+
+By default, this chart configures in-memory caching. If that caching does not work for your deployment, take a lot at the [distributed chart](https://github.com/grafana/helm-charts/tree/main/charts/loki) for how to setup memcache.

--- a/charts/loki-simple-scalable/README.md.gotmpl
+++ b/charts/loki-simple-scalable/README.md.gotmpl
@@ -1,0 +1,152 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Chart Repo
+
+Add the following repo to use the chart:
+
+```console
+helm repo add grafana https://grafana.github.io/helm-charts
+```
+
+{{ template "chart.valuesSection" . }}
+
+## Components
+
+The chart supports the components shown in the following table.
+Ingester, distributor, querier, and query-frontend are always installed.
+The other components are optional.
+
+| Component | Optional | Enabled by default |
+| --- | --- | --- |
+| gateway |  ✅ |  ✅ |
+| write |  ❎ | n/a |
+| read |  ❎ | n/a |
+
+## Configuration
+
+This chart configures Loki in simple, scalable mode.
+It has been tested to work with [boltdb-shipper](https://grafana.com/docs/loki/latest/operations/storage/boltdb-shipper/)
+and [memberlist](https://grafana.com/docs/loki/latest/configuration/#memberlist_config) while other storage and discovery options should work as well.
+However, the chart does not support setting up Consul or Etcd for discovery,
+and it is not intended to support these going forward.
+They would have to be set up separately.
+Instead, memberlist can be used which does not require a separate key/value store.
+The chart creates a headless service for the memberlist which read and write nodes are part of.
+
+----
+
+**NOTE:**
+In its default configuration, the chart uses `boltdb-shipper` and `filesystem` as storage.
+The reason for this is that the chart can be validated and installed in a CI pipeline.
+However, this setup is not fully functional.
+Querying will not be possible (or limited to the write nodes' in-memory caches) because that would otherwise require shared storage between read and write nodes
+which the chart does not support and would require a volume that supports `ReadWriteMany` access mode anyways.
+The recommendation is to use object storage, such as S3, GCS, MinIO, etc., or one of the other options documented at https://grafana.com/docs/loki/latest/storage/.
+In order to do this, please override the `loki.config` value with a valid object storage configuration. This means overriding
+the `common.storage` section, as well as the `object_store` in your `schema_config`. Please note that because of the way
+helm deep merges values, you will need to explicitly `null` out the default `filesystem` configuration.
+
+For exmaple, to use MinIO (deployed separately) as your backend, provide the following values when installing this chart:
+
+```yaml
+loki:
+  config:
+    common:
+      storage:
+        filesystem: null
+        s3:
+          endpoint: minio.minio.svc.cluster.local:9000
+          insecure: true
+          bucketnames: loki-data
+          access_key_id: loki
+          secret_access_key: supersecret
+          s3forcepathstyle: true
+    schema_config:
+      configs:
+        - from: "2020-09-07"
+          store: boltdb-shipper
+          object_store: s3
+          schema: v11
+          index:
+            period: 24h
+            prefix: loki_index_
+```
+
+Alternatively, in order to quickly test Loki using the filestore, the [single binary chart](https://github.com/grafana/helm-charts/tree/main/charts/loki) can be used.
+
+----
+
+### Directory and File Locations
+
+* Volumes are mounted to `/var/loki`. The various directories Loki needs should be configured as subdirectories (e. g. `/var/loki/index`, `/var/loki/cache`). Loki will create the directories automatically.
+  * Persistence is require to use this chart, and PVCs will be created and mapped to `/var/loki`
+* The config file is mounted to `/etc/loki/config/config.yaml` and passed as CLI arg.
+
+### Example configuration using memberlist, boltdb-shipper, and S3 for storage
+
+If using the default config values, queries will not work. At a minimum you need to provide:
+  * `loki.config.common.storage` (with `filesystem` set to `null`, and valid cloud storage provided)
+  * `loki.config.schema_config.configs` (with at least one config that has an `object_store` that matches the the `loki.config.common.storage` config)
+values, you must provide an entire `loki.config` value.
+
+`loki.config` is passed through the `tpl` function, meaning it is also possible to e.g. externalize S3 bucket names:
+
+```yaml
+loki:
+  config:
+    common:
+      storage:
+        s3:
+          s3: s3://eu-central-1
+          bucketnames: {{"{{"}} .values.bucketnames {{"}}"}}
+```
+
+```console
+helm upgrade loki --install -f values.yaml --set bucketnames=my-loki-bucket
+```
+
+## Gateway
+
+By default and inspired by Grafana's [Tanka setup](https://github.com/grafana/loki/tree/master/production/ksonnet/loki), the chart installs the gateway component which is an NGINX that exposes Loki's API
+and automatically proxies requests to the correct Loki components (read or write).
+The gateway must be enabled if an Ingress is required, since the Ingress exposes the gateway only.
+If the gateway is enabled, Grafana and log shipping agents, such as Promtail, should be configured to use the gateway.
+If NetworkPolicies are enabled, they are more restrictive if the gateway is enabled.
+
+## Metrics
+
+Loki exposes Prometheus metrics.
+The chart can create ServiceMonitor objects for all Loki components.
+
+```yaml
+serviceMonitor:
+  enabled: true
+```
+
+Furthermore, it is possible to add Prometheus rules:
+
+```yaml
+prometheusRule:
+  enabled: true
+  groups:
+    - name: loki-rules
+      rules:
+        - record: job:loki_request_duration_seconds_bucket:sum_rate
+          expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, job)
+        - record: job_route:loki_request_duration_seconds_bucket:sum_rate
+          expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, job, route)
+        - record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
+          expr: sum(rate(container_cpu_usage_seconds_total[1m])) by (node, namespace, pod, container)
+```
+
+## Caching
+
+By default, this chart configures in-memory caching. If that caching does not work for your deployment, take a lot at the [distributed chart](https://github.com/grafana/helm-charts/tree/main/charts/loki) for how to setup memcache.

--- a/charts/loki-simple-scalable/README.md.gotmpl
+++ b/charts/loki-simple-scalable/README.md.gotmpl
@@ -12,7 +12,7 @@
 
 Add the following repo to use the chart:
 
-```console
+```sh
 helm repo add grafana https://grafana.github.io/helm-charts
 ```
 

--- a/charts/loki-simple-scalable/ci/ingress-values.yaml
+++ b/charts/loki-simple-scalable/ci/ingress-values.yaml
@@ -1,0 +1,9 @@
+gateway:
+  ingress:
+    enabled: true
+    annotations: {}
+    hosts:
+      - host: gateway.loki.example.com
+        paths:
+          - path: /
+            pathType: Prefix

--- a/charts/loki-simple-scalable/ci/persistence-values.yaml
+++ b/charts/loki-simple-scalable/ci/persistence-values.yaml
@@ -1,0 +1,21 @@
+read:
+  persistence:
+    enabled: true
+    size: 100Mi
+
+write:
+  persistence:
+    enabled: true
+    size: 100Mi
+
+gateway:
+  nginxConfig:
+    httpSnippet: |-
+      client_max_body_size 100M;
+    serverSnippet: |-
+      client_max_body_size 100M;
+
+  basicAuth:
+    enabled: true
+    username: user
+    password: pass

--- a/charts/loki-simple-scalable/templates/NOTES.txt
+++ b/charts/loki-simple-scalable/templates/NOTES.txt
@@ -1,0 +1,42 @@
+***********************************************************************
+ Welcome to Grafana Loki
+ Chart version: {{ .Chart.Version }}
+ Loki version: {{ .Chart.AppVersion }}
+***********************************************************************
+
+Installed components:
+{{- if .Values.gateway.enabled }}
+* gateway
+{{- end }}
+* read
+* write
+
+This chart requires persistence and object storage to work correctly.
+Queries will not work unless you provide a `loki.config.common.storage` section with
+a valid object storage (and the default `filesystem` storage set to `null`), as well
+as a valid `loki.config.schema_config.configs` with an `object_store` that
+matches the common storage section.
+
+For example, to use MinIO as your object storage backend:
+
+loki:
+  config:
+    common:
+      storage:
+        filesystem: null
+        s3:
+          endpoint: minio.minio.svc.cluster.local:9000
+          insecure: true
+          bucketnames: loki-data
+          access_key_id: loki
+          secret_access_key: supersecret
+          s3forcepathstyle: true
+    schema_config:
+      configs:
+        - from: "2020-09-07"
+          store: boltdb-shipper
+          object_store: s3
+          schema: v11
+          index:
+            period: 24h
+            prefix: loki_index_

--- a/charts/loki-simple-scalable/templates/_helpers.tpl
+++ b/charts/loki-simple-scalable/templates/_helpers.tpl
@@ -1,0 +1,143 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "loki.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "loki.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Create a default storage config that uses filesystem storage
+This is required for CI, but Loki will not be queryable with this default
+applied, thus it is encouraged that users override this.
+*/}}
+{{- define "loki.storageConfig" -}}
+{{- if .Values.loki.storageConfig -}}
+{{- .Values.loki.storageConfig | toYaml | nindent 4 -}}
+{{- else }}
+{{- .Values.loki.defaultStorageConfig | toYaml | nindent 4 }}
+{{- end}}
+{{- end}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "loki.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "loki.labels" -}}
+helm.sh/chart: {{ include "loki.chart" . }}
+{{ include "loki.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "loki.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "loki.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "loki.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "loki.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Docker image name for Loki
+*/}}
+{{- define "loki.lokiImage" -}}
+{{- $registry := coalesce .global.registry .service.registry .loki.registry -}}
+{{- $repository := coalesce .service.repository .loki.repository -}}
+{{- $tag := coalesce .service.tag .loki.tag .defaultVersion | toString -}}
+{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- end -}}
+
+{{/*
+Docker image name
+*/}}
+{{- define "loki.image" -}}
+{{- $registry := coalesce .global.registry .service.registry -}}
+{{- $tag := .service.tag | toString -}}
+{{- printf "%s/%s:%s" $registry .service.repository (.service.tag | toString) -}}
+{{- end -}}
+
+{{/*
+Memcached Docker image
+*/}}
+{{- define "loki.memcachedImage" -}}
+{{- $dict := dict "service" .Values.memcached.image "global" .Values.global.image -}}
+{{- include "loki.image" $dict -}}
+{{- end }}
+
+{{/*
+Memcached Exporter Docker image
+*/}}
+{{- define "loki.memcachedExporterImage" -}}
+{{- $dict := dict "service" .Values.memcachedExporter.image "global" .Values.global.image -}}
+{{- include "loki.image" $dict -}}
+{{- end }}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "loki.ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19-0" .Capabilities.KubeVersion.Version) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Return if ingress is stable.
+*/}}
+{{- define "loki.ingress.isStable" -}}
+  {{- eq (include "loki.ingress.apiVersion" .) "networking.k8s.io/v1" -}}
+{{- end -}}
+
+{{/*
+Return if ingress supports ingressClassName.
+*/}}
+{{- define "loki.ingress.supportsIngressClassName" -}}
+  {{- or (eq (include "loki.ingress.isStable" .) "true") (and (eq (include "loki.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
+{{- end -}}
+
+{{/*
+Return if ingress supports pathType.
+*/}}
+{{- define "loki.ingress.supportsPathType" -}}
+  {{- or (eq (include "loki.ingress.isStable" .) "true") (and (eq (include "loki.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
+{{- end -}}

--- a/charts/loki-simple-scalable/templates/configmap.yaml
+++ b/charts/loki-simple-scalable/templates/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if not .Values.loki.existingSecretForConfig -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "loki.fullname" . }}
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- tpl (toYaml .Values.loki.config) . | nindent 4 }}
+{{- end -}}

--- a/charts/loki-simple-scalable/templates/gateway/_helpers-gateway.tpl
+++ b/charts/loki-simple-scalable/templates/gateway/_helpers-gateway.tpl
@@ -1,0 +1,47 @@
+{{/*
+gateway fullname
+*/}}
+{{- define "loki.gatewayFullname" -}}
+{{ include "loki.fullname" . }}-gateway
+{{- end }}
+
+{{/*
+gateway common labels
+*/}}
+{{- define "loki.gatewayLabels" -}}
+{{ include "loki.labels" . }}
+app.kubernetes.io/component: gateway
+{{- end }}
+
+{{/*
+gateway selector labels
+*/}}
+{{- define "loki.gatewaySelectorLabels" -}}
+{{ include "loki.selectorLabels" . }}
+app.kubernetes.io/component: gateway
+{{- end }}
+
+{{/*
+gateway auth secret name
+*/}}
+{{- define "loki.gatewayAuthSecret" -}}
+{{ .Values.gateway.basicAuth.existingSecret | default (include "loki.gatewayFullname" . ) }}
+{{- end }}
+
+{{/*
+gateway Docker image
+*/}}
+{{- define "loki.gatewayImage" -}}
+{{- $dict := dict "service" .Values.gateway.image "global" .Values.global.image -}}
+{{- include "loki.image" $dict -}}
+{{- end }}
+
+{{/*
+gateway priority class name
+*/}}
+{{- define "loki.gatewayPriorityClassName" -}}
+{{- $pcn := coalesce .Values.global.priorityClassName .Values.gateway.priorityClassName -}}
+{{- if $pcn }}
+priorityClassName: {{ $pcn }}
+{{- end }}
+{{- end }}

--- a/charts/loki-simple-scalable/templates/gateway/configmap-gateway.yaml
+++ b/charts/loki-simple-scalable/templates/gateway/configmap-gateway.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "loki.gatewayFullname" . }}
+  labels:
+    {{- include "loki.gatewayLabels" . | nindent 4 }}
+data:
+  nginx.conf: |
+    {{- tpl .Values.gateway.nginxConfig.file . | nindent 4 }}
+{{- end }}

--- a/charts/loki-simple-scalable/templates/gateway/deployment-gateway.yaml
+++ b/charts/loki-simple-scalable/templates/gateway/deployment-gateway.yaml
@@ -1,0 +1,106 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "loki.gatewayFullname" . }}
+  labels:
+    {{- include "loki.gatewayLabels" . | nindent 4 }}
+spec:
+{{- if not .Values.gateway.autoscaling.enabled }}
+  replicas: {{ .Values.gateway.replicas }}
+{{- end }}
+{{- with .Values.gateway.deploymentStrategy }}
+  strategy:
+{{ toYaml . | trim | indent 4 }}
+{{- end }}
+  revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "loki.gatewaySelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print .Template.BasePath "/gateway/configmap-gateway.yaml") . | sha256sum }}
+        {{- with .Values.loki.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.gateway.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "loki.gatewaySelectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "loki.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "loki.gatewayPriorityClassName" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.gateway.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.gateway.terminationGracePeriodSeconds }}
+      containers:
+        - name: nginx
+          image: {{ include "loki.gatewayImage" . }}
+          imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          {{- with .Values.gateway.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.gateway.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          readinessProbe:
+            {{- toYaml .Values.gateway.readinessProbe | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.gateway.containerSecurityContext | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx
+            {{- if .Values.gateway.basicAuth.enabled }}
+            - name: auth
+              mountPath: /etc/nginx/secrets
+            {{- end }}
+            - name: tmp
+              mountPath: /tmp
+            - name: docker-entrypoint-d-override
+              mountPath: /docker-entrypoint.d
+            {{- if .Values.gateway.extraVolumeMounts }}
+            {{- toYaml .Values.gateway.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.gateway.resources | nindent 12 }}
+      {{- with .Values.gateway.affinity }}
+      affinity:
+        {{- tpl . $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.gateway.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.gateway.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "loki.gatewayFullname" . }}
+        {{- if .Values.gateway.basicAuth.enabled }}
+        - name: auth
+          secret:
+            secretName: {{ include "loki.gatewayAuthSecret" . }}
+        {{- end }}
+        - name: tmp
+          emptyDir: {}
+        - name: docker-entrypoint-d-override
+          emptyDir: {}
+        {{- if .Values.gateway.extraVolumes }}
+        {{- toYaml .Values.gateway.extraVolumes | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/charts/loki-simple-scalable/templates/gateway/hpa.yaml
+++ b/charts/loki-simple-scalable/templates/gateway/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.gateway.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "loki.gatewayFullname" . }}
+  labels:
+    {{- include "loki.gatewayLabels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "loki.gatewayFullname" . }}
+  minReplicas: {{ .Values.gateway.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.gateway.autoscaling.maxReplicas }}
+  metrics:
+  {{- with .Values.gateway.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.gateway.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ . }}
+  {{- end }}
+{{- end }}

--- a/charts/loki-simple-scalable/templates/gateway/ingress-gateway.yaml
+++ b/charts/loki-simple-scalable/templates/gateway/ingress-gateway.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.gateway.enabled -}}
+{{- if .Values.gateway.ingress.enabled -}}
+{{- $ingressApiIsStable := eq (include "loki.ingress.isStable" .) "true" -}}
+{{- $ingressSupportsIngressClassName := eq (include "loki.ingress.supportsIngressClassName" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "loki.ingress.supportsPathType" .) "true" -}}
+apiVersion: {{ include "loki.ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+  name: {{ include "loki.gatewayFullname" . }}
+  labels:
+    {{- include "loki.gatewayLabels" . | nindent 4 }}
+  {{- with .Values.gateway.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and $ingressSupportsIngressClassName .Values.gateway.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.gateway.ingress.ingressClassName }}
+  {{- end -}}
+  {{- if .Values.gateway.ingress.tls }}
+  tls:
+    {{- range .Values.gateway.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      {{- with .secretName }}
+      secretName: {{ . }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.gateway.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if $ingressSupportsPathType }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if $ingressApiIsStable }}
+              service:
+                name: {{ include "loki.gatewayFullname" $ }}
+                port:
+                  number: {{ $.Values.gateway.service.port }}
+              {{- else }}
+              serviceName: {{ include "loki.gatewayFullname" $ }}
+              servicePort: {{ $.Values.gateway.service.port }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/loki-simple-scalable/templates/gateway/poddisruptionbudget-gateway.yaml
+++ b/charts/loki-simple-scalable/templates/gateway/poddisruptionbudget-gateway.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.gateway.enabled }}
+{{- if gt (int .Values.gateway.replicas) 1 }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "loki.gatewayFullname" . }}
+  labels:
+    {{- include "loki.gatewayLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "loki.gatewaySelectorLabels" . | nindent 6 }}
+  maxUnavailable: 1
+{{- end }}
+{{- end }}

--- a/charts/loki-simple-scalable/templates/gateway/secret-gateway.yaml
+++ b/charts/loki-simple-scalable/templates/gateway/secret-gateway.yaml
@@ -1,0 +1,13 @@
+{{- with .Values.gateway }}
+{{- if and .enabled .basicAuth.enabled (not .basicAuth.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "loki.gatewayFullname" $ }}
+  labels:
+    {{- include "loki.gatewayLabels" $ | nindent 4 }}
+stringData:
+  .htpasswd: |
+    {{- tpl .basicAuth.htpasswd $ | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/loki-simple-scalable/templates/gateway/service-gateway.yaml
+++ b/charts/loki-simple-scalable/templates/gateway/service-gateway.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.gatewayFullname" . }}
+  labels:
+    {{- include "loki.gatewayLabels" . | nindent 4 }}
+    {{- with .Values.gateway.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.gateway.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.gateway.service.type }}
+  {{- with .Values.gateway.service.clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
+  {{- if and (eq "LoadBalancer" .Values.gateway.service.type) .Values.gateway.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.gateway.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.gateway.service.port }}
+      targetPort: http
+      {{- if and (eq "NodePort" .Values.gateway.service.type) .Values.gateway.service.nodePort }}
+      nodePort: {{ .Values.gateway.service.nodePort }}
+      {{- end }}
+      protocol: TCP
+  selector:
+    {{- include "loki.gatewaySelectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/loki-simple-scalable/templates/networkpolicy.yaml
+++ b/charts/loki-simple-scalable/templates/networkpolicy.yaml
@@ -1,0 +1,198 @@
+{{- if .Values.networkPolicy.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "loki.name" . }}-namespace-only
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector: {}
+  egress:
+    - to:
+        - podSelector: {}
+  ingress:
+    - from:
+        - podSelector: {}
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "loki.name" . }}-egress-dns
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      {{- include "loki.selectorLabels" . | nindent 6 }}
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+      to:
+        - namespaceSelector: {}
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "loki.name" . }}-ingress
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+spec:
+  policyTypes:
+    - Ingress
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/component
+        operator: In
+        values:
+        {{- if .Values.gateway.enabled }}
+          - gateway
+        {{- else }}
+          - read
+          - write
+        {{- end }}
+    matchLabels:
+      {{- include "loki.selectorLabels" . | nindent 6 }}
+  ingress:
+    - ports:
+        - port: http
+          protocol: TCP
+  {{- if .Values.networkPolicy.ingress.namespaceSelector }}
+      from:
+        - namespaceSelector:
+          {{- toYaml .Values.networkPolicy.ingress.namespaceSelector | nindent 12 }}
+          {{- if .Values.networkPolicy.ingress.podSelector }}
+          podSelector:
+          {{- toYaml .Values.networkPolicy.ingress.podSelector | nindent 12 }}
+          {{- end }}
+  {{- end }}
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "loki.name" . }}-ingress-metrics
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+spec:
+  policyTypes:
+    - Ingress
+  podSelector:
+    matchLabels:
+      {{- include "loki.selectorLabels" . | nindent 6 }}
+  ingress:
+    - ports:
+        - port: http-metrics
+          protocol: TCP
+    {{- if .Values.networkPolicy.metrics.cidrs }}
+      from:
+      {{- range $cidr := .Values.networkPolicy.metrics.cidrs }}
+        - ipBlock:
+            cidr: {{ $cidr }}
+      {{- end }}
+      {{- if .Values.networkPolicy.metrics.namespaceSelector }}
+        - namespaceSelector:
+          {{- toYaml .Values.networkPolicy.metrics.namespaceSelector | nindent 12 }}
+          {{- if .Values.networkPolicy.metrics.podSelector }}
+          podSelector:
+          {{- toYaml .Values.networkPolicy.metrics.podSelector | nindent 12 }}
+          {{- end }}
+      {{- end }}
+    {{- end }}
+
+{{- if .Values.ruler.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "loki.name" . }}-egress-alertmanager
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      {{- include "loki.rulerSelectorLabels" . | nindent 6 }}
+  egress:
+    - ports:
+        - port: {{ .Values.networkPolicy.alertmanager.port }}
+          protocol: TCP
+  {{- if .Values.networkPolicy.alertmanager.namespaceSelector }}
+      to:
+        - namespaceSelector:
+          {{- toYaml .Values.networkPolicy.alertmanager.namespaceSelector | nindent 12 }}
+          {{- if .Values.networkPolicy.alertmanager.podSelector }}
+          podSelector:
+          {{- toYaml .Values.networkPolicy.alertmanager.podSelector | nindent 12 }}
+          {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- if .Values.networkPolicy.externalStorage.ports }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "loki.name" . }}-egress-external-storage
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      {{- include "loki.selectorLabels" . | nindent 6 }}
+  egress:
+    - ports:
+      {{- range $port := .Values.networkPolicy.externalStorage.ports }}
+        - port: {{ $port }}
+          protocol: TCP
+      {{- end }}
+  {{- if .Values.networkPolicy.externalStorage.cidrs }}
+      to:
+      {{- range $cidr := .Values.networkPolicy.externalStorage.cidrs }}
+        - ipBlock:
+            cidr: {{ $cidr }}
+      {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- end }}
+
+{{- if .Values.networkPolicy.discovery.port }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "loki.name" . }}-egress-discovery
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      {{- include "loki.selectorLabels" . | nindent 6 }}
+  egress:
+    - ports:
+        - port: {{ .Values.networkPolicy.discovery.port }}
+          protocol: TCP
+  {{- if .Values.networkPolicy.discovery.namespaceSelector }}
+      to:
+        - namespaceSelector:
+          {{- toYaml .Values.networkPolicy.discovery.namespaceSelector | nindent 12 }}
+          {{- if .Values.networkPolicy.discovery.podSelector }}
+          podSelector:
+          {{- toYaml .Values.networkPolicy.discovery.podSelector | nindent 12 }}
+          {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/loki-simple-scalable/templates/podsecuritypolicy.yaml
+++ b/charts/loki-simple-scalable/templates/podsecuritypolicy.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "loki.fullname" . }}
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'persistentVolumeClaim'
+    - 'secret'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+    - ALL
+{{- end }}

--- a/charts/loki-simple-scalable/templates/prometheusrule.yaml
+++ b/charts/loki-simple-scalable/templates/prometheusrule.yaml
@@ -1,0 +1,23 @@
+{{- with .Values.prometheusRule }}
+{{- if .enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "loki.fullname" $ }}
+  {{- with .namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "loki.labels" $ | nindent 4 }}
+  {{- with .labels }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  groups:
+    {{- toYaml .groups | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/loki-simple-scalable/templates/read/_helpers-read.tpl
+++ b/charts/loki-simple-scalable/templates/read/_helpers-read.tpl
@@ -1,0 +1,40 @@
+{{/*
+read fullname
+*/}}
+{{- define "loki.readFullname" -}}
+{{ include "loki.fullname" . }}-read
+{{- end }}
+
+{{/*
+read common labels
+*/}}
+{{- define "loki.readLabels" -}}
+{{ include "loki.labels" . }}
+app.kubernetes.io/component: read
+{{- end }}
+
+{{/*
+read selector labels
+*/}}
+{{- define "loki.readSelectorLabels" -}}
+{{ include "loki.selectorLabels" . }}
+app.kubernetes.io/component: read
+{{- end }}
+
+{{/*
+read image
+*/}}
+{{- define "loki.readImage" -}}
+{{- $dict := dict "loki" .Values.loki.image "service" .Values.read.image "global" .Values.global.image "defaultVersion" .Chart.AppVersion -}}
+{{- include "loki.lokiImage" $dict -}}
+{{- end }}
+
+{{/*
+read priority class name
+*/}}
+{{- define "loki.readPriorityClassName" -}}
+{{- $pcn := coalesce .Values.global.priorityClassName .Values.read.priorityClassName -}}
+{{- if $pcn }}
+priorityClassName: {{ $pcn }}
+{{- end }}
+{{- end }}

--- a/charts/loki-simple-scalable/templates/read/poddisruptionbudget-read.yaml
+++ b/charts/loki-simple-scalable/templates/read/poddisruptionbudget-read.yaml
@@ -1,0 +1,13 @@
+{{- if gt (int .Values.read.replicas) 1 }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "loki.readFullname" . }}
+  labels:
+    {{- include "loki.readLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "loki.readSelectorLabels" . | nindent 6 }}
+  maxUnavailable: 1
+{{- end }}

--- a/charts/loki-simple-scalable/templates/read/service-querier.yaml
+++ b/charts/loki-simple-scalable/templates/read/service-querier.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.readFullname" . }}
+  labels:
+    {{- include "loki.readLabels" . | nindent 4 }}
+    {{- with .Values.read.serviceLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 3100
+      targetPort: http
+      protocol: TCP
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+  selector:
+    {{- include "loki.readSelectorLabels" . | nindent 4 }}

--- a/charts/loki-simple-scalable/templates/read/service-read-headless.yaml
+++ b/charts/loki-simple-scalable/templates/read/service-read-headless.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.readFullname" . }}-headless
+  labels:
+    {{- include "loki.readSelectorLabels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 3100
+      targetPort: http
+      protocol: TCP
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+  selector:
+    {{- include "loki.readSelectorLabels" . | nindent 4 }}

--- a/charts/loki-simple-scalable/templates/read/servicemonitor-read.yaml
+++ b/charts/loki-simple-scalable/templates/read/servicemonitor-read.yaml
@@ -1,0 +1,47 @@
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "loki.readFullname" $ }}
+  {{- with .namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "loki.readLabels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .namespaceSelector }}
+  namespaceSelector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "loki.readSelectorLabels" $ | nindent 6 }}
+  endpoints:
+    - port: http
+      {{- with .interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/loki-simple-scalable/templates/read/statefulset-read.yaml
+++ b/charts/loki-simple-scalable/templates/read/statefulset-read.yaml
@@ -1,0 +1,119 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "loki.readFullname" . }}
+  labels:
+    {{- include "loki.readLabels" . | nindent 4 }}
+    app.kubernetes.io/part-of: memberlist
+spec:
+  replicas: {{ .Values.read.replicas }}
+  podManagementPolicy: Parallel
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+  serviceName: {{ include "loki.readFullname" . }}-headless
+  revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "loki.readSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.loki.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.read.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "loki.readSelectorLabels" . | nindent 8 }}
+        app.kubernetes.io/part-of: memberlist
+    spec:
+      serviceAccountName: {{ include "loki.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "loki.readPriorityClassName" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.loki.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.read.terminationGracePeriodSeconds }}
+      containers:
+        - name: loki
+          image: {{ include "loki.readImage" . }}
+          imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
+          args:
+            - -config.file=/etc/loki/config/config.yaml
+            - -target=read
+            {{- with .Values.read.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 3100
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: http-memberlist
+              containerPort: 7946
+              protocol: TCP
+          {{- with .Values.read.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.read.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.loki.readinessProbe | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki/config
+            - name: data
+              mountPath: /var/loki
+            {{- with .Values.read.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.read.resources | nindent 12 }}
+      {{- with .Values.read.affinity }}
+      affinity:
+        {{- tpl . $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.read.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.read.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          {{- if .Values.loki.existingSecretForConfig }}
+          secret:
+            secretName: {{ .Values.loki.existingSecretForConfig }}
+          {{- else }}
+          configMap:
+            name: {{ include "loki.fullname" . }}
+          {{- end }}
+        {{- with .Values.read.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- with .Values.read.persistence.storageClass }}
+        storageClassName: {{ if (eq "-" .) }}""{{ else }}{{ . }}{{ end }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.read.persistence.size | quote }}

--- a/charts/loki-simple-scalable/templates/role.yaml
+++ b/charts/loki-simple-scalable/templates/role.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "loki.fullname" . }}
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+rules:
+  - apiGroups:      
+      - policy
+    resources:      
+      - podsecuritypolicies
+    verbs:          
+      - use
+    resourceNames:  
+      - {{ include "loki.fullname" . }}
+{{- end }}

--- a/charts/loki-simple-scalable/templates/rolebinding.yaml
+++ b/charts/loki-simple-scalable/templates/rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "loki.fullname" . }}
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "loki.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "loki.serviceAccountName" . }}
+{{- end }}

--- a/charts/loki-simple-scalable/templates/service-memberlist.yaml
+++ b/charts/loki-simple-scalable/templates/service-memberlist.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.fullname" . }}-memberlist
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 7946
+      targetPort: http-memberlist
+      protocol: TCP
+  selector:
+    {{- include "loki.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/part-of: memberlist

--- a/charts/loki-simple-scalable/templates/serviceaccount.yaml
+++ b/charts/loki-simple-scalable/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{ if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "loki.serviceAccountName" . }}
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- with .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+

--- a/charts/loki-simple-scalable/templates/write/_helpers-write.tpl
+++ b/charts/loki-simple-scalable/templates/write/_helpers-write.tpl
@@ -1,0 +1,40 @@
+{{/*
+write fullname
+*/}}
+{{- define "loki.writeFullname" -}}
+{{ include "loki.fullname" . }}-write
+{{- end }}
+
+{{/*
+write common labels
+*/}}
+{{- define "loki.writeLabels" -}}
+{{ include "loki.labels" . }}
+app.kubernetes.io/component: write
+{{- end }}
+
+{{/*
+write selector labels
+*/}}
+{{- define "loki.writeSelectorLabels" -}}
+{{ include "loki.selectorLabels" . }}
+app.kubernetes.io/component: write
+{{- end }}
+
+{{/*
+write image
+*/}}
+{{- define "loki.writeImage" -}}
+{{- $dict := dict "loki" .Values.loki.image "service" .Values.write.image "global" .Values.global.image "defaultVersion" .Chart.AppVersion -}}
+{{- include "loki.lokiImage" $dict -}}
+{{- end }}
+
+{{/*
+write priority class name
+*/}}
+{{- define "loki.writePriorityClassName" -}}
+{{- $pcn := coalesce .Values.global.priorityClassName .Values.write.priorityClassName -}}
+{{- if $pcn }}
+priorityClassName: {{ $pcn }}
+{{- end }}
+{{- end }}

--- a/charts/loki-simple-scalable/templates/write/poddisruptionbudget-write.yaml
+++ b/charts/loki-simple-scalable/templates/write/poddisruptionbudget-write.yaml
@@ -1,0 +1,13 @@
+{{- if gt (int .Values.write.replicas) 1 }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "loki.writeFullname" . }}
+  labels:
+    {{- include "loki.writeLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "loki.writeSelectorLabels" . | nindent 6 }}
+  maxUnavailable: 1
+{{- end }}

--- a/charts/loki-simple-scalable/templates/write/service-write-headless.yaml
+++ b/charts/loki-simple-scalable/templates/write/service-write-headless.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.writeFullname" . }}-headless
+  labels:
+    {{- include "loki.writeSelectorLabels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 3100
+      targetPort: http
+      protocol: TCP
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+  selector:
+    {{- include "loki.writeSelectorLabels" . | nindent 4 }}

--- a/charts/loki-simple-scalable/templates/write/service-write.yaml
+++ b/charts/loki-simple-scalable/templates/write/service-write.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.writeFullname" . }}
+  labels:
+    {{- include "loki.writeLabels" . | nindent 4 }}
+    {{- with .Values.write.serviceLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 3100
+      targetPort: http
+      protocol: TCP
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+  selector:
+    {{- include "loki.writeSelectorLabels" . | nindent 4 }}

--- a/charts/loki-simple-scalable/templates/write/servicemonitor-write.yaml
+++ b/charts/loki-simple-scalable/templates/write/servicemonitor-write.yaml
@@ -1,0 +1,47 @@
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "loki.writeFullname" $ }}
+  {{- with .namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "loki.writeLabels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .namespaceSelector }}
+  namespaceSelector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "loki.writeSelectorLabels" $ | nindent 6 }}
+  endpoints:
+    - port: http
+      {{- with .interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/loki-simple-scalable/templates/write/statefulset-write.yaml
+++ b/charts/loki-simple-scalable/templates/write/statefulset-write.yaml
@@ -1,0 +1,119 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "loki.writeFullname" . }}
+  labels:
+    {{- include "loki.writeLabels" . | nindent 4 }}
+    app.kubernetes.io/part-of: memberlist
+spec:
+  replicas: {{ .Values.write.replicas }}
+  podManagementPolicy: Parallel
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+  serviceName: {{ include "loki.writeFullname" . }}-headless
+  revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "loki.writeSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.loki.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.write.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "loki.writeSelectorLabels" . | nindent 8 }}
+        app.kubernetes.io/part-of: memberlist
+    spec:
+      serviceAccountName: {{ include "loki.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "loki.writePriorityClassName" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.loki.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.write.terminationGracePeriodSeconds }}
+      containers:
+        - name: loki
+          image: {{ include "loki.writeImage" . }}
+          imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
+          args:
+            - -config.file=/etc/loki/config/config.yaml
+            - -target=write
+            {{- with .Values.write.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 3100
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: http-memberlist
+              containerPort: 7946
+              protocol: TCP
+          {{- with .Values.write.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.write.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.loki.readinessProbe | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki/config
+            - name: data
+              mountPath: /var/loki
+            {{- with .Values.write.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.write.resources | nindent 12 }}
+      {{- with .Values.write.affinity }}
+      affinity:
+        {{- tpl . $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.write.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.write.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          {{- if .Values.loki.existingSecretForConfig }}
+          secret:
+            secretName: {{ .Values.loki.existingSecretForConfig }}
+          {{- else }}
+          configMap:
+            name: {{ include "loki.fullname" . }}
+          {{- end }}
+        {{- with .Values.write.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- with .Values.write.persistence.storageClass }}
+        storageClassName: {{ if (eq "-" .) }}""{{ else }}{{ . }}{{ end }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.write.persistence.size | quote }}

--- a/charts/loki-simple-scalable/values.yaml
+++ b/charts/loki-simple-scalable/values.yaml
@@ -1,0 +1,585 @@
+---
+global:
+  image:
+    # -- Overrides the Docker registry globally for all images
+    registry: null
+  # -- Overrides the priorityClassName for all pods
+  priorityClassName: null
+  # -- configures cluster domain ("cluster.local" by default)
+  clusterDomain: "cluster.local"
+  # -- configures DNS service name
+  dnsService: "kube-dns"
+  # -- configures DNS service namespace
+  dnsNamespace: "kube-system"
+
+# -- Overrides the chart's name
+nameOverride: null
+
+# -- Overrides the chart's computed fullname
+fullnameOverride: null
+
+# -- Image pull secrets for Docker images
+imagePullSecrets: []
+
+loki:
+  # Configures the readiness probe for all of the Loki pods
+  readinessProbe:
+    httpGet:
+      path: /ready
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 1
+  image:
+    # -- The Docker registry
+    registry: docker.io
+    # -- Docker image repository
+    repository: grafana/loki
+    # -- Overrides the image tag whose default is the chart's appVersion
+    tag: null
+    # -- Docker image pull policy
+    pullPolicy: IfNotPresent
+  # -- Common annotations for all pods
+  podAnnotations: {}
+  # -- The number of old ReplicaSets to retain to allow rollback
+  revisionHistoryLimit: 10
+  # -- The SecurityContext for Loki pods
+  podSecurityContext:
+    fsGroup: 10001
+    runAsGroup: 10001
+    runAsNonRoot: true
+    runAsUser: 10001
+  # -- The SecurityContext for Loki containers
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    allowPrivilegeEscalation: false
+  # -- Specify an existing secret containing loki configuration. If non-empty, overrides `loki.config`
+  existingSecretForConfig: ""
+  # -- Config file contents for Loki
+  # @default -- See values.yaml
+  config:
+    auth_enabled: false
+
+    server:
+      http_listen_port: 3100
+
+    memberlist:
+      join_members:
+        - "{{ include \"loki.fullname\" . }}-memberlist"
+
+    common:
+      path_prefix: /var/loki
+      replication_factor: 1
+      ring:
+        kvstore:
+          store: memberlist
+      storage:
+        filesystem:
+          chunks_directory: /var/loki/chunks,
+          rules_directory: /var/loki/rules
+
+    limits_config:
+      enforce_metric_name: false
+      reject_old_samples: true
+      reject_old_samples_max_age: 168h
+      max_cache_freshness_per_query: 10m
+
+    schema_config:
+      configs:
+        - from: 2020-09-07
+          store: boltdb-shipper
+          object_store: filesystem
+          schema: v11
+          index:
+            prefix: loki_index_
+            period: 24h
+  # -- Common storage config component of loki configuration file.
+  # The must be overriden with a valid object storage backend
+  # in order for queries to work.
+  # @default -- loki.defaultStorageConfig
+  storageConfig: {}
+  # -- Default storage config, used when no loki.storageConfig is provided.
+  # Required for CI, but queries will not work using these defaults.
+  defaultStorageConfig:
+    filesystem:
+      chunks_directory: /var/loki/chunks,
+      rules_directory: /var/loki/rules
+serviceAccount:
+  # -- Specifies whether a ServiceAccount should be created
+  create: true
+  # -- The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: null
+  # -- Image pull secrets for the service account
+  imagePullSecrets: []
+  # -- Annotations for the service account
+  annotations: {}
+  # -- Set this toggle to false to opt out of automounting API credentials for the service account
+  automountServiceAccountToken: true
+
+# RBAC configuration
+rbac:
+  # -- If enabled, a PodSecurityPolicy is created
+  pspEnabled: false
+
+# ServiceMonitor configuration
+serviceMonitor:
+  # -- If enabled, ServiceMonitor resources for Prometheus Operator are created
+  enabled: false
+  # -- Alternative namespace for ServiceMonitor resources
+  namespace: null
+  # -- Namespace selector for ServiceMonitor resources
+  namespaceSelector: {}
+  # -- ServiceMonitor annotations
+  annotations: {}
+  # -- Additional ServiceMonitor labels
+  labels: {}
+  # -- ServiceMonitor scrape interval
+  interval: null
+  # -- ServiceMonitor scrape timeout in Go duration format (e.g. 15s)
+  scrapeTimeout: null
+  # -- ServiceMonitor relabel configs to apply to samples before scraping
+  # https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+  relabelings: []
+  # -- ServiceMonitor will use http by default, but you can pick https as well
+  scheme: http
+  # -- ServiceMonitor will use these tlsConfig settings to make the health check requests
+  tlsConfig: null
+
+# Rules for the Prometheus Operator
+prometheusRule:
+  # -- If enabled, a PrometheusRule resource for Prometheus Operator is created
+  enabled: false
+  # -- Alternative namespace for the PrometheusRule resource
+  namespace: null
+  # -- PrometheusRule annotations
+  annotations: {}
+  # -- Additional PrometheusRule labels
+  labels: {}
+  # -- Contents of Prometheus rules file
+  groups: []
+  # - name: loki-rules
+  #   rules:
+  #     - record: job:loki_request_duration_seconds_bucket:sum_rate
+  #       expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, job)
+  #     - record: job_route:loki_request_duration_seconds_bucket:sum_rate
+  #       expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, job, route)
+  #     - record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
+  #       expr: sum(rate(container_cpu_usage_seconds_total[1m])) by (node, namespace, pod, container)
+
+# Configuration for the write
+write:
+  # -- Number of replicas for the write
+  replicas: 1
+  image:
+    # -- The Docker registry for the write image. Overrides `loki.image.registry`
+    registry: null
+    # -- Docker image repository for the write image. Overrides `loki.image.repository`
+    repository: null
+    # -- Docker image tag for the write image. Overrides `loki.image.tag`
+    tag: null
+  # -- The name of the PriorityClass for write pods
+  priorityClassName: null
+  # -- Annotations for write pods
+  podAnnotations: {}
+  # -- Labels for ingestor service
+  serviceLabels: {}
+  # -- Additional CLI args for the write
+  extraArgs: []
+  # -- Environment variables to add to the write pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to the write pods
+  extraEnvFrom: []
+  # -- Volume mounts to add to the write pods
+  extraVolumeMounts: []
+  # -- Volumes to add to the write pods
+  extraVolumes: []
+  # -- Resource requests and limits for the write
+  resources: {}
+  # -- Grace period to allow the write to shutdown before it is killed. Especially for the ingestor,
+  # this must be increased. It must be long enough so writes can be gracefully shutdown flushing/transferring
+  # all data and to successfully leave the member ring on shutdown.
+  terminationGracePeriodSeconds: 300
+  # -- Affinity for write pods. Passed through `tpl` and, thus, to be configured as string
+  # @default -- Hard node and soft zone anti-affinity
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              {{- include "loki.writeSelectorLabels" . | nindent 10 }}
+          topologyKey: kubernetes.io/hostname
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                {{- include "loki.writeSelectorLabels" . | nindent 12 }}
+            topologyKey: failure-domain.beta.kubernetes.io/zone
+  # -- Node selector for write pods
+  nodeSelector: {}
+  # -- Tolerations for write pods
+  tolerations: []
+  persistence:
+    # -- Size of persistent disk
+    size: 10Gi
+    # -- Storage class to be used.
+    # If defined, storageClassName: <storageClass>.
+    # If set to "-", storageClassName: "", which disables dynamic provisioning.
+    # If empty or set to null, no storageClassName spec is
+    # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
+    storageClass: null
+
+# Configuration for the read node(s)
+read:
+  # -- Number of replicas for the read
+  replicas: 1
+  autoscaling:
+    # -- Enable autoscaling for the read, this is only used if `queryIndex.enabled: true`
+    enabled: false
+    # -- Minimum autoscaling replicas for the read
+    minReplicas: 1
+    # -- Maximum autoscaling replicas for the read
+    maxReplicas: 3
+    # -- Target CPU utilisation percentage for the read
+    targetCPUUtilizationPercentage: 60
+    # -- Target memory utilisation percentage for the read
+    targetMemoryUtilizationPercentage:
+  image:
+    # -- The Docker registry for the read image. Overrides `loki.image.registry`
+    registry: null
+    # -- Docker image repository for the read image. Overrides `loki.image.repository`
+    repository: null
+    # -- Docker image tag for the read image. Overrides `loki.image.tag`
+    tag: null
+  # -- The name of the PriorityClass for read pods
+  priorityClassName: null
+  # -- Annotations for read pods
+  podAnnotations: {}
+  # -- Labels for read service
+  serviceLabels: {}
+  # -- Additional CLI args for the read
+  extraArgs: []
+  # -- Environment variables to add to the read pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to the read pods
+  extraEnvFrom: []
+  # -- Volume mounts to add to the read pods
+  extraVolumeMounts: []
+  # -- Volumes to add to the read pods
+  extraVolumes: []
+  # -- Resource requests and limits for the read
+  resources: {}
+  # -- Grace period to allow the read to shutdown before it is killed
+  terminationGracePeriodSeconds: 30
+  # -- Affinity for read pods. Passed through `tpl` and, thus, to be configured as string
+  # @default -- Hard node and soft zone anti-affinity
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              {{- include "loki.readSelectorLabels" . | nindent 10 }}
+          topologyKey: kubernetes.io/hostname
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                {{- include "loki.readSelectorLabels" . | nindent 12 }}
+            topologyKey: failure-domain.beta.kubernetes.io/zone
+  # -- Node selector for read pods
+  nodeSelector: {}
+  # -- Tolerations for read pods
+  tolerations: []
+  persistence:
+    # -- Size of persistent disk
+    size: 10Gi
+    # -- Storage class to be used.
+    # If defined, storageClassName: <storageClass>.
+    # If set to "-", storageClassName: "", which disables dynamic provisioning.
+    # If empty or set to null, no storageClassName spec is
+    # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
+    storageClass: null
+
+# Configuration for the gateway
+gateway:
+  # -- Specifies whether the gateway should be enabled
+  enabled: true
+  # -- Number of replicas for the gateway
+  replicas: 1
+  # -- Enable logging of 2xx and 3xx HTTP requests
+  verboseLogging: true
+  autoscaling:
+    # -- Enable autoscaling for the gateway
+    enabled: false
+    # -- Minimum autoscaling replicas for the gateway
+    minReplicas: 1
+    # -- Maximum autoscaling replicas for the gateway
+    maxReplicas: 3
+    # -- Target CPU utilisation percentage for the gateway
+    targetCPUUtilizationPercentage: 60
+    # -- Target memory utilisation percentage for the gateway
+    targetMemoryUtilizationPercentage:
+  # -- See `kubectl explain deployment.spec.strategy` for more
+  # -- ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  deploymentStrategy:
+    type: RollingUpdate
+  image:
+    # -- The Docker registry for the gateway image
+    registry: docker.io
+    # -- The gateway image repository
+    repository: nginxinc/nginx-unprivileged
+    # -- The gateway image tag
+    tag: 1.19-alpine
+    # -- The gateway image pull policy
+    pullPolicy: IfNotPresent
+  # -- The name of the PriorityClass for gateway pods
+  priorityClassName: null
+  # -- Annotations for gateway pods
+  podAnnotations: {}
+  # -- Additional CLI args for the gateway
+  extraArgs: []
+  # -- Environment variables to add to the gateway pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to the gateway pods
+  extraEnvFrom: []
+  # -- Volumes to add to the gateway pods
+  extraVolumes: []
+  # -- Volume mounts to add to the gateway pods
+  extraVolumeMounts: []
+  # -- The SecurityContext for gateway containers
+  podSecurityContext:
+    fsGroup: 101
+    runAsGroup: 101
+    runAsNonRoot: true
+    runAsUser: 101
+  # -- The SecurityContext for gateway containers
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    allowPrivilegeEscalation: false
+  # -- Resource requests and limits for the gateway
+  resources: {}
+  # -- Grace period to allow the gateway to shutdown before it is killed
+  terminationGracePeriodSeconds: 30
+  # -- Affinity for gateway pods. Passed through `tpl` and, thus, to be configured as string
+  # @default -- Hard node and soft zone anti-affinity
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              {{- include "loki.gatewaySelectorLabels" . | nindent 10 }}
+          topologyKey: kubernetes.io/hostname
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                {{- include "loki.gatewaySelectorLabels" . | nindent 12 }}
+            topologyKey: failure-domain.beta.kubernetes.io/zone
+  # -- Node selector for gateway pods
+  nodeSelector: {}
+  # -- Tolerations for gateway pods
+  tolerations: []
+  # Gateway service configuration
+  service:
+    # -- Port of the gateway service
+    port: 80
+    # -- Type of the gateway service
+    type: ClusterIP
+    # -- ClusterIP of the gateway service
+    clusterIP: null
+    # -- Node port if service type is NodePort
+    nodePort: null
+    # -- Load balancer IPO address if service type is LoadBalancer
+    loadBalancerIP: null
+    # -- Annotations for the gateway service
+    annotations: {}
+    # -- Labels for gateway service
+    labels: {}
+  # Gateway ingress configuration
+  ingress:
+    # -- Specifies whether an ingress for the gateway should be created
+    enabled: false
+    # -- Ingress Class Name. MAY be required for Kubernetes versions >= 1.18
+    # ingressClassName: nginx
+    # -- Annotations for the gateway ingress
+    annotations: {}
+    # -- Hosts configuration for the gateway ingress
+    hosts:
+      - host: gateway.loki.example.com
+        paths:
+          - path: /
+            # -- pathType (e.g. ImplementationSpecific, Prefix, .. etc.) might also be required by some Ingress Controllers
+            # pathType: Prefix
+    # -- TLS configuration for the gateway ingress
+    tls:
+      - secretName: loki-gateway-tls
+        hosts:
+          - gateway.loki.example.com
+  # Basic auth configuration
+  basicAuth:
+    # -- Enables basic authentication for the gateway
+    enabled: false
+    # -- The basic auth username for the gateway
+    username: null
+    # -- The basic auth password for the gateway
+    password: null
+    # -- Uses the specified username and password to compute a htpasswd using Sprig's `htpasswd` function.
+    # The value is templated using `tpl`. Override this to use a custom htpasswd, e.g. in case the default causes
+    # high CPU load.
+    htpasswd: >-
+      {{ htpasswd (required "'gateway.basicAuth.username' is required" .Values.gateway.basicAuth.username) (required "'gateway.basicAuth.password' is required" .Values.gateway.basicAuth.password) }}
+    # -- Existing basic auth secret to use. Must contain '.htpasswd'
+    existingSecret: null
+  # Configures the readiness probe for the gateway
+  readinessProbe:
+    httpGet:
+      path: /
+      port: http
+    initialDelaySeconds: 15
+    timeoutSeconds: 1
+  nginxConfig:
+    # -- NGINX log format
+    logFormat: |-
+      main '$remote_addr - $remote_user [$time_local]  $status '
+              '"$request" $body_bytes_sent "$http_referer" '
+              '"$http_user_agent" "$http_x_forwarded_for"';
+    # -- Allows appending custom configuration to the server block
+    serverSnippet: ""
+    # -- Allows appending custom configuration to the http block
+    httpSnippet: ""
+    # -- Config file contents for Nginx. Passed through the `tpl` function to allow templating
+    # @default -- See values.yaml
+    file: |
+      worker_processes  5;  ## Default: 1
+      error_log  /dev/stderr;
+      pid        /tmp/nginx.pid;
+      worker_rlimit_nofile 8192;
+
+      events {
+        worker_connections  4096;  ## Default: 1024
+      }
+
+      http {
+        client_body_temp_path /tmp/client_temp;
+        proxy_temp_path       /tmp/proxy_temp_path;
+        fastcgi_temp_path     /tmp/fastcgi_temp;
+        uwsgi_temp_path       /tmp/uwsgi_temp;
+        scgi_temp_path        /tmp/scgi_temp;
+
+        default_type application/octet-stream;
+        log_format   {{ .Values.gateway.nginxConfig.logFormat }}
+
+        {{- if .Values.gateway.verboseLogging }}
+        access_log   /dev/stderr  main;
+        {{- else }}
+
+        map $status $loggable {
+          ~^[23]  0;
+          default 1;
+        }
+        access_log   /dev/stderr  main  if=$loggable;
+        {{- end }}
+
+        sendfile     on;
+        tcp_nopush   on;
+        resolver {{ .Values.global.dnsService }}.{{ .Values.global.dnsNamespace }}.svc.{{ .Values.global.clusterDomain }};
+
+        {{- with .Values.gateway.nginxConfig.httpSnippet }}
+        {{ . | nindent 2 }}
+        {{- end }}
+
+        server {
+          listen             8080;
+
+          {{- if .Values.gateway.basicAuth.enabled }}
+          auth_basic           "Loki";
+          auth_basic_user_file /etc/nginx/secrets/.htpasswd;
+          {{- end }}
+
+          location = / {
+            return 200 'OK';
+            auth_basic off;
+          }
+
+          location = /api/prom/push {
+            proxy_pass       http://{{ include "loki.writeFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+          }
+
+          location = /api/prom/tail {
+            proxy_pass       http://{{ include "loki.readFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+          }
+
+          location ~ /api/prom/.* {
+            proxy_pass       http://{{ include "loki.readFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+          }
+
+          location = /loki/api/v1/push {
+            proxy_pass       http://{{ include "loki.writeFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+          }
+
+          location = /loki/api/v1/tail {
+            proxy_pass       http://{{ include "loki.readFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+          }
+
+          location ~ /loki/api/.* {
+            proxy_pass       http://{{ include "loki.readFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+          }
+
+          {{- with .Values.gateway.nginxConfig.serverSnippet }}
+          {{ . | nindent 4 }}
+          {{- end }}
+        }
+      }
+
+networkPolicy:
+  # -- Specifies whether Network Policies should be created
+  enabled: false
+  metrics:
+    # -- Specifies the Pods which are allowed to access the metrics port.
+    # As this is cross-namespace communication, you also need the namespaceSelector.
+    podSelector: {}
+    # -- Specifies the namespaces which are allowed to access the metrics port
+    namespaceSelector: {}
+    # -- Specifies specific network CIDRs which are allowed to access the metrics port.
+    # In case you use namespaceSelector, you also have to specify your kubelet networks here.
+    # The metrics ports are also used for probes.
+    cidrs: []
+  ingress:
+    # -- Specifies the Pods which are allowed to access the http port.
+    # As this is cross-namespace communication, you also need the namespaceSelector.
+    podSelector: {}
+    # -- Specifies the namespaces which are allowed to access the http port
+    namespaceSelector: {}
+  alertmanager:
+    # -- Specify the alertmanager port used for alerting
+    port: 9093
+    # -- Specifies the alertmanager Pods.
+    # As this is cross-namespace communication, you also need the namespaceSelector.
+    podSelector: {}
+    # -- Specifies the namespace the alertmanager is running in
+    namespaceSelector: {}
+  externalStorage:
+    # -- Specify the port used for external storage, e.g. AWS S3
+    ports: []
+    # -- Specifies specific network CIDRs you want to limit access to
+    cidrs: []
+  discovery:
+    # -- Specify the port used for discovery
+    port: null
+    # -- Specifies the Pods labels used for discovery.
+    # As this is cross-namespace communication, you also need the namespaceSelector.
+    podSelector: {}
+    # -- Specifies the namespace the discovery Pods are running in
+    namespaceSelector: {}

--- a/charts/loki-simple-scalable/values.yaml
+++ b/charts/loki-simple-scalable/values.yaml
@@ -77,7 +77,7 @@ loki:
           store: memberlist
       storage:
         filesystem:
-          chunks_directory: /var/loki/chunks,
+          chunks_directory: /var/loki/chunks
           rules_directory: /var/loki/rules
 
     limits_config:


### PR DESCRIPTION
This PR introduces a new helm chart based on the "simple, scalable" deployment architecture introduced in Loki 2.4

Fixes #825