### PR TITLE
[loki-stack] Update Promtail helm-chart dependency

### DIFF
--- a/charts/loki-stack/requirements.yaml
+++ b/charts/loki-stack/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
 - name: "promtail"
   condition: promtail.enabled
   repository: "https://grafana.github.io/helm-charts"
-  version: "^2.2.0"
+  version: "^3.0.0"
 - name: "fluent-bit"
   condition: fluent-bit.enabled
   repository: "https://grafana.github.io/helm-charts"


### PR DESCRIPTION
The loki version which is referenced in the loki-stack, is broken and there is no way to properly configure the syslog receiver, since the template is invalid.

Relates to #208 and #730
