### PR TITLE
[agent-operator] Bump agent-operator version to v0.22.0

### DIFF
--- a/charts/agent-operator/Chart.yaml
+++ b/charts/agent-operator/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: grafana-agent-operator
 description: A Helm chart for Grafana Agent Operator
 type: application
-version: 0.1.4
-appVersion: "0.20.0"
+version: 0.1.5
+appVersion: "0.22.0"
 home: https://grafana.com/docs/agent/latest/
-icon: https://raw.githubusercontent.com/grafana/agent/v0.20.0/docs/assets/logo_and_name.png
+icon: https://raw.githubusercontent.com/grafana/agent/v0.22.0/docs/assets/logo_and_name.png
 sources:
-  - https://github.com/grafana/agent/tree/v0.20.0/pkg/operator
+  - https://github.com/grafana/agent/tree/v0.22.0/pkg/operator

--- a/charts/agent-operator/README.md
+++ b/charts/agent-operator/README.md
@@ -1,6 +1,6 @@
 # grafana-agent-operator
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.20.0](https://img.shields.io/badge/AppVersion-0.20.0-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.22.0](https://img.shields.io/badge/AppVersion-0.22.0-informational?style=flat-square)
 
 A Helm chart for Grafana Agent Operator
 
@@ -8,7 +8,7 @@ A Helm chart for Grafana Agent Operator
 
 ## Source Code
 
-* <https://github.com/grafana/agent/tree/v0.20.0/pkg/operator>
+* <https://github.com/grafana/agent/tree/v0.22.0/pkg/operator>
 
 Note that this chart does not provision custom resources like `GrafanaAgent` and `MetricsInstance` (formerly `PrometheusInstance`) or any `*Monitor` resources.
 
@@ -60,7 +60,7 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 | image.pullSecrets | list | `[]` | Image pull secrets |
 | image.registry | string | `"docker.io"` | Image registry |
 | image.repository | string | `"grafana/agent-operator"` | Image repo |
-| image.tag | string | `"v0.20.0"` | Image tag |
+| image.tag | string | `"v0.22.0"` | Image tag |
 | kubeletService | object | `{"namespace":"default","serviceName":"kubelet"}` | If both are set, Agent Operator will create and maintain a service for scraping kubelets -- https://grafana.com/docs/agent/latest/operator/getting-started/#monitor-kubelets |
 | nameOverride | string | `""` | Overrides the chart's name |
 | nodeSelector | object | `{}` | nodeSelector configuration |

--- a/charts/agent-operator/templates/tests/test-grafanaagent.yaml
+++ b/charts/agent-operator/templates/tests/test-grafanaagent.yaml
@@ -106,7 +106,7 @@ spec:
   - name: busybox
     image: busybox
     command: ['wget']
-    args:  ['grafana-agent-operated:8080/-/healthy']
+    args:  ['grafana-agent-test-operated:8080/-/healthy']
   # Wait for GrafanaAgent CR
   initContainers:
   - name: sleep

--- a/charts/agent-operator/values.yaml
+++ b/charts/agent-operator/values.yaml
@@ -29,7 +29,7 @@ image:
   # -- Image repo
   repository: grafana/agent-operator
   # -- Image tag
-  tag: v0.20.0
+  tag: v0.22.0
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Image pull secrets


### PR DESCRIPTION
See https://github.com/grafana/agent/releases/tag/v0.22.0 for more info

Signed-off-by: hjet <hjet@users.noreply.github.com>

Keeping a log of manual changes so we can automate this in the future:
- [x] Bump chart version
- [x] Bump app version
- [x] Update icon & sources paths in `Chart.yaml`
- [x] Bump image version in `values.yaml`
- [x] Run `helm-docs`
- [x] Sync CRDs