### PR TITLE
[grafana] Allowing older version of Kubernetes (<1.13) to use the latest versio…

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.19.4
+version: 6.20.0
 appVersion: 8.3.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -125,7 +125,9 @@ imagePullSecrets:
   - name: {{ . }}
 {{- end}}
 {{- end }}
+{{- if not .Values.enableKubeBackwardCompatibility }}
 enableServiceLinks: {{ .Values.enableServiceLinks }}
+{{- end }}
 containers:
 {{- if .Values.sidecar.dashboards.enabled }}
   - name: {{ template "grafana.name" . }}-sc-dashboard

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -788,3 +788,6 @@ networkPolicy:
   ##    - {key: role, operator: In, values: [frontend]}
   ##
   explicitNamespacesSelector: {}
+
+# Enable backward compatibility of kubernetes where version below 1.13 doesn't have the enableServiceLinks option
+enableKubeBackwardCompatibility: false


### PR DESCRIPTION
Allowing older version of Kubernetes (<1.13) to use the latest version of the chart by making the pod parameter enableServiceLinks optional.

Fix #669
Signed-off-by: Philippe Bürgisser <philippe.burgisser@camptocamp.com>

I didn't use the helm built-in object Capabilities.KubeVersion as is always return version 1.18 on a OpenShift 3.11 which is based on Kubernetes version 1.11 and the enableServiceLinks is available since Kube 1.13 