### PR TITLE
[loki] Fix correct ingress for >= 1.20

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 2.8.3
+version: 2.8.4
 appVersion: v2.4.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki/templates/_helpers.tpl
+++ b/charts/loki/templates/_helpers.tpl
@@ -65,11 +65,11 @@ Generate a right Ingress apiVersion
 */}}
 {{- define "ingress.apiVersion" -}}
 {{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.GitVersion -}}
-"networking.k8s.io/v1"
+networking.k8s.io/v1
 {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-"networking.k8s.io/v1beta1"
+networking.k8s.io/v1beta1
 {{- else  -}}
- "extensions/v1"
+extensions/v1
 {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
The helper returns "networking.k8s.io/v1" and not networking.k8s.io/v1. This fails the if comparison and always generates the else part, which is not valid for the new api.