### PR TITLE
[enterprise-logs] multiple fixes

### DIFF
--- a/charts/enterprise-logs/CHANGELOG.md
+++ b/charts/enterprise-logs/CHANGELOG.md
@@ -13,6 +13,7 @@ Entries should include a reference to the pull request that introduced the chang
 
 ## Unreleased
 
+- [BUGFIX] Fixed issue that prevented users from mouting extra persistent volumes for the compactor.
 - [CHANGE] Configure `securityContext.fsGroup` value for Admin API pod based on the value `adminApi.securityContext.runAsGroup`.
 
 ## 1.3.4

--- a/charts/enterprise-logs/CHANGELOG.md
+++ b/charts/enterprise-logs/CHANGELOG.md
@@ -13,6 +13,8 @@ Entries should include a reference to the pull request that introduced the chang
 
 ## Unreleased
 
+## 1.3.5
+
 - [BUGFIX] Use correct subPath configuration for the compactor's storage mount.
 - [BUGFIX] Fixed issue that prevented users from mouting extra persistent volumes for the compactor.
 - [CHANGE] Configure `securityContext.fsGroup` value for Admin API pod based on the value `adminApi.securityContext.runAsGroup`.

--- a/charts/enterprise-logs/CHANGELOG.md
+++ b/charts/enterprise-logs/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## Unreleased
+
+- [CHANGE] Configure `securityContext.fsGroup` value for Admin API pod based on the value `adminApi.securityContext.runAsGroup`.
+
 ## 1.3.4
 
 - [CHANGE] Remove selector and config hash annotations from the tokengen job that make it hard to update the helm chart after deploying that job

--- a/charts/enterprise-logs/CHANGELOG.md
+++ b/charts/enterprise-logs/CHANGELOG.md
@@ -13,6 +13,7 @@ Entries should include a reference to the pull request that introduced the chang
 
 ## Unreleased
 
+- [BUGFIX] Use correct subPath configuration for the compactor's storage mount.
 - [BUGFIX] Fixed issue that prevented users from mouting extra persistent volumes for the compactor.
 - [CHANGE] Configure `securityContext.fsGroup` value for Admin API pod based on the value `adminApi.securityContext.runAsGroup`.
 

--- a/charts/enterprise-logs/Chart.yaml
+++ b/charts/enterprise-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v2"
 name: "enterprise-logs"
 type: application
-version: "1.3.4"
+version: "1.3.5"
 appVersion: "v1.2.0"
 kubeVersion: "^1.10.0-0"
 description: "Grafana Enterprise Logs"

--- a/charts/enterprise-logs/templates/admin-api/deployment-admin-api.yaml
+++ b/charts/enterprise-logs/templates/admin-api/deployment-admin-api.yaml
@@ -41,8 +41,10 @@ spec:
       {{- if .Values.adminApi.priorityClassName }}
       priorityClassName: {{ .Values.adminApi.priorityClassName }}
       {{- end }}
+      {{- if .Values.adminApi.securityContext.runAsGroup }}
       securityContext:
-        fsGroup: 10001
+        fsGroup: {{ .Values.adminApi.securityContext.runAsGroup | int }}
+      {{- end}}
       initContainers:
       # Taken from
       # https://github.com/minio/charts/blob/a5c84bcbad884728bff5c9c23541f936d57a13b3/minio/templates/post-install-create-bucket-job.yaml

--- a/charts/enterprise-logs/templates/compactor/statefulset-compactor.yaml
+++ b/charts/enterprise-logs/templates/compactor/statefulset-compactor.yaml
@@ -129,7 +129,7 @@ spec:
               mountPath: /etc/enterprise-logs/license
             - name: storage
               mountPath: /data
-              subPath: {{ .Values.gateway.persistence.subPath }}
+              subPath: {{ .Values.compactor.persistentVolume.subPath }}
             {{- if .Values.compactor.extraVolumeMounts }}
             {{ toYaml .Values.compactor.extraVolumeMounts | nindent 12 }}
             {{- end }}

--- a/charts/enterprise-logs/templates/compactor/statefulset-compactor.yaml
+++ b/charts/enterprise-logs/templates/compactor/statefulset-compactor.yaml
@@ -98,8 +98,8 @@ spec:
           {{- end }}
         - name: storage
           emptyDir: {}
-        {{- if .Values.gateway.extraVolumes }}
-        {{ toYaml .Values.gateway.extraVolumes | nindent 8 }}
+        {{- if .Values.compactor.extraVolumes }}
+        {{ toYaml .Values.compactor.extraVolumes | nindent 8 }}
         {{- end }}
       containers:
         {{- if .Values.compactor.extraContainers }}
@@ -130,8 +130,8 @@ spec:
             - name: storage
               mountPath: /data
               subPath: {{ .Values.gateway.persistence.subPath }}
-            {{- if .Values.gateway.extraVolumeMounts }}
-            {{ toYaml .Values.gateway.extraVolumeMounts | nindent 12 }}
+            {{- if .Values.compactor.extraVolumeMounts }}
+            {{ toYaml .Values.compactor.extraVolumeMounts | nindent 12 }}
             {{- end }}
           ports:
             - name: http-metrics


### PR DESCRIPTION
This PR contains multiple changes and fixes:

- [BUGFIX] Use correct subPath configuration for the compactor's storage mount.
- [BUGFIX] Fixed issue that prevented users from mouting extra persistent volumes for the compactor.
- [CHANGE] Configure `securityContext.fsGroup` value for Admin API pod based on the value `adminApi.securityContext.runAsGroup`.

This PR supersedes #915 

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>