### PR TITLE
[loki] Lower version for "networking.k8s.io/v1" to 1.20

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 2.8.2
+version: 2.8.3
 appVersion: v2.4.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki/templates/_helpers.tpl
+++ b/charts/loki/templates/_helpers.tpl
@@ -64,7 +64,7 @@ Create the app name of loki clients. Defaults to the same logic as "loki.fullnam
 Generate a right Ingress apiVersion
 */}}
 {{- define "ingress.apiVersion" -}}
-{{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.GitVersion -}}
 "networking.k8s.io/v1"
 {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 "networking.k8s.io/v1beta1"


### PR DESCRIPTION
This is an addition to https://github.com/grafana/helm-charts/pull/879 to fix problem, mentioned here https://github.com/grafana/helm-charts/commit/2127b36b286e31480f49d49f4929afe616d093f0#r62024255

Actually "networking.k8s.io/v1" is supported from 1.20, not from 1.22
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#ingressclass-v1-networking-k8s-io