### PR TITLE
[enterprise-metrics] Remove non-relevant default limits

### DIFF
--- a/charts/enterprise-metrics/CHANGELOG.md
+++ b/charts/enterprise-metrics/CHANGELOG.md
@@ -10,6 +10,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the Pull Request that introduced the change.
 
+## 1.7.1
+
+* [BUGFIX] Remove chunks related default limits. #867
+
 ## 1.7.0
 
 * [FEATURE] Upgrade to [Grafana Enterprise Metrics v1.6.1](https://grafana.com/docs/metrics-enterprise/latest/downloads/#v161----november-18th-2021). #839

--- a/charts/enterprise-metrics/Chart.yaml
+++ b/charts/enterprise-metrics/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.7.0
+version: 1.7.1
 appVersion: v1.6.1
 description: 'Grafana Enterprise Metrics'
 engine: gotpl

--- a/charts/enterprise-metrics/values.yaml
+++ b/charts/enterprise-metrics/values.yaml
@@ -89,10 +89,7 @@ config:
     distributor_client:
       address: 'dns:///{{ template "enterprise-metrics.fullname" . }}-distributor.{{ .Release.Namespace }}.svc:{{ .Values.config.server.grpc_listen_port }}'
 
-  limits:
-    enforce_metric_name: false
-    reject_old_samples: true
-    reject_old_samples_max_age: 168h
+  limits: {}
 
   server:
     http_listen_port: 8080


### PR DESCRIPTION
I think these limits shouldn't be set in this way, as they are likely to
come from copy-pasting the loki helm chart.

- `enforce_metric_name: false`: Is required for Loki, but not really helpful for Metrics.
- `reject_old_samples: true`/`reject_old_samples_max_age: 168h` are not relevant for TSDB storage engine, as the limiting factor is the TSDB storage engine for ingestion older samples, rathern than these defaults.
