### PR TITLE
[enterprise-metrics] alertmanager: fix readonly /tmp dir

### DIFF
--- a/charts/enterprise-metrics/CHANGELOG.md
+++ b/charts/enterprise-metrics/CHANGELOG.md
@@ -9,6 +9,9 @@ Entries should be ordered as follows:
 - [BUGFIX]
 
 Entries should include a reference to the Pull Request that introduced the change.
+## 1.7.3
+
+* [BUGFIX] Alertmanager does not fail anymore to load configuration via the API. #945
 
 ## 1.7.2
 

--- a/charts/enterprise-metrics/Chart.yaml
+++ b/charts/enterprise-metrics/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.7.2
+version: 1.7.3
 appVersion: v1.6.1
 description: "Grafana Enterprise Metrics"
 engine: gotpl

--- a/charts/enterprise-metrics/templates/alertmanager-dep.yaml
+++ b/charts/enterprise-metrics/templates/alertmanager-dep.yaml
@@ -88,6 +88,8 @@ spec:
             - name: storage
               mountPath: "/data"
               subPath: {{ .Values.alertmanager.persistence.subPath }}
+            - name: tmp
+              mountPath: /tmp
           ports:
             - name: http-metrics
               containerPort: {{ .Values.config.server.http_listen_port }}
@@ -132,5 +134,7 @@ spec:
           secret:
             secretName: {{ .Values.license.secretName }}
         - name: storage
+          emptyDir: {}
+        - name: tmp
           emptyDir: {}
 {{- end -}}

--- a/charts/enterprise-metrics/templates/alertmanager-statefulset.yaml
+++ b/charts/enterprise-metrics/templates/alertmanager-statefulset.yaml
@@ -103,6 +103,8 @@ spec:
         - name: storage
           emptyDir: {}
         {{- end }}
+        - name: tmp
+          emptyDir: {}
         {{- if .Values.alertmanager.extraVolumes }}
         {{ toYaml .Values.alertmanager.extraVolumes | nindent 8 }}
         {{- end }}
@@ -155,6 +157,8 @@ spec:
               subPath: {{ .Values.alertmanager.persistentVolume.subPath }}
               {{- else }}
               {{- end }}
+            - name: tmp
+              mountPath: /tmp
           ports:
             - name: http-metrics
               containerPort: {{ .Values.config.server.http_listen_port }}


### PR DESCRIPTION
Alertmanager writes /tmp to validate the configuration being uploaded.
Allow RW access to a /tmp directory. Not using memory backend volume as
most functions of GEM are memory limited.

Signed-off-by: György Krajcsovits <gyorgy.krajcsovits@grafana.com>