### PR TITLE
[grafana] bump kiwigrdi/k8s-sidecar to 1.15.1

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.20.8
+version: 6.21.0
 appVersion: 8.3.4
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -138,7 +138,7 @@ This version requires Helm >= 3.1.0.
 | `podLabels`                               | Pod labels                                    | `{}`                                                    |
 | `podPortName`                             | Name of the grafana port on the pod           | `grafana`                                               |
 | `sidecar.image.repository`                | Sidecar image repository                      | `quay.io/kiwigrid/k8s-sidecar`                          |
-| `sidecar.image.tag`                       | Sidecar image tag                             | `1.12.3`                                                |
+| `sidecar.image.tag`                       | Sidecar image tag                             | `1.15.1`                                                |
 | `sidecar.image.sha`                       | Sidecar image sha (optional)                  | `""`                                                    |
 | `sidecar.imagePullPolicy`                 | Sidecar image pull policy                     | `IfNotPresent`                                          |
 | `sidecar.resources`                       | Sidecar resources                             | `{}`                                                    |

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -618,7 +618,7 @@ smtp:
 sidecar:
   image:
     repository: quay.io/kiwigrid/k8s-sidecar
-    tag: 1.14.3
+    tag: 1.15.1
     sha: ""
   imagePullPolicy: IfNotPresent
   resources: {}


### PR DESCRIPTION
Signed-off-by: Marlene Pereira <wear_mar@hotmail.com>

Updating k8s-sidecar version to `1.15.1` as more CVEs are addressed in this version, [see](https://github.com/kiwigrid/k8s-sidecar/pull/151).