### PR TITLE
[grafana] Update README.md

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.20.4
+version: 6.20.5
 appVersion: 8.3.4
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -528,7 +528,7 @@ This example uses a CSI driver e.g. retrieving secrets using [Azure Key Vault Pr
 
 ## Image Renderer Plug-In
 
-This chart supports enabling [remote image rendering](https://github.com/grafana/grafana-image-renderer/blob/master/docs/remote_rendering_using_docker.md)
+This chart supports enabling [remote image rendering](https://github.com/grafana/grafana-image-renderer/blob/master/README.md#run-in-docker)
 
 ```yaml
 imageRenderer:


### PR DESCRIPTION
This commit updates the Grafana Helm chart documentation.

In the section about the image renderer plugin, the reference was linking to
a broken documentation in another GitHub repository.

After inspecting the changes on the `grafana-image-render` repository,
I found out that the change below updated most of the documentation,
where the content of the `remote_rendering_using_docker.md` was
moved to the main `README.md` file.

Then, this fix points towards the new reference.

Here it is the commit that changed the documentation on the remote repo.

https://github.com/grafana/grafana-image-renderer/pull/277