### PR TITLE
[loki-stack] Allow query limit increase over 1000 lines

### DIFF
--- a/charts/loki-stack/Chart.yaml
+++ b/charts/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 2.5.1
+version: 2.5.2
 appVersion: v2.1.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki-stack/templates/datasources.yaml
+++ b/charts/loki-stack/templates/datasources.yaml
@@ -20,6 +20,8 @@ data:
       access: proxy
       url: http://{{(include "loki.serviceName" .)}}:{{ .Values.loki.service.port }}
       version: 1
+      jsonData:
+        maxLines: {{ .Values.grafana.sidecar.datasources.enabled }}
 {{- end }}
 {{- if .Values.prometheus.enabled }}
     - name: Prometheus

--- a/charts/loki-stack/values.yaml
+++ b/charts/loki-stack/values.yaml
@@ -12,6 +12,7 @@ grafana:
   sidecar:
     datasources:
       enabled: true
+      maxLines: 1000
   image:
     tag: 8.1.6
 

--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 2.9.0
+version: 2.9.1
 appVersion: v2.4.2
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -75,7 +75,7 @@ config:
     enforce_metric_name: false
     reject_old_samples: true
     reject_old_samples_max_age: 168h
-    max_entries_limit_per_query: 1000
+    max_entries_limit_per_query: 5000
   schema_config:
     configs:
     - from: 2020-10-24

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -75,6 +75,7 @@ config:
     enforce_metric_name: false
     reject_old_samples: true
     reject_old_samples_max_age: 168h
+    max_entries_limit_per_query: 1000
   schema_config:
     configs:
     - from: 2020-10-24


### PR DESCRIPTION
Query limit is changed via _max_entries_limit_ https://grafana.com/docs/loki/latest/configuration/#limits_config which default value is 5000 but not affecting here when using Dashboard sidecar as the datasource is limited by default to 1000.

This PR allows to override both values and setting default Loki and Loki Datasource default, lowest of them will apply when using sidecar.