### PR TITLE
[enterprise-logs] Fix template rendering bug

### DIFF
--- a/charts/enterprise-logs/CHANGELOG.md
+++ b/charts/enterprise-logs/CHANGELOG.md
@@ -11,7 +11,7 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
-## Unreleased
+## 1.3.1
 
 - [BUGFIX] Fixed error in template rendering when MinIO is disabled.
 

--- a/charts/enterprise-logs/CHANGELOG.md
+++ b/charts/enterprise-logs/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## 1.3.0
+
+- [CHANGE] Bump GEL version to v1.2.0
+
 ## 1.2.1
 
 - [BUGFIX] Fixed the dev cluster MinIO endpoints in the default configuration. #826

--- a/charts/enterprise-logs/CHANGELOG.md
+++ b/charts/enterprise-logs/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## Unreleased
+
+- [BUGFIX] Fixed error in template rendering when MinIO is disabled.
+
 ## 1.3.0
 
 - [CHANGE] Bump GEL version to v1.2.0

--- a/charts/enterprise-logs/Chart.yaml
+++ b/charts/enterprise-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v2"
 name: "enterprise-logs"
 type: application
-version: "1.3.0"
+version: "1.3.1"
 appVersion: "v1.2.0"
 kubeVersion: "^1.10.0-0"
 description: "Grafana Enterprise Logs"

--- a/charts/enterprise-logs/Chart.yaml
+++ b/charts/enterprise-logs/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: "v2"
 name: "enterprise-logs"
 type: application
-version: "1.2.1"
-appVersion: "v1.1.0"
+version: "1.3.0"
+appVersion: "v1.2.0"
 kubeVersion: "^1.10.0-0"
 description: "Grafana Enterprise Logs"
 home: "https://grafana.com/products/enterprise/logs/"

--- a/charts/enterprise-logs/templates/_helpers.tpl
+++ b/charts/enterprise-logs/templates/_helpers.tpl
@@ -80,5 +80,7 @@ Create the app name of enterprise-logs clients. Defaults to the same logic as "e
 Create the service endpoint including port for MinIO.
 */}}
 {{- define "enterprise-logs.minio" -}}
-{{- printf "%s-%s.%s.svc:%s" .Release.Name "minio" .Release.Namespace (.Values.minio.service.port | toString)  -}}
+{{- if .Values.minio.enabled -}}
+{{- printf "%s-%s.%s.svc:%s" .Release.Name "minio" .Release.Namespace (.Values.minio.service.port | toString) -}}
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
Commit d75c89a164ff96f3a1b400ab59c0d2bac67896cf introduced a bug that caused an error when MinIO was disabled. It was caused by the `"enterprise-logs.minio"` template macro, which tried to sus the service port configuration even when `minio.enabled` was set to `false`.

---

This PR includes PR #832 