### PR TITLE
[grafana] Remove sidecar dashboard label on configmap

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.19.0
+version: 6.19.1
 appVersion: 8.3.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/dashboards-json-configmap.yaml
+++ b/charts/grafana/templates/dashboards-json-configmap.yaml
@@ -9,9 +9,6 @@ metadata:
   labels:
     {{- include "grafana.labels" $ | nindent 4 }}
     dashboard-provider: {{ $provider }}
-    {{- if $.Values.sidecar.dashboards.label }}
-    {{ $.Values.sidecar.dashboards.label }}: "1"
-    {{- end }}
 {{- if $dashboards }}
 data:
 {{- $dashboardFound := false }}


### PR DESCRIPTION
I meet side effect when I pass `.Values.dashboards`, then however, sidecar will include these [ConfigMaps](https://github.com/grafana/helm-charts/blob/main/charts/grafana/templates/dashboards-json-configmap.yaml) into grafana's folder due to side dashboard label.

But these [ConfigMaps](https://github.com/grafana/helm-charts/blob/main/charts/grafana/templates/dashboards-json-configmap.yaml) has already been mounted as volumes (see below), so it's not necessary to tell sidecar includes these files 
https://github.com/grafana/helm-charts/blob/589022e7e2680f0f6dd99ae6c9d015755fef6e5d/charts/grafana/templates/_pod.tpl#L282-L292

Previous PR: https://github.com/grafana/helm-charts/pull/746

