### PR TITLE
[loki-distributed] Loki config as secret

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.4.1
-version: 0.39.2
+version: 0.39.3
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -78,7 +78,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | compactor.serviceLabels | object | `{}` | Labels for compactor service |
 | compactor.terminationGracePeriodSeconds | int | `30` | Grace period to allow the compactor to shutdown before it is killed |
 | compactor.tolerations | list | `[]` | Tolerations for compactor pods |
-| configAsSecrets | bool | `false` | Save config as a secrets |
+| configAsSecret | bool | `false` | Save config as a secrets |
 | distributor.affinity | string | Hard node and soft zone anti-affinity | Affinity for distributor pods. Passed through `tpl` and, thus, to be configured as string |
 | distributor.autoscaling.enabled | bool | `false` | Enable autoscaling for the distributor |
 | distributor.autoscaling.maxReplicas | int | `3` | Maximum autoscaling replicas for the distributor |

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -78,6 +78,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | compactor.serviceLabels | object | `{}` | Labels for compactor service |
 | compactor.terminationGracePeriodSeconds | int | `30` | Grace period to allow the compactor to shutdown before it is killed |
 | compactor.tolerations | list | `[]` | Tolerations for compactor pods |
+| configAsSecrets | bool | `false` | Save config as a secrets |
 | distributor.affinity | string | Hard node and soft zone anti-affinity | Affinity for distributor pods. Passed through `tpl` and, thus, to be configured as string |
 | distributor.autoscaling.enabled | bool | `false` | Enable autoscaling for the distributor |
 | distributor.autoscaling.maxReplicas | int | `3` | Maximum autoscaling replicas for the distributor |

--- a/charts/loki-distributed/templates/compactor/deployment-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/deployment-compactor.yaml
@@ -89,6 +89,9 @@ spec:
           {{- if .Values.loki.existingSecretForConfig }}
           secret:
             secretName: {{ .Values.loki.existingSecretForConfig }}
+          {{- else if .Values.configAsSecret }}
+          secret:
+            secretName: {{ include "loki.fullname" . }}
           {{- else }}
           configMap:
             name: {{ include "loki.fullname" . }}

--- a/charts/loki-distributed/templates/compactor/deployment-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/deployment-compactor.yaml
@@ -89,7 +89,7 @@ spec:
           {{- if .Values.loki.existingSecretForConfig }}
           secret:
             secretName: {{ .Values.loki.existingSecretForConfig }}
-          {{- else if .Values.configAsSecret }}
+          {{- else if .Values.configAsSecret.enabled }}
           secret:
             secretName: {{ include "loki.fullname" . }}
           {{- else }}

--- a/charts/loki-distributed/templates/configmap.yaml
+++ b/charts/loki-distributed/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.loki.existingSecretForConfig) (not .Values.configAsSecrets) -}}
+{{- if and (not .Values.loki.existingSecretForConfig) (not .Values.configAsSecret.enabled) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/loki-distributed/templates/distributor/deployment-distributor.yaml
+++ b/charts/loki-distributed/templates/distributor/deployment-distributor.yaml
@@ -97,7 +97,7 @@ spec:
           {{- if .Values.loki.existingSecretForConfig }}
           secret:
             secretName: {{ .Values.loki.existingSecretForConfig }}
-          {{- else if .Values.configAsSecret }}
+          {{- else if .Values.configAsSecret.enabled }}
           secret:
             secretName: {{ include "loki.fullname" . }}
           {{- else }}

--- a/charts/loki-distributed/templates/distributor/deployment-distributor.yaml
+++ b/charts/loki-distributed/templates/distributor/deployment-distributor.yaml
@@ -97,6 +97,9 @@ spec:
           {{- if .Values.loki.existingSecretForConfig }}
           secret:
             secretName: {{ .Values.loki.existingSecretForConfig }}
+          {{- else if .Values.configAsSecret }}
+          secret:
+            secretName: {{ include "loki.fullname" . }}
           {{- else }}
           configMap:
             name: {{ include "loki.fullname" . }}

--- a/charts/loki-distributed/templates/index-gateway/statefulset-index-gateway.yaml
+++ b/charts/loki-distributed/templates/index-gateway/statefulset-index-gateway.yaml
@@ -93,7 +93,7 @@ spec:
           {{- if .Values.loki.existingSecretForConfig }}
           secret:
             secretName: {{ .Values.loki.existingSecretForConfig }}
-          {{- else if .Values.configAsSecret }}
+          {{- else if .Values.configAsSecret.enabled }}
           secret:
             secretName: {{ include "loki.fullname" . }}
           {{- else }}

--- a/charts/loki-distributed/templates/index-gateway/statefulset-index-gateway.yaml
+++ b/charts/loki-distributed/templates/index-gateway/statefulset-index-gateway.yaml
@@ -93,6 +93,9 @@ spec:
           {{- if .Values.loki.existingSecretForConfig }}
           secret:
             secretName: {{ .Values.loki.existingSecretForConfig }}
+          {{- else if .Values.configAsSecret }}
+          secret:
+            secretName: {{ include "loki.fullname" . }}
           {{- else }}
           configMap:
             name: {{ include "loki.fullname" . }}

--- a/charts/loki-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/statefulset-ingester.yaml
@@ -98,6 +98,9 @@ spec:
           {{- if .Values.loki.existingSecretForConfig }}
           secret:
             secretName: {{ .Values.loki.existingSecretForConfig }}
+          {{- else if .Values.configAsSecret }}
+          secret:
+            secretName: {{ include "loki.fullname" . }}
           {{- else }}
           configMap:
             name: {{ include "loki.fullname" . }}

--- a/charts/loki-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/statefulset-ingester.yaml
@@ -98,7 +98,7 @@ spec:
           {{- if .Values.loki.existingSecretForConfig }}
           secret:
             secretName: {{ .Values.loki.existingSecretForConfig }}
-          {{- else if .Values.configAsSecret }}
+          {{- else if .Values.configAsSecret.enabled }}
           secret:
             secretName: {{ include "loki.fullname" . }}
           {{- else }}

--- a/charts/loki-distributed/templates/querier/deployment-querier.yaml
+++ b/charts/loki-distributed/templates/querier/deployment-querier.yaml
@@ -100,7 +100,7 @@ spec:
           {{- if .Values.loki.existingSecretForConfig }}
           secret:
             secretName: {{ .Values.loki.existingSecretForConfig }}
-          {{- else if .Values.configAsSecret }}
+          {{- else if .Values.configAsSecret.enabled }}
           secret:
             secretName: {{ include "loki.fullname" . }}
           {{- else }}

--- a/charts/loki-distributed/templates/querier/deployment-querier.yaml
+++ b/charts/loki-distributed/templates/querier/deployment-querier.yaml
@@ -100,6 +100,9 @@ spec:
           {{- if .Values.loki.existingSecretForConfig }}
           secret:
             secretName: {{ .Values.loki.existingSecretForConfig }}
+          {{- else if .Values.configAsSecret }}
+          secret:
+            secretName: {{ include "loki.fullname" . }}
           {{- else }}
           configMap:
             name: {{ include "loki.fullname" . }}

--- a/charts/loki-distributed/templates/querier/statefulset-querier.yaml
+++ b/charts/loki-distributed/templates/querier/statefulset-querier.yaml
@@ -99,6 +99,9 @@ spec:
           {{- if .Values.loki.existingSecretForConfig }}
           secret:
             secretName: {{ .Values.loki.existingSecretForConfig }}
+          {{- else if .Values.configAsSecret }}
+          secret:
+            secretName: {{ include "loki.fullname" . }}
           {{- else }}
           configMap:
             name: {{ include "loki.fullname" . }}

--- a/charts/loki-distributed/templates/querier/statefulset-querier.yaml
+++ b/charts/loki-distributed/templates/querier/statefulset-querier.yaml
@@ -99,7 +99,7 @@ spec:
           {{- if .Values.loki.existingSecretForConfig }}
           secret:
             secretName: {{ .Values.loki.existingSecretForConfig }}
-          {{- else if .Values.configAsSecret }}
+          {{- else if .Values.configAsSecret.enabled }}
           secret:
             secretName: {{ include "loki.fullname" . }}
           {{- else }}

--- a/charts/loki-distributed/templates/query-frontend/deployment-query-frontend.yaml
+++ b/charts/loki-distributed/templates/query-frontend/deployment-query-frontend.yaml
@@ -90,7 +90,7 @@ spec:
           {{- if .Values.loki.existingSecretForConfig }}
           secret:
             secretName: {{ .Values.loki.existingSecretForConfig }}
-          {{- else if .Values.configAsSecret }}
+          {{- else if .Values.configAsSecret.enabled }}
           secret:
             secretName: {{ include "loki.fullname" . }}
           {{- else }}

--- a/charts/loki-distributed/templates/query-frontend/deployment-query-frontend.yaml
+++ b/charts/loki-distributed/templates/query-frontend/deployment-query-frontend.yaml
@@ -90,6 +90,9 @@ spec:
           {{- if .Values.loki.existingSecretForConfig }}
           secret:
             secretName: {{ .Values.loki.existingSecretForConfig }}
+          {{- else if .Values.configAsSecret }}
+          secret:
+            secretName: {{ include "loki.fullname" . }}
           {{- else }}
           configMap:
             name: {{ include "loki.fullname" . }}

--- a/charts/loki-distributed/templates/ruler/deployment-ruler.yaml
+++ b/charts/loki-distributed/templates/ruler/deployment-ruler.yaml
@@ -101,6 +101,9 @@ spec:
           {{- if .Values.loki.existingSecretForConfig }}
           secret:
             secretName: {{ .Values.loki.existingSecretForConfig }}
+          {{- else if .Values.configAsSecret }}
+          secret:
+            secretName: {{ include "loki.fullname" . }}
           {{- else }}
           configMap:
             name: {{ include "loki.fullname" . }}

--- a/charts/loki-distributed/templates/ruler/deployment-ruler.yaml
+++ b/charts/loki-distributed/templates/ruler/deployment-ruler.yaml
@@ -101,7 +101,7 @@ spec:
           {{- if .Values.loki.existingSecretForConfig }}
           secret:
             secretName: {{ .Values.loki.existingSecretForConfig }}
-          {{- else if .Values.configAsSecret }}
+          {{- else if .Values.configAsSecret.enabled }}
           secret:
             secretName: {{ include "loki.fullname" . }}
           {{- else }}

--- a/charts/loki-distributed/templates/secret.yaml
+++ b/charts/loki-distributed/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.loki.existingSecretForConfig) .Values.configAsSecrets -}}
+{{- if and (not .Values.loki.existingSecretForConfig) .Values.configAsSecret.enabled -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,6 +6,5 @@ metadata:
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 data:
-  config.yaml: |
-    {{ tpl .Values.loki.config . | nindent 4 | b64enc }}
+  config.yaml: {{ tpl .Values.loki.config . | nindent 4 | b64enc }}
 {{- end -}}

--- a/charts/loki-distributed/templates/secret.yaml
+++ b/charts/loki-distributed/templates/secret.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 data:
-  config.yaml: {{ tpl .Values.loki.config . | nindent 4 | b64enc }}
+  config.yaml: {{ tpl .Values.loki.config . | b64enc }}
 {{- end -}}

--- a/charts/loki-distributed/templates/secret.yaml
+++ b/charts/loki-distributed/templates/secret.yaml
@@ -1,11 +1,11 @@
-{{- if and (not .Values.loki.existingSecretForConfig) (not .Values.configAsSecrets) -}}
+{{- if and (not .Values.loki.existingSecretForConfig) .Values.configAsSecrets -}}
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: {{ include "loki.fullname" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 data:
   config.yaml: |
-    {{- tpl .Values.loki.config . | nindent 4 }}
+    {{ tpl .Values.loki.config . | nindent 4 | b64enc }}
 {{- end -}}

--- a/charts/loki-distributed/templates/table-manager/deployment-table-manager.yaml
+++ b/charts/loki-distributed/templates/table-manager/deployment-table-manager.yaml
@@ -87,7 +87,7 @@ spec:
           {{- if .Values.loki.existingSecretForConfig }}
           secret:
             secretName: {{ .Values.loki.existingSecretForConfig }}
-          {{- else if .Values.configAsSecret }}
+          {{- else if .Values.configAsSecret.enabled }}
           secret:
             secretName: {{ include "loki.fullname" . }}
           {{- else }}

--- a/charts/loki-distributed/templates/table-manager/deployment-table-manager.yaml
+++ b/charts/loki-distributed/templates/table-manager/deployment-table-manager.yaml
@@ -87,6 +87,9 @@ spec:
           {{- if .Values.loki.existingSecretForConfig }}
           secret:
             secretName: {{ .Values.loki.existingSecretForConfig }}
+          {{- else if .Values.configAsSecret }}
+          secret:
+            secretName: {{ include "loki.fullname" . }}
           {{- else }}
           configMap:
             name: {{ include "loki.fullname" . }}

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -14,6 +14,10 @@ global:
 # -- Overrides the chart's name
 nameOverride: null
 
+# -- Loki config as a secrets
+configAsSecret: 
+  enabled: false
+
 # -- Overrides the chart's computed fullname
 fullnameOverride: null
 


### PR DESCRIPTION
When we use external storage, access keys will be wrote on CM, it's bad. 

Added flag will create and mount config as a secret to hide private data