### PR TITLE
[enterprise-metrics] update ingester podManagementPolicy to Parallel

### DIFF
--- a/charts/enterprise-metrics/CHANGELOG.md
+++ b/charts/enterprise-metrics/CHANGELOG.md
@@ -12,7 +12,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## 1.7.2
 
-* [CHANGE] The Ingester statefulset now uses podManagementPolicy Parallel. #920
+* [CHANGE] The Ingester statefulset now uses podManagementPolicy Parallel, upgrading requires recreating the statefulset #920
 
 ## 1.7.1
 

--- a/charts/enterprise-metrics/CHANGELOG.md
+++ b/charts/enterprise-metrics/CHANGELOG.md
@@ -10,6 +10,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the Pull Request that introduced the change.
 
+## 1.7.2
+
+* [CHANGE] The Ingester statefulset now uses podManagementPolicy Parallel. #920
+
 ## 1.7.1
 
 * [BUGFIX] Remove chunks related default limits. #867

--- a/charts/enterprise-metrics/Chart.yaml
+++ b/charts/enterprise-metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
-version: 1.7.1
+version: 1.7.2
 appVersion: v1.6.1
-description: 'Grafana Enterprise Metrics'
+description: "Grafana Enterprise Metrics"
 engine: gotpl
 home: https://grafana.com/products/enterprise/metrics
 icon: https://grafana.com/static/img/menu/metrics-enterprise.svg

--- a/charts/enterprise-metrics/templates/ingester-statefulset.yaml
+++ b/charts/enterprise-metrics/templates/ingester-statefulset.yaml
@@ -11,6 +11,7 @@ metadata:
   annotations:
     {{- toYaml .Values.ingester.annotations | nindent 4 }}
 spec:
+  podManagementPolicy: Parallel
   replicas: {{ .Values.ingester.replicas }}
   selector:
     matchLabels:


### PR DESCRIPTION
This is a request for feedback, I'm curious if others in the team agree that the pros outweigh the cons.

I think we should update the ingester `podManagementPolicy` to `Parallel`.

Pros:

* This is what we use in our own clusters
* It will help to recover clusters with a broken ingester ring faster, because to do so we'll then simply have to:
  * Scale down Distributors to `0` (to cut off ingestion)
  * Scale down Ingesters to `0`
  * Drop Ingester ring
  * Scale up Ingesters to final replica count. This will now be much faster because all Ingesters will replay their WALs concurrently as opposed to sequentially 
  * Scale up Distributors to final replica count
* [According to the docs the `podManagementPolicy` is on relevant when scaling the SFS up/down, not when rolling out updates](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#parallel-pod-management) 

Cons:

* The upgrade procedure from before this change to after this change is rather complicated. It will require that the SFS is deleted with `--cascade=false` and then recreated. This is risky, because if a customer fails to specify `--cascade=false` their write path will go down.