### PR TITLE
[enterprise-logs] Convert config value from structured data to a string

### DIFF
--- a/charts/enterprise-logs/Chart.yaml
+++ b/charts/enterprise-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v2"
 name: "enterprise-logs"
 type: application
-version: "1.4.0"
+version: "2.0.0"
 appVersion: "v1.3.0"
 kubeVersion: "^1.10.0-0"
 description: "Grafana Enterprise Logs"

--- a/charts/enterprise-logs/templates/admin-api/deployment-admin-api.yaml
+++ b/charts/enterprise-logs/templates/admin-api/deployment-admin-api.yaml
@@ -103,10 +103,10 @@ spec:
             {{- end }}
           ports:
             - name: http-metrics
-              containerPort: {{ .Values.config.server.http_listen_port }}
+              containerPort: 3100
               protocol: TCP
             - name: grpc
-              containerPort: {{ .Values.config.server.grpc_listen_port }}
+              containerPort: 9095
               protocol: TCP
             - name: http-memberlist
               containerPort: 7946

--- a/charts/enterprise-logs/templates/admin-api/service-admin-api.yaml
+++ b/charts/enterprise-logs/templates/admin-api/service-admin-api.yaml
@@ -15,11 +15,11 @@ spec:
   type: ClusterIP
   ports:
     - name: http-metrics
-      port: {{ .Values.config.server.http_listen_port }}
+      port: 3100
       protocol: TCP
       targetPort: http-metrics
     - name: grpc
-      port: {{ .Values.config.server.grpc_listen_port }}
+      port: 9095
       protocol: TCP
       targetPort: grpc
   selector:

--- a/charts/enterprise-logs/templates/compactor/statefulset-compactor.yaml
+++ b/charts/enterprise-logs/templates/compactor/statefulset-compactor.yaml
@@ -135,10 +135,10 @@ spec:
             {{- end }}
           ports:
             - name: http-metrics
-              containerPort: {{ .Values.config.server.http_listen_port }}
+              containerPort: 3100
               protocol: TCP
             - name: grpc
-              containerPort: {{ .Values.config.server.grpc_listen_port }}
+              containerPort: 9095
               protocol: TCP
             - name: http-memberlist
               containerPort: 7946

--- a/charts/enterprise-logs/templates/gateway/deployment-gateway.yaml
+++ b/charts/enterprise-logs/templates/gateway/deployment-gateway.yaml
@@ -65,12 +65,12 @@ spec:
             - -admin.client.s3.insecure=true
             {{- end }}
             {{- if .Values.gateway.useDefaultProxyURLs }}
-            - -gateway.proxy.default.url=http://{{ template "enterprise-logs.fullname" . }}-admin-api.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
-            - -gateway.proxy.admin-api.url=http://{{ template "enterprise-logs.fullname" . }}-admin-api.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
-            - -gateway.proxy.distributor.url=http://{{ template "enterprise-logs.fullname" . }}-distributor.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
-            - -gateway.proxy.ingester.url=http://{{ template "enterprise-logs.fullname" . }}-ingester.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
-            - -gateway.proxy.query-frontend.url=http://{{ template "enterprise-logs.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
-            - -gateway.proxy.ruler.url=http://{{ template "enterprise-logs.fullname" . }}-ruler.{{ .Release.Namespace }}.svc:{{ .Values.config.server.http_listen_port }}
+            - -gateway.proxy.default.url=http://{{ template "enterprise-logs.fullname" . }}-admin-api.{{ .Release.Namespace }}.svc:3100
+            - -gateway.proxy.admin-api.url=http://{{ template "enterprise-logs.fullname" . }}-admin-api.{{ .Release.Namespace }}.svc:3100
+            - -gateway.proxy.distributor.url=http://{{ template "enterprise-logs.fullname" . }}-distributor.{{ .Release.Namespace }}.svc:3100
+            - -gateway.proxy.ingester.url=http://{{ template "enterprise-logs.fullname" . }}-ingester.{{ .Release.Namespace }}.svc:3100
+            - -gateway.proxy.query-frontend.url=http://{{ template "enterprise-logs.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc:3100
+            - -gateway.proxy.ruler.url=http://{{ template "enterprise-logs.fullname" . }}-ruler.{{ .Release.Namespace }}.svc:3100
             {{- end }}
             {{- range $key, $value := .Values.gateway.extraArgs }}
             - "-{{ $key }}={{ $value }}"
@@ -88,7 +88,7 @@ spec:
             {{- end }}
           ports:
             - name: http-metrics
-              containerPort: {{ .Values.config.server.http_listen_port }}
+              containerPort: 3100
               protocol: TCP
           livenessProbe:
             {{- toYaml .Values.gateway.livenessProbe | nindent 12 }}

--- a/charts/enterprise-logs/templates/gateway/service-gateway.yaml
+++ b/charts/enterprise-logs/templates/gateway/service-gateway.yaml
@@ -14,7 +14,7 @@ spec:
   type: ClusterIP
   ports:
     - name: http-metrics
-      port: {{ .Values.config.server.http_listen_port }}
+      port: 3100
       protocol: TCP
       targetPort: http-metrics
   selector:

--- a/charts/enterprise-logs/templates/secret-config.yaml
+++ b/charts/enterprise-logs/templates/secret-config.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     {{- include "enterprise-logs.labels" . | nindent 4 }}
 data:
-  config.yaml: {{ tpl (toYaml .Values.config) . | b64enc }}
+  config.yaml: {{ tpl .Values.config . | b64enc }}
 {{- end }}

--- a/charts/enterprise-logs/values.yaml
+++ b/charts/enterprise-logs/values.yaml
@@ -56,7 +56,7 @@ license:
   contents: "NOTAVALIDLICENSE"
 
 # -- Grafana Enterprise Logs configuration file
-config:
+config: |
   auth:
     type: enterprise
   auth_enabled: true

--- a/charts/enterprise-logs/values.yaml
+++ b/charts/enterprise-logs/values.yaml
@@ -63,7 +63,8 @@ config: |
 
   license:
     path: "/etc/enterprise-logs/license/license.jwt"
-  cluster_name: "{{ .Release.Name }}"
+
+  cluster_name: {{ .Release.Name }}
 
   server:
     http_listen_port: 3100
@@ -73,7 +74,7 @@ config: |
     storage:
       type: s3
       s3:
-        endpoint: "{{ include \"enterprise-logs.minio\" . }}"
+        endpoint: {{ include "enterprise-logs.minio" . }}
         bucket_name: enterprise-logs-admin
         secret_access_key: supersecret
         access_key_id: enterprise-logs
@@ -114,14 +115,14 @@ config: |
   frontend:
     log_queries_longer_than: 10s
     compress_responses: true
-    tail_proxy_url: "http://{{ include \"loki.querierFullname\" . }}:3100"
+    tail_proxy_url: http://{{ include "loki.querierFullname" . }}:3100
 
   frontend_worker:
-    frontend_address: "{{ include \"loki.queryFrontendFullname\" . }}:9095"
+    frontend_address: {{ include "loki.queryFrontendFullname" . }}:9095
 
   memberlist:
     join_members:
-      - "{{ include \"loki.fullname\" . }}-memberlist"
+      - {{ include "loki.fullname" . }}-memberlist
 
   querier:
     query_ingesters_within: 12h
@@ -149,7 +150,7 @@ config: |
 
   storage_config:
     aws:
-      endpoint: "{{ include \"enterprise-logs.minio\" . }}"
+      endpoint: {{ include "enterprise-logs.minio" . }}
       bucketnames: enterprise-logs-tsdb
       access_key_id: enterprise-logs
       secret_access_key: supersecret
@@ -161,13 +162,13 @@ config: |
       cache_ttl: 24h
       shared_store: s3
       index_gateway_client:
-        server_address: "dns:///{{ include \"loki.indexGatewayFullname\" . }}:9095"
+        server_address: dns:///{{ include "loki.indexGatewayFullname" . }}:9095
 
   ruler:
     storage:
       type: s3
       s3:
-        endpoint: "{{ include \"enterprise-logs.minio\" . }}"
+        endpoint: {{ include "enterprise-logs.minio" . }}
         bucketnames: enterprise-logs-ruler
         access_key_id: enterprise-logs
         secret_access_key: supersecret
@@ -180,6 +181,7 @@ config: |
       kvstore:
         store: memberlist
     rule_path: /var/loki
+
 
 # -- Configuration for `tokengen` target
 tokengen:


### PR DESCRIPTION
This change brings the enterprise-logs chart in line with the loki-distributed chart in terms of how the config is handled. In the loki-distributed chart, the config is a string. This has the benefit of accepting the config exactly as the user provides it, without merging in other default values that are hard to keep up to date as the software changes. It has the downside of the config no longer being structured data, so we can't access nested properties like `server.http_listen_port`.

I considered exposing the http and grpc ports as top level configs, but they are hardcoded in multiple places in the loki-distributed chart, so I'd rather force that convention here as well to reduce the configuration surface area. I would be open to hardcoding `http_listen_port` to 80 as that's what's the default in Loki, but I fear that could create issues since it's a reserved port. Maybe we should change the default in Loki?