### PR TITLE
[grafana] bump kiwigrdi/k8s-sidecar to 1.14.3

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.20.7
+version: 6.20.8
 appVersion: 8.3.4
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -618,7 +618,7 @@ smtp:
 sidecar:
   image:
     repository: quay.io/kiwigrid/k8s-sidecar
-    tag: 1.14.2
+    tag: 1.14.3
     sha: ""
   imagePullPolicy: IfNotPresent
   resources: {}


### PR DESCRIPTION
Signed-off-by: Marlene Pereira <wear_mar@hotmail.com>

There are a number of high severity vulnerabilities items addressed in `1.14.3`.
Please refer to [kiwigrid/k8s-sidecar/issues/148](https://github.com/kiwigrid/k8s-sidecar/issues/148).