### PR TITLE
[enterprise-logs] remove fields that make it hard to do helm updates

### DIFF
--- a/charts/enterprise-logs/CHANGELOG.md
+++ b/charts/enterprise-logs/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## 1.3.4
+
+- [CHANGE] Remove selector and config hash annotations from the tokengen job that make it hard to update the helm chart after deploying that job
+
 ## 1.3.3
 
 - [BUGFIX] Bumped version of `loki-disctributed` chart to 0.39.3 that defines default WAL location. #863

--- a/charts/enterprise-logs/Chart.yaml
+++ b/charts/enterprise-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v2"
 name: "enterprise-logs"
 type: application
-version: "1.3.3"
+version: "1.3.4"
 appVersion: "v1.2.0"
 kubeVersion: "^1.10.0-0"
 description: "Grafana Enterprise Logs"

--- a/charts/enterprise-logs/templates/tokengen/job-tokengen.yaml
+++ b/charts/enterprise-logs/templates/tokengen/job-tokengen.yaml
@@ -17,7 +17,6 @@ spec:
   backoffLimit: 6
   completions: 1
   parallelism: 1
-  selector:
   template:
     metadata:
       labels:
@@ -26,11 +25,6 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
-        {{- if .Values.useExternalConfig }}
-        checksum/config: {{ .Values.externalConfigVersion }}
-        {{- else }}
-        checksum/config: {{ include (print $.Template.BasePath "/secret-config.yaml") . | sha256sum }}
-        {{- end}}
         {{- with .Values.tokengen.annotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
I'm no helm expert, but I found by setting the selector to explicitly `null`, and using the `checksum/config` annotation, it made it hard to do a helm upgrade of the enterprise logs chart. Since the tokengen is a job, `spec.selector` and `spec.template` are immutable, thus updates always fail when `selector` is trying to be set to `null`, and also fail whenever theres a change to config. I think in the case of the tokenjob it is expected you will have to delete it an recreate it to make changes.