### PR TITLE
[tempo] Fix server.http_listen_port in tempo-query backend config

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 0.11.0
+version: 0.12.0
 appVersion: 1.2.1
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.1](https://img.shields.io/badge/AppVersion-1.2.1-informational?style=flat-square)
+![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.1](https://img.shields.io/badge/AppVersion-1.2.1-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 

--- a/charts/tempo/templates/configmap-tempo-query.yaml
+++ b/charts/tempo/templates/configmap-tempo-query.yaml
@@ -7,4 +7,4 @@ metadata:
     {{- include "tempo.labels" . | nindent 4 }}
 data:
   tempo-query.yaml: |
-    backend: {{ template "tempo.fullname" . }}:{{ .Values.tempo.server.httpListenPort }}
+    backend: {{ template "tempo.fullname" . }}:{{ .Values.tempo.server.http_listen_port }}


### PR DESCRIPTION
`tempo.server.httpListenPort` was renamed `tempo.server.http_listen_port` in #822 .

This should also use `tempo.server.http_listen_port` in backend url in tempo-query config.