### PR TITLE
[enterprise-metrics] Extend enterprise metrics with graphite proxy

### DIFF
--- a/charts/enterprise-metrics/Chart.yaml
+++ b/charts/enterprise-metrics/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.7.2
+version: 1.7.3
 appVersion: v1.6.1
 description: "Grafana Enterprise Metrics"
 engine: gotpl

--- a/charts/enterprise-metrics/capped-large.yaml
+++ b/charts/enterprise-metrics/capped-large.yaml
@@ -151,3 +151,33 @@ store_gateway:
     limits:
       cpu: 1
       memory: 6Gi
+
+graphite_querier:
+  replicas: 6
+  resources:
+    limits:
+      cpu: 1
+      memory: 12Gi
+    requests:
+      cpu: 1
+      memory: 12Gi
+
+graphite_write_proxy:
+  replicas: 6
+  resources:
+    limits:
+      cpu: 1
+      memory: 8Gi
+    requests:
+      cpu: 1
+      memory: 8Gi
+
+graphite_web:
+  replicas: 1
+  resources:
+    limits:
+      cpu: 1
+      memory: 8Gi
+    requests:
+      cpu: 1
+      memory: 8Gi

--- a/charts/enterprise-metrics/capped-small.yaml
+++ b/charts/enterprise-metrics/capped-small.yaml
@@ -151,3 +151,33 @@ store_gateway:
     limits:
       cpu: 1
       memory: 6Gi
+
+graphite_querier:
+  replicas: 2
+  resources:
+    limits:
+      cpu: 1
+      memory: 12Gi
+    requests:
+      cpu: 1
+      memory: 12Gi
+
+graphite_write_proxy:
+  replicas: 2
+  resources:
+    limits:
+      cpu: 1
+      memory: 4Gi
+    requests:
+      cpu: 1
+      memory: 4Gi
+
+graphite_web:
+  replicas: 1
+  resources:
+    limits:
+      cpu: 1
+      memory: 4Gi
+    requests:
+      cpu: 1
+      memory: 4Gi

--- a/charts/enterprise-metrics/large.yaml
+++ b/charts/enterprise-metrics/large.yaml
@@ -138,3 +138,28 @@ store_gateway:
     requests:
       cpu: 1
       memory: 6Gi
+
+graphite_querier:
+  replicas: 6
+  resources:
+    limits:
+      memory: 24Gi
+    requests:
+      cpu: 1
+      memory: 12Gi
+
+graphite_write_proxy:
+  replicas: 6
+  resources:
+    limits:
+      memory: 8Gi
+    requests:
+      cpu: 1
+      memory: 4Gi
+
+graphite_web:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi

--- a/charts/enterprise-metrics/small.yaml
+++ b/charts/enterprise-metrics/small.yaml
@@ -138,3 +138,28 @@ store_gateway:
     requests:
       cpu: 1
       memory: 6Gi
+
+graphite_querier:
+  replicas: 2
+  resources:
+    limits:
+      memory: 24Gi
+    requests:
+      cpu: 1
+      memory: 12Gi
+
+graphite_write_proxy:
+  replicas: 2
+  resources:
+    limits:
+      memory: 8Gi
+    requests:
+      cpu: 1
+      memory: 4Gi
+
+graphite_web:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi

--- a/charts/enterprise-metrics/templates/gateway-dep.yaml
+++ b/charts/enterprise-metrics/templates/gateway-dep.yaml
@@ -72,7 +72,7 @@ spec:
             - -gateway.proxy.admin-api.url=http://{{ template "enterprise-metrics.fullname" . }}-admin-api.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
             - -gateway.proxy.alertmanager.url=http://{{ template "enterprise-metrics.fullname" . }}-alertmanager.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
             - -gateway.proxy.distributor.url=http://{{ template "enterprise-metrics.fullname" . }}-distributor.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
-            - -gateway.proxy.graphite.url=http://{{ template "enterprise-metrics.fullname" . }}-graphite.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
+            - -gateway.proxy.graphite.url=http://{{ template "enterprise-metrics.fullname" . }}-graphite-querier.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
             - -gateway.proxy.ingester.url=http://{{ template "enterprise-metrics.fullname" . }}-ingester.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
             - -gateway.proxy.query-frontend.url=http://{{ template "enterprise-metrics.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
             - -gateway.proxy.ruler.url=http://{{ template "enterprise-metrics.fullname" . }}-ruler.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}

--- a/charts/enterprise-metrics/templates/gateway-dep.yaml
+++ b/charts/enterprise-metrics/templates/gateway-dep.yaml
@@ -72,7 +72,7 @@ spec:
             - -gateway.proxy.admin-api.url=http://{{ template "enterprise-metrics.fullname" . }}-admin-api.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
             - -gateway.proxy.alertmanager.url=http://{{ template "enterprise-metrics.fullname" . }}-alertmanager.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
             - -gateway.proxy.distributor.url=http://{{ template "enterprise-metrics.fullname" . }}-distributor.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
-            - -gateway.proxy.graphite.url=http://{{ template "enterprise-metrics.fullname" . }}-graphite-querier.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
+            - -gateway.proxy.graphite-querier.url=http://{{ template "enterprise-metrics.fullname" . }}-graphite-querier.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
             - -gateway.proxy.ingester.url=http://{{ template "enterprise-metrics.fullname" . }}-ingester.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
             - -gateway.proxy.query-frontend.url=http://{{ template "enterprise-metrics.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
             - -gateway.proxy.ruler.url=http://{{ template "enterprise-metrics.fullname" . }}-ruler.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}

--- a/charts/enterprise-metrics/templates/gateway-dep.yaml
+++ b/charts/enterprise-metrics/templates/gateway-dep.yaml
@@ -73,6 +73,7 @@ spec:
             - -gateway.proxy.alertmanager.url=http://{{ template "enterprise-metrics.fullname" . }}-alertmanager.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
             - -gateway.proxy.distributor.url=http://{{ template "enterprise-metrics.fullname" . }}-distributor.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
             - -gateway.proxy.graphite-querier.url=http://{{ template "enterprise-metrics.fullname" . }}-graphite-querier.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
+            - -gateway.proxy.graphite-write-proxy.url=http://{{ template "enterprise-metrics.fullname" . }}-graphite-write-proxy.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
             - -gateway.proxy.ingester.url=http://{{ template "enterprise-metrics.fullname" . }}-ingester.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
             - -gateway.proxy.query-frontend.url=http://{{ template "enterprise-metrics.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
             - -gateway.proxy.ruler.url=http://{{ template "enterprise-metrics.fullname" . }}-ruler.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}

--- a/charts/enterprise-metrics/templates/graphite-querier-dep.yaml
+++ b/charts/enterprise-metrics/templates/graphite-querier-dep.yaml
@@ -58,7 +58,6 @@ spec:
             - -target=graphite-querier
             - -config.file=/etc/enterprise-metrics/enterprise-metrics.yaml
             - -graphite.enabled=true
-            - -graphite.querier.remote-read-enabled=true
             - -graphite.querier.query-address=http://{{ template "enterprise-metrics.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}/api/prom
             - -graphite.querier.graphite-fallback=http://{{ template "enterprise-metrics.fullname" . }}-graphite-web.{{ .Release.Namespace}}.svc:{{ .Values.config.server.http_listen_port }}
             - -graphite.querier.schemas.default-storage-schemas-file=/etc/graphite-proxy/storage-schemas.conf

--- a/charts/enterprise-metrics/templates/graphite-querier-dep.yaml
+++ b/charts/enterprise-metrics/templates/graphite-querier-dep.yaml
@@ -56,7 +56,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - -target=graphite-querier
-            - -config.file=/etc/enterprise-metrics/enterprise-metrics.yaml # TODO(jesus.vazquez) Remove when metrics enterprise v1.6.2 is released
+            - -config.file=/etc/enterprise-metrics/enterprise-metrics.yaml
             - -graphite.enabled=true
             - -graphite.querier.remote-read-enabled=true
             - -graphite.querier.query-address=http://{{ template "enterprise-metrics.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}/api/prom

--- a/charts/enterprise-metrics/templates/graphite-querier-dep.yaml
+++ b/charts/enterprise-metrics/templates/graphite-querier-dep.yaml
@@ -73,11 +73,6 @@ spec:
             - -admin.client.s3.access-key-id=enterprise-metrics
             - -admin.client.s3.secret-access-key=supersecret
             - -admin.client.s3.insecure=true
-            - -blocks-storage.s3.endpoint={{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000
-            - -blocks-storage.s3.bucket-name=enterprise-metrics-tsdb
-            - -blocks-storage.s3.access-key-id=enterprise-metrics
-            - -blocks-storage.s3.secret-access-key=supersecret
-            - -blocks-storage.s3.insecure=true
             {{- end }}
           {{- range $key, $value := .Values.graphite_querier.extraArgs }}
             - "-{{ $key }}={{ $value }}"

--- a/charts/enterprise-metrics/templates/graphite-querier-dep.yaml
+++ b/charts/enterprise-metrics/templates/graphite-querier-dep.yaml
@@ -24,7 +24,6 @@ spec:
         app: {{ template "enterprise-metrics.name" . }}-graphite-querier
         # The name label is important for cortex-mixin compatibility which expects certain names for services.
         name: graphite-querier
-        gossip_ring_member: "true"
         target: querier
         release: {{ .Release.Name }}
         {{- with .Values.graphite_querier.podLabels }}

--- a/charts/enterprise-metrics/templates/graphite-querier-dep.yaml
+++ b/charts/enterprise-metrics/templates/graphite-querier-dep.yaml
@@ -22,9 +22,6 @@ spec:
     metadata:
       labels:
         app: {{ template "enterprise-metrics.name" . }}-graphite-querier
-        # The name label is important for cortex-mixin compatibility which expects certain names for services.
-        name: graphite-querier
-        target: querier
         release: {{ .Release.Name }}
         {{- with .Values.graphite_querier.podLabels }}
         {{- toYaml . | nindent 8 }}

--- a/charts/enterprise-metrics/templates/graphite-querier-dep.yaml
+++ b/charts/enterprise-metrics/templates/graphite-querier-dep.yaml
@@ -1,32 +1,33 @@
+{{- if .Values.graphite.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "enterprise-metrics.fullname" . }}-querier
+  name: {{ template "enterprise-metrics.fullname" . }}-graphite-querier
   labels:
-    app: {{ template "enterprise-metrics.name" . }}-querier
+    app: {{ template "enterprise-metrics.name" . }}-graphite-querier
     chart: {{ template "enterprise-metrics.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    {{- toYaml .Values.querier.annotations | nindent 4 }}
+    {{- toYaml .Values.graphite_querier.annotations | nindent 4 }}
 spec:
-  replicas: {{ .Values.querier.replicas }}
+  replicas: {{ .Values.graphite_querier.replicas }}
   selector:
     matchLabels:
-      app: {{ template "enterprise-metrics.name" . }}-querier
+      app: {{ template "enterprise-metrics.name" . }}-graphite-querier
       release: {{ .Release.Name }}
   strategy:
-    {{- toYaml .Values.querier.strategy | nindent 4 }}
+    {{- toYaml .Values.graphite_querier.strategy | nindent 4 }}
   template:
     metadata:
       labels:
-        app: {{ template "enterprise-metrics.name" . }}-querier
+        app: {{ template "enterprise-metrics.name" . }}-graphite-querier
         # The name label is important for cortex-mixin compatibility which expects certain names for services.
-        name: querier
+        name: graphite-querier
         gossip_ring_member: "true"
         target: querier
         release: {{ .Release.Name }}
-        {{- with .Values.querier.podLabels }}
+        {{- with .Values.graphite_querier.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
@@ -35,18 +36,18 @@ spec:
 {{- else }}
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
 {{- end}}
-        {{- with .Values.querier.podAnnotations }}
+        {{- with .Values.graphite_querier.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
       serviceAccountName: {{ template "enterprise-metrics.serviceAccountName" . }}
-    {{- if .Values.querier.priorityClassName }}
-      priorityClassName: {{ .Values.querier.priorityClassName }}
+    {{- if .Values.graphite_querier.priorityClassName }}
+      priorityClassName: {{ .Values.graphite_querier.priorityClassName }}
     {{- end }}
       securityContext:
-        {{- toYaml .Values.querier.securityContext | nindent 8 }}
+        {{- toYaml .Values.graphite_querier.securityContext | nindent 8 }}
       initContainers:
-        {{- toYaml .Values.querier.initContainers | nindent 8 }}
+        {{- toYaml .Values.graphite_querier.initContainers | nindent 8 }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}
@@ -58,10 +59,14 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - "-target=querier"
-            - "-config.file=/etc/enterprise-metrics/enterprise-metrics.yaml"
-            - "-querier.frontend-address={{ template "enterprise-metrics.fullname" . }}-query-frontend-headless.{{ .Release.Namespace }}.svc:{{ .Values.config.server.grpc_listen_port }}"
-            - "-memberlist.join={{ template "enterprise-metrics.fullname" . }}-gossip-ring"
+            - -target=graphite-querier
+            - -config.file=/etc/enterprise-metrics/enterprise-metrics.yaml # TODO(jesus.vazquez) Remove when metrics enterprise v1.6.2 is released
+            - -graphite.enabled=true
+            - -graphite.querier.remote-read-enabled=true
+            - -graphite.querier.query-address=http://{{ template "enterprise-metrics.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}/api/prom
+            - -graphite.querier.graphite-fallback=http://{{ template "enterprise-metrics.fullname" . }}-graphite-web.{{ .Release.Namespace}}.svc:{{ .Values.config.server.http_listen_port }}
+            - -graphite.querier.schemas.default-storage-schemas-file=/etc/graphite-proxy/storage-schemas.conf
+            - -graphite.querier.schemas.default-storage-aggregations-file=/etc/graphite-proxy/storage-aggregations.conf
             {{- if .Values.minio.enabled }}
             - -admin.client.backend-type=s3
             - -admin.client.s3.endpoint={{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000
@@ -75,20 +80,12 @@ spec:
             - -blocks-storage.s3.secret-access-key=supersecret
             - -blocks-storage.s3.insecure=true
             {{- end }}
-            {{- if index .Values "memcached-metadata" "enabled" }}
-            - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-            - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dns+{{ .Release.Name }}-memcached-metadata.{{ .Release.Namespace }}.svc:11211
-            - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size={{ (index .Values "memcached-metadata").maxItemMemory }}
-            {{- end }}
-            {{- if eq .Values.config.storage.engine "blocks" }}
-            - -querier.store-gateway-addresses=dns+{{ template "enterprise-metrics.fullname" . }}-store-gateway.{{ .Release.Namespace }}.svc:{{ .Values.config.server.grpc_listen_port }}
-            {{- end }}
-          {{- range $key, $value := .Values.querier.extraArgs }}
+          {{- range $key, $value := .Values.graphite_querier.extraArgs }}
             - "-{{ $key }}={{ $value }}"
           {{- end }}
           volumeMounts:
-            {{- if .Values.querier.extraVolumeMounts }}
-              {{ toYaml .Values.querier.extraVolumeMounts | nindent 12}}
+            {{- if .Values.graphite_querier.extraVolumeMounts }}
+              {{ toYaml .Values.graphite_querier.extraVolumeMounts | nindent 12}}
             {{- end }}
             - name: config
               mountPath: /etc/enterprise-metrics
@@ -100,7 +97,7 @@ spec:
               mountPath: /license
             - name: storage
               mountPath: "/data"
-              subPath: {{ .Values.querier.persistence.subPath }}
+              subPath: {{ .Values.graphite_querier.persistence.subPath }}
           ports:
             - name: http-metrics
               containerPort: {{ .Values.config.server.http_listen_port }}
@@ -109,27 +106,27 @@ spec:
               containerPort: {{ .Values.config.server.grpc_listen_port }}
               protocol: TCP
           livenessProbe:
-            {{- toYaml .Values.querier.livenessProbe | nindent 12 }}
+            {{- toYaml .Values.graphite_querier.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.querier.readinessProbe | nindent 12 }}
+            {{- toYaml .Values.graphite_querier.readinessProbe | nindent 12 }}
           resources:
-            {{- toYaml .Values.querier.resources | nindent 12 }}
+            {{- toYaml .Values.graphite_querier.resources | nindent 12 }}
           securityContext:
             readOnlyRootFilesystem: true
           env:
-            {{- if .Values.querier.env }}
-              {{- toYaml .Values.querier.env | nindent 12 }}
+            {{- if .Values.graphite_querier.env }}
+              {{- toYaml .Values.graphite_querier.env | nindent 12 }}
             {{- end }}
-{{- if .Values.querier.extraContainers }}
-{{ toYaml .Values.querier.extraContainers | indent 8}}
+{{- if .Values.graphite_querier.extraContainers }}
+{{ toYaml .Values.graphite_querier.extraContainers | indent 8}}
 {{- end }}
       nodeSelector:
-        {{- toYaml .Values.querier.nodeSelector | nindent 8 }}
+        {{- toYaml .Values.graphite_querier.nodeSelector | nindent 8 }}
       affinity:
-        {{- toYaml .Values.querier.affinity | nindent 8 }}
+        {{- toYaml .Values.graphite_querier.affinity | nindent 8 }}
       tolerations:
-        {{- toYaml .Values.querier.tolerations | nindent 8 }}
-      terminationGracePeriodSeconds: {{ .Values.querier.terminationGracePeriodSeconds }}
+        {{- toYaml .Values.graphite_querier.tolerations | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.graphite_querier.terminationGracePeriodSeconds }}
       volumes:
         - name: config
           secret:
@@ -144,11 +141,12 @@ spec:
         - name: graphite-schemas
           configMap:
             name: {{ template "enterprise-metrics.fullname" . }}-graphite-schemas
-{{- if .Values.querier.extraVolumes }}
-{{ toYaml .Values.querier.extraVolumes | indent 8}}
+{{- if .Values.graphite_querier.extraVolumes }}
+{{ toYaml .Values.graphite_querier.extraVolumes | indent 8}}
 {{- end }}
         - name: license
           secret:
             secretName: {{ .Values.license.secretName }}
         - name: storage
           emptyDir: {}
+{{- end -}}

--- a/charts/enterprise-metrics/templates/graphite-querier-schemas-configmap.yaml
+++ b/charts/enterprise-metrics/templates/graphite-querier-schemas-configmap.yaml
@@ -11,12 +11,12 @@ metadata:
 data:
   storage-schemas.conf: |
     [default]
-    pattern = .*
-    intervals = 0:1s
-    retentions = 10s:8d,10min:1y
+    pattern = {{ .Values.graphite_querier.schemasConfiguration.storageSchemas.pattern }}
+    intervals = {{ .Values.graphite_querier.schemasConfiguration.storageSchemas.intervals }}
+    retentions = {{ .Values.graphite_querier.schemasConfiguration.storageSchemas.retentions }}
   storage-aggregations.conf: |
     [default]
-    aggregationMethod = avg
-    pattern = .*
-    xFilesFactor = 0.1
+    aggregationMethod = {{ .Values.graphite_querier.schemasConfiguration.storageAggregations.aggregationMethod }}
+    pattern = {{ .Values.graphite_querier.schemasConfiguration.storageAggregations.patern }}
+    xFilesFactor = {{ .Values.graphite_querier.schemasConfiguration.storageAggregations.xFilesFactor }}
 {{- end -}}

--- a/charts/enterprise-metrics/templates/graphite-querier-schemas-configmap.yaml
+++ b/charts/enterprise-metrics/templates/graphite-querier-schemas-configmap.yaml
@@ -9,14 +9,13 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
+{{- range  $storageSchemas := toStrings .Values.graphite_querier.schemasConfiguration.storageSchemas }}
   storage-schemas.conf: |
-    [default]
-    pattern = {{ .Values.graphite_querier.schemasConfiguration.storageSchemas.pattern }}
-    intervals = {{ .Values.graphite_querier.schemasConfiguration.storageSchemas.intervals }}
-    retentions = {{ .Values.graphite_querier.schemasConfiguration.storageSchemas.retentions }}
+{{ $storageSchemas | indent 4}}
+{{- end }}
+
+{{- range  $storageAggregations := toStrings .Values.graphite_querier.schemasConfiguration.storageAggregations }}
   storage-aggregations.conf: |
-    [default]
-    aggregationMethod = {{ .Values.graphite_querier.schemasConfiguration.storageAggregations.aggregationMethod }}
-    pattern = {{ .Values.graphite_querier.schemasConfiguration.storageAggregations.patern }}
-    xFilesFactor = {{ .Values.graphite_querier.schemasConfiguration.storageAggregations.xFilesFactor }}
+{{ $storageAggregations | indent 4}}
+{{- end }}
 {{- end -}}

--- a/charts/enterprise-metrics/templates/graphite-querier-schemas-configmap.yaml
+++ b/charts/enterprise-metrics/templates/graphite-querier-schemas-configmap.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.graphite.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "enterprise-metrics.fullname" . }}-graphite-schemas
+  labels:
+    app: {{ template "enterprise-metrics.name" . }}
+    chart: {{ template "enterprise-metrics.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  storage-schemas.conf: |
+    [default]
+    pattern = .*
+    intervals = 0:1s
+    retentions = 10s:8d,10min:1y
+  storage-aggregations.conf: |
+    [default]
+    aggregationMethod = avg
+    pattern = .*
+    xFilesFactor = 0.1
+{{- end -}}

--- a/charts/enterprise-metrics/templates/graphite-querier-svc.yaml
+++ b/charts/enterprise-metrics/templates/graphite-querier-svc.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.graphite.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "enterprise-metrics.fullname" . }}-graphite-querier
+  labels:
+    app: {{ template "enterprise-metrics.name" . }}-graphite-querier
+    chart: {{ template "enterprise-metrics.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- with .Values.graphite_querier.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- toYaml .Values.graphite_querier.annotations | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.config.server.http_listen_port }}
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: {{ .Values.config.server.grpc_listen_port }}
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app: {{ template "enterprise-metrics.name" . }}-graphite-querier
+    release: {{ .Release.Name }}
+{{- end -}}

--- a/charts/enterprise-metrics/templates/graphite-web-dep.yaml
+++ b/charts/enterprise-metrics/templates/graphite-web-dep.yaml
@@ -1,0 +1,72 @@
+{{- if .Values.graphite.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "enterprise-metrics.fullname" . }}-graphite-web
+  labels:
+    app: {{ template "enterprise-metrics.fullname" . }}-graphite-web
+    chart: {{ template "enterprise-metrics.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- toYaml .Values.graphite_web.deployment.annotations | nindent 4 }}
+spec:
+  replicas: {{ .Values.graphite_web.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "enterprise-metrics.fullname" . }}-graphite-web
+      release: {{ .Release.Name }}
+  strategy:
+    {{- toYaml .Values.graphite_web.strategy | nindent 4 }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "enterprise-metrics.fullname" . }}-graphite-web
+        target: {{ template "enterprise-metrics.fullname" . }}-graphite-web
+        release: {{ .Release.Name }}
+        {{- with .Values.graphite_web.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+      {{- with .Values.graphite_web.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ template "enterprise-metrics.serviceAccountName" . }}
+      containers:
+        - name: graphite-web
+          image: "{{ .Values.graphite_web.image.repository }}:{{ .Values.graphite_web.image.tag }}"
+          imagePullPolicy: {{ .Values.graphite_web.image.pullPolicy }}
+          env:
+            - name: GRAPHITE_CLUSTER_SERVERS
+              {{- if .Values.gateway.useDefaultProxyURLs }}
+              value: {{ template "enterprise-metrics.fullname" . }}-graphite.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}/graphite
+              {{- else }}
+              value: {{ template "enterprise-metrics.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}/graphite
+              {{- end }}
+            - name: GRAPHITE_ENFORCE_INPUT_VALIDATION
+              value: "true"
+            - name: GRAPHITE_POOL_WORKERS
+              value: "1"
+            - name: GRAPHITE_POOL_WORKERS_PER_BACKEND
+              value: "16"
+            - name: GRAPHITE_USE_WORKER_POOL
+              value: "false"
+            {{- range $key, $value := .Values.graphite_web.extraEnvVars }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.graphite_web.resources | nindent 12 }}
+      nodeSelector:
+        {{- toYaml .Values.graphite_web.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.graphite_web.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.graphite_web.tolerations | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.graphite_web.terminationGracePeriodSeconds }}
+{{- end -}}

--- a/charts/enterprise-metrics/templates/graphite-web-svc.yaml
+++ b/charts/enterprise-metrics/templates/graphite-web-svc.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.graphite.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "enterprise-metrics.fullname" . }}-graphite-web
+  labels:
+    app: {{ template "enterprise-metrics.fullname" . }}-graphite-web
+    chart: {{ template "enterprise-metrics.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- with .Values.graphite_web.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- toYaml .Values.graphite_web.service.annotations | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.config.server.http_listen_port }}
+      protocol: TCP
+      name: graphite-http
+      targetPort: 80
+  selector:
+    app: {{ template "enterprise-metrics.fullname" . }}-graphite-web
+    release: {{ .Release.Name }}
+{{- end -}}

--- a/charts/enterprise-metrics/templates/graphite-write-proxy-dep.yaml
+++ b/charts/enterprise-metrics/templates/graphite-write-proxy-dep.yaml
@@ -22,9 +22,6 @@ spec:
     metadata:
       labels:
         app: {{ template "enterprise-metrics.name" . }}-graphite-write-proxy
-        # The name label is important for cortex-mixin compatibility which expects certain names for services.
-        name: graphite-querier
-        target: querier
         release: {{ .Release.Name }}
         {{- with .Values.graphite_write_proxy.podLabels }}
         {{- toYaml . | nindent 8 }}

--- a/charts/enterprise-metrics/templates/graphite-write-proxy-dep.yaml
+++ b/charts/enterprise-metrics/templates/graphite-write-proxy-dep.yaml
@@ -1,0 +1,136 @@
+{{- if .Values.graphite.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "enterprise-metrics.fullname" . }}-graphite-write-proxy
+  labels:
+    app: {{ template "enterprise-metrics.name" . }}-graphite-write-proxy
+    chart: {{ template "enterprise-metrics.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- toYaml .Values.graphite_write_proxy.annotations | nindent 4 }}
+spec:
+  replicas: {{ .Values.graphite_write_proxy.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "enterprise-metrics.name" . }}-graphite-write-proxy
+      release: {{ .Release.Name }}
+  strategy:
+    {{- toYaml .Values.graphite_write_proxy.strategy | nindent 4 }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "enterprise-metrics.name" . }}-graphite-write-proxy
+        # The name label is important for cortex-mixin compatibility which expects certain names for services.
+        name: graphite-querier
+        gossip_ring_member: "true"
+        target: querier
+        release: {{ .Release.Name }}
+        {{- with .Values.graphite_write_proxy.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+{{- if .Values.useExternalConfig }}
+        checksum/config: {{ .Values.externalConfigVersion }}
+{{- else }}
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+{{- end}}
+        {{- with .Values.graphite_write_proxy.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "enterprise-metrics.serviceAccountName" . }}
+    {{- if .Values.graphite_write_proxy.priorityClassName }}
+      priorityClassName: {{ .Values.graphite_write_proxy.priorityClassName }}
+    {{- end }}
+      securityContext:
+        {{- toYaml .Values.graphite_write_proxy.securityContext | nindent 8 }}
+      initContainers:
+        {{- toYaml .Values.graphite_write_proxy.initContainers | nindent 8 }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end}}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - -target=graphite-write-proxy
+            - -license.path=/license/license.jwt
+            - -server.http-listen-port={{ .Values.config.server.http_listen_port }}
+            - -graphite.enabled=true
+            - -graphite.write-proxy.distributor-client.address=dns:///{{ template "enterprise-metrics.fullname" . }}-distributor.{{ .Release.Namespace }}.svc:{{ .Values.config.server.grpc_listen_port }}
+          {{- range $key, $value := .Values.graphite_write_proxy.extraArgs }}
+            - "-{{ $key }}={{ $value }}"
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.graphite_write_proxy.extraVolumeMounts }}
+              {{ toYaml .Values.graphite_write_proxy.extraVolumeMounts | nindent 12}}
+            {{- end }}
+            - name: config
+              mountPath: /etc/enterprise-metrics
+            - name: runtime-config
+              mountPath: /var/enterprise-metrics
+            - name: graphite-schemas
+              mountPath: /etc/graphite-proxy
+            - name: license
+              mountPath: /license
+            - name: storage
+              mountPath: "/data"
+              subPath: {{ .Values.graphite_write_proxy.persistence.subPath }}
+          ports:
+            - name: http-metrics
+              containerPort: {{ .Values.config.server.http_listen_port }}
+              protocol: TCP
+            - name: grpc
+              containerPort: {{ .Values.config.server.grpc_listen_port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.graphite_write_proxy.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.graphite_write_proxy.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.graphite_write_proxy.resources | nindent 12 }}
+          securityContext:
+            readOnlyRootFilesystem: true
+          env:
+            {{- if .Values.graphite_write_proxy.env }}
+              {{- toYaml .Values.graphite_write_proxy.env | nindent 12 }}
+            {{- end }}
+{{- if .Values.graphite_write_proxy.extraContainers }}
+{{ toYaml .Values.graphite_write_proxy.extraContainers | indent 8}}
+{{- end }}
+      nodeSelector:
+        {{- toYaml .Values.graphite_write_proxy.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.graphite_write_proxy.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.graphite_write_proxy.tolerations | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.graphite_write_proxy.terminationGracePeriodSeconds }}
+      volumes:
+        - name: config
+          secret:
+{{- if .Values.useExternalConfig }}
+            secretName: {{ .Values.externalConfigSecretName }}
+{{- else }}
+            secretName: {{ template "enterprise-metrics.fullname" . }}
+{{- end }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "enterprise-metrics.fullname" . }}-runtime
+        - name: graphite-schemas
+          configMap:
+            name: {{ template "enterprise-metrics.fullname" . }}-graphite-schemas
+{{- if .Values.graphite_write_proxy.extraVolumes }}
+{{ toYaml .Values.graphite_write_proxy.extraVolumes | indent 8}}
+{{- end }}
+        - name: license
+          secret:
+            secretName: {{ .Values.license.secretName }}
+        - name: storage
+          emptyDir: {}
+{{- end -}}

--- a/charts/enterprise-metrics/templates/graphite-write-proxy-dep.yaml
+++ b/charts/enterprise-metrics/templates/graphite-write-proxy-dep.yaml
@@ -75,8 +75,6 @@ spec:
               mountPath: /etc/enterprise-metrics
             - name: runtime-config
               mountPath: /var/enterprise-metrics
-            - name: graphite-schemas
-              mountPath: /etc/graphite-proxy
             - name: license
               mountPath: /license
             - name: storage
@@ -122,9 +120,6 @@ spec:
         - name: runtime-config
           configMap:
             name: {{ template "enterprise-metrics.fullname" . }}-runtime
-        - name: graphite-schemas
-          configMap:
-            name: {{ template "enterprise-metrics.fullname" . }}-graphite-schemas
 {{- if .Values.graphite_write_proxy.extraVolumes }}
 {{ toYaml .Values.graphite_write_proxy.extraVolumes | indent 8}}
 {{- end }}

--- a/charts/enterprise-metrics/templates/graphite-write-proxy-dep.yaml
+++ b/charts/enterprise-metrics/templates/graphite-write-proxy-dep.yaml
@@ -24,7 +24,6 @@ spec:
         app: {{ template "enterprise-metrics.name" . }}-graphite-write-proxy
         # The name label is important for cortex-mixin compatibility which expects certain names for services.
         name: graphite-querier
-        gossip_ring_member: "true"
         target: querier
         release: {{ .Release.Name }}
         {{- with .Values.graphite_write_proxy.podLabels }}

--- a/charts/enterprise-metrics/templates/graphite-write-proxy-svc.yaml
+++ b/charts/enterprise-metrics/templates/graphite-write-proxy-svc.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.graphite.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "enterprise-metrics.fullname" . }}-graphite-write-proxy
+  labels:
+    app: {{ template "enterprise-metrics.name" . }}-graphite-write-proxy
+    chart: {{ template "enterprise-metrics.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- with .Values.graphite_write_proxy.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- toYaml .Values.graphite_write_proxy.annotations | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.config.server.http_listen_port }}
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: {{ .Values.config.server.grpc_listen_port }}
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app: {{ template "enterprise-metrics.name" . }}-graphite-write-proxy
+    release: {{ .Release.Name }}
+  {{- end -}}

--- a/charts/enterprise-metrics/templates/querier-dep.yaml
+++ b/charts/enterprise-metrics/templates/querier-dep.yaml
@@ -83,6 +83,12 @@ spec:
             {{- if eq .Values.config.storage.engine "blocks" }}
             - -querier.store-gateway-addresses=dns+{{ template "enterprise-metrics.fullname" . }}-store-gateway.{{ .Release.Namespace }}.svc:{{ .Values.config.server.grpc_listen_port }}
             {{- end }}
+            {{- if eq .Values.graphite.enabled }}
+            - -graphite.enabled=true
+            - -graphite.querier.graphite-fallback=https://graphite
+            - -graphite.querier.remote-read-enabled=true
+            - -graphite.querier.query-address=TODO
+            {{- end }}
           {{- range $key, $value := .Values.querier.extraArgs }}
             - "-{{ $key }}={{ $value }}"
           {{- end }}

--- a/charts/enterprise-metrics/templates/querier-dep.yaml
+++ b/charts/enterprise-metrics/templates/querier-dep.yaml
@@ -94,8 +94,6 @@ spec:
               mountPath: /etc/enterprise-metrics
             - name: runtime-config
               mountPath: /var/enterprise-metrics
-            - name: graphite-schemas
-              mountPath: /etc/graphite-proxy
             - name: license
               mountPath: /license
             - name: storage
@@ -141,9 +139,6 @@ spec:
         - name: runtime-config
           configMap:
             name: {{ template "enterprise-metrics.fullname" . }}-runtime
-        - name: graphite-schemas
-          configMap:
-            name: {{ template "enterprise-metrics.fullname" . }}-graphite-schemas
 {{- if .Values.querier.extraVolumes }}
 {{ toYaml .Values.querier.extraVolumes | indent 8}}
 {{- end }}

--- a/charts/enterprise-metrics/templates/ruler-dep.yaml
+++ b/charts/enterprise-metrics/templates/ruler-dep.yaml
@@ -73,13 +73,12 @@ spec:
             - -blocks-storage.s3.access-key-id=enterprise-metrics
             - -blocks-storage.s3.secret-access-key=supersecret
             - -blocks-storage.s3.insecure=true
-            - -ruler.storage.type=s3
-            - -ruler.storage.s3.endpoint={{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000
-            - -ruler.storage.s3.buckets=enterprise-metrics-ruler
-            - -ruler.storage.s3.access-key-id=enterprise-metrics
-            - -ruler.storage.s3.secret-access-key=supersecret
-            - -ruler.storage.s3.insecure=true
-            - -ruler.storage.s3.force-path-style=true
+            - -ruler-storage.backend=s3
+            - -ruler-storage.s3.endpoint={{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000
+            - -ruler-storage.s3.bucket-name=enterprise-metrics-ruler
+            - -ruler-storage.s3.access-key-id=enterprise-metrics
+            - -ruler-storage.s3.secret-access-key=supersecret
+            - -ruler-storage.s3.insecure=true
            {{- end }}
             {{- if .Values.config.ruler.enable_alertmanager_discovery }}
             - "-ruler.alertmanager-discovery=true"

--- a/charts/enterprise-metrics/values.yaml
+++ b/charts/enterprise-metrics/values.yaml
@@ -1102,7 +1102,70 @@ graphite:
   enabled: true # TODO(jesus.vazquez) Set to false before merge, also propagate config to small.yaml and large.yaml
 
 graphite_querier:
-  replicas: 2
+  replicas: 1 #TODO(jesus.vazquez) Leave this to two replicas
+
+  service:
+    annotations: {}
+    labels: {}
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  # Additional Grafana Enterprise Metrics container arguments, e.g. log level (debug, info, warn, error)
+  extraArgs: {}
+
+  # Pod Labels
+  podLabels: {}
+
+  # Pod Annotations
+  podAnnotations: {}
+
+  nodeSelector: {}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: target
+                  operator: In
+                  values:
+                    - graphite-querier
+            topologyKey: 'kubernetes.io/hostname'
+
+  annotations: {}
+  persistence:
+    subPath:
+
+  readinessProbe:
+    httpGet:
+      path: /ready
+      port: http-metrics
+    initialDelaySeconds: 45
+
+  securityContext: {}
+
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+
+  terminationGracePeriodSeconds: 180
+
+  tolerations: []
+  podDisruptionBudget: {}
+  initContainers: []
+  extraContainers: []
+  extraVolumes: []
+  extraVolumeMounts: []
+  extraPorts: []
+
+graphite_write_proxy:
+  replicas: 1 #TODO(jesus.vazquez) Leave this to two replicas
 
   service:
     annotations: {}

--- a/charts/enterprise-metrics/values.yaml
+++ b/charts/enterprise-metrics/values.yaml
@@ -1096,5 +1096,119 @@ minio:
       memory: 128Mi
   secretKey: supersecret
 
-  graphite:
-    enabled: false
+graphite:
+  # If true, enables graphite querier and graphite writer functionality.
+  # Read more in https://grafana.com/docs/metrics-enterprise/latest/graphite/
+  enabled: true # TODO(jesus.vazquez) Set to false before merge, also propagate config to small.yaml and large.yaml
+
+graphite_querier:
+  replicas: 2
+
+  service:
+    annotations: {}
+    labels: {}
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  # Additional Grafana Enterprise Metrics container arguments, e.g. log level (debug, info, warn, error)
+  extraArgs: {}
+
+  # Pod Labels
+  podLabels: {}
+
+  # Pod Annotations
+  podAnnotations: {}
+
+  nodeSelector: {}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: target
+                  operator: In
+                  values:
+                    - graphite-querier
+            topologyKey: 'kubernetes.io/hostname'
+
+  annotations: {}
+  persistence:
+    subPath:
+
+  readinessProbe:
+    httpGet:
+      path: /ready
+      port: http-metrics
+    initialDelaySeconds: 45
+
+  securityContext: {}
+
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+
+  terminationGracePeriodSeconds: 180
+
+  tolerations: []
+  podDisruptionBudget: {}
+  initContainers: []
+  extraContainers: []
+  extraVolumes: []
+  extraVolumeMounts: []
+  extraPorts: []
+
+graphite_web:
+  replicas: 1
+
+  image:
+    repository: docker.io/raintank/graphite-mt
+    tag: 8-7ebde4c60
+    pullPolicy: IfNotPresent
+
+  service:
+    annotations: {}
+    labels: {}
+
+  deployment:
+    annotations: {}
+    labels: {}
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+
+  extraEnvVars: {}
+
+  # Pod Labels
+  podLabels: {}
+
+  # Pod Annotations
+  podAnnotations: {}
+
+  nodeSelector: {}
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: target
+                operator: In
+                values:
+                  - graphite-web
+          topologyKey: 'kubernetes.io/hostname'
+
+  strategy:
+    type: RollingUpdate
+
+  terminationGracePeriodSeconds: 30
+
+  tolerations: []
+  podDisruptionBudget: {}

--- a/charts/enterprise-metrics/values.yaml
+++ b/charts/enterprise-metrics/values.yaml
@@ -1099,7 +1099,7 @@ minio:
 graphite:
   # If true, enables graphite querier and graphite write proxy functionality.
   # Read more in https://grafana.com/docs/metrics-enterprise/latest/graphite/
-  enabled: true #TODO(jesus.vazquez) Don't commit this
+  enabled: false
 
 graphite_querier:
   replicas: 2

--- a/charts/enterprise-metrics/values.yaml
+++ b/charts/enterprise-metrics/values.yaml
@@ -1095,3 +1095,6 @@ minio:
       cpu: 100m
       memory: 128Mi
   secretKey: supersecret
+
+  graphite:
+    enabled: false

--- a/charts/enterprise-metrics/values.yaml
+++ b/charts/enterprise-metrics/values.yaml
@@ -1099,10 +1099,20 @@ minio:
 graphite:
   # If true, enables graphite querier and graphite write proxy functionality.
   # Read more in https://grafana.com/docs/metrics-enterprise/latest/graphite/
-  enabled: false
+  enabled: true #TODO(jesus.vazquez) Don't commit this
 
 graphite_querier:
   replicas: 2
+
+  schemasConfiguration:
+    storageSchemas:
+      pattern: ".*"
+      intervals: "0:1s"
+      retentions: "10s:8d,10min:1y"
+    storageAggregations:
+      aggregationMethod: "avg"
+      pattern: ".*"
+      xFilesFactor: "0.1"
 
   service:
     annotations: {}

--- a/charts/enterprise-metrics/values.yaml
+++ b/charts/enterprise-metrics/values.yaml
@@ -1099,20 +1099,22 @@ minio:
 graphite:
   # If true, enables graphite querier and graphite write proxy functionality.
   # Read more in https://grafana.com/docs/metrics-enterprise/latest/graphite/
-  enabled: false
+  enabled: true
 
 graphite_querier:
   replicas: 2
 
   schemasConfiguration:
-    storageSchemas:
-      pattern: ".*"
-      intervals: "0:1s"
-      retentions: "10s:8d,10min:1y"
-    storageAggregations:
-      aggregationMethod: "avg"
-      pattern: ".*"
-      xFilesFactor: "0.1"
+    storageSchemas: |-
+      [default]
+      pattern = .*
+      intervals = 0:1s
+      retentions = 10s:8d,10min:1y
+    storageAggregations: |-
+      [default]
+      aggregationMethod = avg
+      pattern = .*
+      xFilesFactor = 0.1
 
   service:
     annotations: {}

--- a/charts/enterprise-metrics/values.yaml
+++ b/charts/enterprise-metrics/values.yaml
@@ -1097,12 +1097,12 @@ minio:
   secretKey: supersecret
 
 graphite:
-  # If true, enables graphite querier and graphite writer functionality.
+  # If true, enables graphite querier and graphite write proxy functionality.
   # Read more in https://grafana.com/docs/metrics-enterprise/latest/graphite/
-  enabled: true # TODO(jesus.vazquez) Set to false before merge, also propagate config to small.yaml and large.yaml
+  enabled: false
 
 graphite_querier:
-  replicas: 1 #TODO(jesus.vazquez) Leave this to two replicas
+  replicas: 2
 
   service:
     annotations: {}
@@ -1165,7 +1165,7 @@ graphite_querier:
   extraPorts: []
 
 graphite_write_proxy:
-  replicas: 1 #TODO(jesus.vazquez) Leave this to two replicas
+  replicas: 2
 
   service:
     annotations: {}
@@ -1196,7 +1196,7 @@ graphite_write_proxy:
                 - key: target
                   operator: In
                   values:
-                    - graphite-querier
+                    - graphite-write-proxy
             topologyKey: 'kubernetes.io/hostname'
 
   annotations: {}

--- a/charts/enterprise-metrics/values.yaml
+++ b/charts/enterprise-metrics/values.yaml
@@ -8,7 +8,7 @@
 # Since the image is unique for all microservices, so are image settings.
 image:
   repository: grafana/metrics-enterprise
-  tag: v1.6.1
+  tag: r168-eb3f021e # TODO This needs to be replaced with v2.0 when it's released
   pullPolicy: IfNotPresent
   # Optionally specify an array of imagePullSecrets.
   # Secrets must be manually created in the namespace.
@@ -74,7 +74,6 @@ config:
     path: "/license/license.jwt"
 
   ingester:
-    max_transfer_retries: 0
     lifecycler:
       join_after: 0s
       final_sleep: 0s
@@ -125,7 +124,6 @@ config:
       health_check_ingesters: true
 
   querier:
-    active_query_tracker_dir: /data/enterprise-metrics/querier
     query_ingesters_within: 12h
 
   query_range:


### PR DESCRIPTION
This PR brings the configuration changes to deploy the metrics-enterprise chart with our graphite on GEM offering https://grafana.com/docs/metrics-enterprise/latest/graphite/

Additions:
- `graphite` flag to enable this feature that will be set to `false` by default.
- Addition of three new deployments and services: `graphite-querier`, `graphite-write-proxy`, `graphite-web`
- Resource requirements for the previous services for all the existing configuration profiles `small, large, capped-small, capped-large`.

For the user it should be as simple as setting the flag to true.

:construction: :construction:  **Waiting for GEM release v2.0 to get this merged. That said the changes have been tested locally and we were able to test graphite successfully.** :construction: :construction: 