### PR TITLE
[enterprise-logs] bumped version of loki-distributed chart

### DIFF
--- a/charts/enterprise-logs/CHANGELOG.md
+++ b/charts/enterprise-logs/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## 1.3.3
+
+- [BUGFIX] Bumped version of `loki-disctributed` chart to 0.39.3 that defines default WAL location. #863
+
 ## 1.3.2
 
 - [BUGFIX] Fixed issue that caused GEL version not to be updated in the templates of the loki-distributed child chart. #863

--- a/charts/enterprise-logs/Chart.lock
+++ b/charts/enterprise-logs/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: loki-distributed
   repository: https://grafana.github.io/helm-charts
-  version: 0.37.3
+  version: 0.39.3
 - name: minio
   repository: https://helm.min.io/
   version: 8.0.9
-digest: sha256:fa052639999004f64f6ac6e847a91ab2b8ecd814f90df4c4ebab246b3c178e05
-generated: "2021-09-16T17:30:46.384947051+02:00"
+digest: sha256:6158172124f81a657a4652eba44e6187120311154755cd3497a2501e9e41fd3f
+generated: "2021-11-30T16:46:51.046894+02:00"

--- a/charts/enterprise-logs/Chart.yaml
+++ b/charts/enterprise-logs/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: "v2"
 name: "enterprise-logs"
 type: application
-version: "1.3.2"
+version: "1.3.3"
 appVersion: "v1.2.0"
 kubeVersion: "^1.10.0-0"
 description: "Grafana Enterprise Logs"
 home: "https://grafana.com/products/enterprise/logs/"
 dependencies:
 - name: loki-distributed
-  version: ^0.37.3
+  version: ^0.39.3
   repository: https://grafana.github.io/helm-charts
 - name: minio
   alias: minio


### PR DESCRIPTION
fixes the issue #853 

> in GEL:v1.2.0 , WAL is enabled by default and the default WAL path is wal that makes the app to create a folder wal in working directory (/ect/enterprise-logs/) that is read-only.

the latest version of loki-distributed defines correct path for the WAL.