### PR TITLE
Only specify replicas if given a value

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
 version: 6.20.1
-appVersion: 8.3.3
+appVersion: 8.3.4
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/charts/grafana/templates/deployment.yaml
+++ b/charts/grafana/templates/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
+  {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}


### PR DESCRIPTION
This allows to manage the number of replicas manually and to not be overwritten while upgrading.

Signed-off-by: Sylvain Rabot <sylvain@abstraction.fr>