### PR TITLE
[grafana] Update to Grafana 8.3.1

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.18.1
-appVersion: 8.3.0
+version: 6.18.2
+appVersion: 8.3.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -73,7 +73,7 @@ livenessProbe:
 
 image:
   repository: grafana/grafana
-  tag: 8.3.0
+  tag: 8.3.1
   sha: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Update to Grafana 8.3.1 due to [high severity security fix](https://grafana.com/blog/2021/12/07/grafana-8.3.1-8.2.7-8.1.8-and-8.0.7-released-with-high-severity-security-fix/?plcmt=footer)