### PR TITLE
[tempo] authEnabled -> multitenancyEnabled

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 0.12.2
+version: 0.12.3
 appVersion: 1.2.1
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 0.12.2](https://img.shields.io/badge/Version-0.12.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.1](https://img.shields.io/badge/AppVersion-1.2.1-informational?style=flat-square)
+![Version: 0.12.3](https://img.shields.io/badge/Version-0.12.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.1](https://img.shields.io/badge/AppVersion-1.2.1-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 
@@ -34,12 +34,12 @@ Grafana Tempo Single Binary Mode
 | serviceMonitor.annotations | object | `{}` |  |
 | serviceMonitor.enabled | bool | `false` |  |
 | serviceMonitor.interval | string | `""` |  |
-| tempo.authEnabled | bool | `false` |  |
 | tempo.extraArgs | object | `{}` |  |
 | tempo.extraEnv | list | `[]` | Environment variables to add |
 | tempo.extraVolumeMounts | list | `[]` | Volume mounts to add |
 | tempo.ingester | object | `{}` |  |
 | tempo.memBallastSizeMbs | int | `1024` |  |
+| tempo.multitenancyEnabled | bool | `false` |  |
 | tempo.overrides | object | `{}` |  |
 | tempo.pullPolicy | string | `"IfNotPresent"` |  |
 | tempo.receivers.jaeger.protocols.grpc.endpoint | string | `"0.0.0.0:14250"` |  |

--- a/charts/tempo/templates/configmap-tempo.yaml
+++ b/charts/tempo/templates/configmap-tempo.yaml
@@ -10,7 +10,7 @@ data:
     overrides:
       {{- toYaml .Values.tempo.overrides | nindent 6 }}
   tempo.yaml: |
-    auth_enabled: {{ .Values.tempo.authEnabled }}
+    multitenancy_enabled: {{ .Values.tempo.multitenancyEnabled }}
     search_enabled: {{ .Values.tempo.searchEnabled }}
     compactor:
       compaction:

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -26,7 +26,7 @@ tempo:
   #    memory: 6Gi
 
   memBallastSizeMbs: 1024
-  authEnabled: false
+  multitenancyEnabled: false
   # -- If true, enables Tempo's native search
   searchEnabled: false
   ingester: {}


### PR DESCRIPTION
authEnabled created the auth_enabled key in the config file.

This has been renamed a while ago in
https://github.com/grafana/tempo/pull/646, so update the helm chart
accordingly.