### PR TITLE
[grafana] Update to Grafana 8.3.2

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.19.1
-appVersion: 8.3.1
+version: 6.19.2
+appVersion: 8.3.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -73,7 +73,7 @@ livenessProbe:
 
 image:
   repository: grafana/grafana
-  tag: 8.3.1
+  tag: 8.3.2
   sha: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
[Grafana 8.3.2](https://grafana.com/blog/2021/12/10/grafana-8.3.2-and-7.5.12-released-with-moderate-severity-security-fix/) is released with moderate severity security fix and updated to image tag.