### PR TITLE
[grafana] Add app.kubernetes.io/component label

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.21.0
+version: 6.21.1
 appVersion: 8.3.4
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_helpers.tpl
+++ b/charts/grafana/templates/_helpers.tpl
@@ -82,6 +82,7 @@ Selector labels
 {{- define "grafana.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "grafana.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: grafana
 {{- end -}}
 
 {{/*
@@ -102,6 +103,7 @@ Selector labels ImageRenderer
 {{- define "grafana.imageRenderer.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "grafana.name" . }}-image-renderer
 app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: grafana
 {{- end -}}
 
 {{/*

--- a/charts/grafana/templates/hpa.yaml
+++ b/charts/grafana/templates/hpa.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ template "grafana.name" . }}
     helm.sh/chart: {{ template "grafana.chart" . }}
+    app.kubernetes.io/component: grafana
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:


### PR DESCRIPTION
Signed-off-by: Loïc Fouray <loic.fouray@orange.com>

Helm lists the recommended kubernetes labels from https://helm.sh/docs/chart_best_practices/labels/

Currently two labels are missing in Grafana Chart Helm :

app.kubernetes.io/component : it will be interesting to add this label
app.kubernetes.io/part-of : my opinion is that it is a label to add by the user