### PR TITLE
Remove spurious port definition on Grafana Pods.

### DIFF
--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -314,9 +314,6 @@ containers:
         mountPath: {{ .mountPath }}
     {{- end }}
     ports:
-      - name: {{ .Values.service.portName }}
-        containerPort: {{ .Values.service.port }}
-        protocol: TCP
       - name: {{ .Values.podPortName }}
         containerPort: 3000
         protocol: TCP


### PR DESCRIPTION
The Grafana Pods declare two ports. One is hard-coded to 3000 (translated to 80 by the default value for the Service port). The other adds the _Service_ port details to the _Pods_. This looks like a copy-and-paste error?

This is causing me real issues - leaving `Values.service.port` set to `80` just results in a spurious port definition, but setting it to 3000 (where a lot of systems expect grafana to be) causes TWO ports 3000 to be declared on the grafana Deployment. kubectl is happy to apply those manifests, but some things eg Flux 2 do more rigours checks and reject the resource.