### PR TITLE
[loki-stack] Update Prometheus to work on K8S 1.22.3

### DIFF
--- a/charts/loki-stack/requirements.yaml
+++ b/charts/loki-stack/requirements.yaml
@@ -17,7 +17,7 @@ dependencies:
   repository:  "https://grafana.github.io/helm-charts"
 - name: "prometheus"
   condition: prometheus.enabled
-  version: "~11.16.0"
+  version: "~15.0.1"
   repository:  "https://prometheus-community.github.io/helm-charts"
 - name: "filebeat"
   condition: filebeat.enabled


### PR DESCRIPTION
When enabling `prometheus` in `loki-stack` it does not work in Kubernetes v1.22.3:

```
Error: UPGRADE FAILED: [unable to recognize "": no matches for kind "ClusterRole" in version "rbac.authorization.k8s.io/v1beta1", unable to recognize "": no matches for kind "ClusterRoleBinding" in version "rbac.authorization.k8s.io/v1beta1"]
```

This upgrades to the latest available version at this time.

Can you help me get this approved @mapno?

Ref: #821