### PR TITLE
[tempo] fix tempo-oltp-http ports

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 0.12.1
+version: 0.12.2
 appVersion: 1.2.1
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 0.12.1](https://img.shields.io/badge/Version-0.12.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.1](https://img.shields.io/badge/AppVersion-1.2.1-informational?style=flat-square)
+![Version: 0.12.2](https://img.shields.io/badge/Version-0.12.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.1](https://img.shields.io/badge/AppVersion-1.2.1-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 

--- a/charts/tempo/templates/service.yaml
+++ b/charts/tempo/templates/service.yaml
@@ -66,9 +66,9 @@ spec:
     protocol: TCP
     targetPort: 55680
   - name: tempo-otlp-http
-    port: 55681
+    port: 4318
     protocol: TCP
-    targetPort: 55681
+    targetPort: 4318
   - name: tempo-otlp-grpc
     port: 4317
     protocol: TCP


### PR DESCRIPTION
`values.yaml` configures `receivers.otlp.protocols.http` to `0.0.0.0:4318`.

The service should match that config.