### PR TITLE
[grafana] fix: Sync image tag with appVersion

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.20.5
+version: 6.20.6
 appVersion: 8.3.4
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -73,7 +73,7 @@ livenessProbe:
 
 image:
   repository: grafana/grafana
-  tag: 8.3.3
+  tag: 8.3.4
   sha: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Commit f1c0555 bumped the appVersion without bumping the image.tag in values.yaml

This PR fixes the version skew.