### PR TITLE
[tempo] Make setting service annotations works correctly and fix indent

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 0.13.0
+version: 0.13.1
 appVersion: 1.3.0
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
+![Version: 0.13.1](https://img.shields.io/badge/Version-0.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 

--- a/charts/tempo/templates/service.yaml
+++ b/charts/tempo/templates/service.yaml
@@ -5,16 +5,16 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" . | nindent 4 }}
-  {{- with .Values.annotations }}
+  {{- with .Values.service.annotations }}
   annotations:
-    {{ toYaml . | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
 {{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}
   type: ClusterIP
   {{- if .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP }}
-  {{end}}
+  {{ end }}
 {{- else if eq .Values.service.type "LoadBalancer" }}
   type: {{ .Values.service.type }}
   {{- if .Values.service.loadBalancerIP }}
@@ -22,14 +22,14 @@ spec:
   {{- end }}
   {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
-    {{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+    {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end -}}
-  {{- else }}
+{{- else }}
   type: {{ .Values.service.type }}
-  {{- end }}
   {{- if .Values.service.externalIPs }}
   externalIPs:
-  {{ toYaml .Values.service.externalIPs | indent 4 }}
+    {{- toYaml .Values.service.externalIPs | nindent 4 }}
+  {{- end }}
 {{- end }}
   ports:
   - name: tempo-prom-metrics


### PR DESCRIPTION
This PR make setting service annotations works correctly and fix indent on helm template.

When I set the following value in `values.yaml`, the annotations value is not set correctly. So, I renamed `.Values.annotations` to `.Values.service.annotations` and fixed some indent issue.

```
service:
  type: ClusterIP
  annotations:
    networking.istio.io/exportTo: "."
```

This seems related to #740.
Thank you!

Signed-off-by: Takaaki Furukawa <takaaki.frkw@gmail.com>