### PR TITLE
Update README.md

### DIFF
--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -528,7 +528,7 @@ This example uses a CSI driver e.g. retrieving secrets using [Azure Key Vault Pr
 
 ## Image Renderer Plug-In
 
-This chart supports enabling [remote image rendering](https://github.com/grafana/grafana-image-renderer/blob/master/docs/remote_rendering_using_docker.md)
+This chart supports enabling [remote image rendering](https://github.com/grafana/grafana-image-renderer/blob/master/README.md#run-in-docker)
 
 ```yaml
 imageRenderer:


### PR DESCRIPTION
The image renderer plugin-in was linking to a broken documentation.

After inspecting the changes on the `grafana-image-render repository`,
I found out that the change below updated most of the documentation,
where the content of the `remote_rendering_using_docker.md` was 
moved to the main `README.md` file.

https://github.com/grafana/grafana-image-renderer/pull/277