### PR TITLE
[loki] Update loki ingress template to support kubernetes 1.22+

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 2.8.1
+version: 2.8.2
 appVersion: v2.4.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki/templates/_helpers.tpl
+++ b/charts/loki/templates/_helpers.tpl
@@ -59,3 +59,17 @@ Create the app name of loki clients. Defaults to the same logic as "loki.fullnam
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Generate a right Ingress apiVersion
+*/}}
+{{- define "ingress.apiVersion" -}}
+{{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion -}}
+"networking.k8s.io/v1"
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+"networking.k8s.io/v1beta1"
+{{- else  -}}
+ "extensions/v1"
+{{- end }}
+{{- end -}}
+

--- a/charts/loki/templates/ingress.yaml
+++ b/charts/loki/templates/ingress.yaml
@@ -1,12 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "loki.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- $apiVersion := "extensions/v1" -}}
-{{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- $apiVersion = "networking.k8s.io/v1" -}}
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- $apiVersion = "networking.k8s.io/v1beta1" -}}
-{{- end }}
+{{- $apiVersion := include "ingress.apiVersion" . -}}
 apiVersion: {{ $apiVersion }}
 kind: Ingress
 metadata:

--- a/charts/loki/templates/ingress.yaml
+++ b/charts/loki/templates/ingress.yaml
@@ -4,8 +4,7 @@
 {{- $apiVersion := "extensions/v1" -}}
 {{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- $apiVersion = "networking.k8s.io/v1" -}}
-{{- end }}
-{{- if and (semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.22-0" .Capabilities.KubeVersion.GitVersion) -}}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- $apiVersion = "networking.k8s.io/v1beta1" -}}
 {{- end }}
 apiVersion: {{ $apiVersion }}

--- a/charts/loki/templates/ingress.yaml
+++ b/charts/loki/templates/ingress.yaml
@@ -1,11 +1,14 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "loki.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
+{{- $apiVersion := "extensions/v1" -}}
+{{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- $apiVersion = "networking.k8s.io/v1" -}}
 {{- end }}
+{{- if and (semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.22-0" .Capabilities.KubeVersion.GitVersion) -}}
+{{- $apiVersion = "networking.k8s.io/v1beta1" -}}
+{{- end }}
+apiVersion: {{ $apiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -37,9 +40,19 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            {{- if eq $apiVersion "networking.k8s.io/v1" }}
+            pathType: Prefix
+              {{- end }}
             backend:
+              {{- if eq $apiVersion "networking.k8s.io/v1" }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+              {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
When I'm installing loki helm chart to Kubernetes 1.22+, I got the error:
```
Error: UPGRADE FAILED: unable to recognize "": no matches for kind "Ingress" in version "networking.k8s.io/v1beta1"
```
This is because `apiVersion: networking.k8s.io/v1beta1` [becomes deprecated in Kubernetes 1.22+](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122), with replacing to stable `networking.k8s.io/v1`.

Also in `path` part of the template there are some changes needed.

P.S. `grafana` chart installs succesfully on k8s 1.22.4.

_And there are several warnings about compatibility with v1.25+:_
```
W1207 15:08:07.725807 1034065 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
```
_I can fix them in next PR._