### PR TITLE
[grafana] Alerting: add options and documentation to deploy a HA cluster

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.17.9
+version: 6.17.10
 appVersion: 8.2.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -75,6 +75,7 @@ This version requires Helm >= 3.1.0.
 | `service.loadBalancerIP`                  | IP address to assign to load balancer (if supported) | `nil`                                            |
 | `service.loadBalancerSourceRanges`        | list of IP CIDRs allowed access to lb (if supported) | `[]`                                             |
 | `service.externalIPs`                     | service external IP addresses                 | `[]`                                                    |
+| `headlessService`                         | Create a headless service                     | `false`                                                 |
 | `extraExposePorts`                        | Additional service ports for sidecar containers| `[]`                                                   |
 | `hostAliases`                             | adds rules to the pod's /etc/hosts            | `[]`                                                    |
 | `ingress.enabled`                         | Enables Ingress                               | `false`                                                 |
@@ -528,3 +529,23 @@ imageRenderer:
 ### Image Renderer NetworkPolicy
 
 By default the image-renderer pods will have a network policy which only allows ingress traffic from the created grafana instance
+
+### High Availability for unified alerting
+
+If you want to run Grafana in a high availability cluster you need to enable 
+the headless service by setting `headlessService: true` in your `values.yaml`
+file.
+
+As next step you have to setup the `grafana.ini` in a way that it will make use
+of the headless service to obtain all the IPs of the cluster. You should replace
+``{{ Name }}`` with the name of your helm deployment.
+
+```yaml
+grafana.ini:
+  ...
+  unified_alerting:
+    enabled: true
+    ha_peers: {{ Name }}-headless:9094
+  alerting:
+    enabled: false
+```

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -536,9 +536,9 @@ If you want to run Grafana in a high availability cluster you need to enable
 the headless service by setting `headlessService: true` in your `values.yaml`
 file.
 
-As next step you have to setup the `grafana.ini` in a way that it will make use
-of the headless service to obtain all the IPs of the cluster. You should replace
-``{{ Name }}`` with the name of your helm deployment.
+As next step you have to setup the `grafana.ini` in your `values.yaml` in a way 
+that it will make use of the headless service to obtain all the IPs of the 
+cluster. You should replace ``{{ Name }}`` with the name of your helm deployment.
 
 ```yaml
 grafana.ini:

--- a/charts/grafana/templates/headless-service.yaml
+++ b/charts/grafana/templates/headless-service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.persistence.type "statefulset")}}
+{{- if or .Values.headlessService (and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.persistence.type "statefulset"))}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,4 +15,8 @@ spec:
   selector:
     {{- include "grafana.selectorLabels" . | nindent 4 }}
   type: ClusterIP
+  ports:
+  - protocol: TCP
+    port: 3000
+    targetPort: 3000
 {{- end }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -23,6 +23,9 @@ serviceAccount:
 
 replicas: 1
 
+## Create a headless service for the deployment
+headlessService: false
+
 ## Create HorizontalPodAutoscaler object for deployment type
 #
 autoscaling:


### PR DESCRIPTION
This PR adds the possibility to create a headless service for normal deployments and adds some documentation on how to setup a cluster for unfied alerting.

fixes #747 