### PR TITLE
[loki-stack] Bumped grafana 8.1.6->8.3.4

### DIFF
--- a/charts/loki-stack/Chart.yaml
+++ b/charts/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 2.5.1
+version: 2.6.0
 appVersion: v2.1.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki-stack/requirements.yaml
+++ b/charts/loki-stack/requirements.yaml
@@ -13,7 +13,7 @@ dependencies:
   version: "^2.2.0"
 - name: "grafana"
   condition: grafana.enabled
-  version: "~6.16.12"
+  version: "~6.21.2"
   repository:  "https://grafana.github.io/helm-charts"
 - name: "prometheus"
   condition: prometheus.enabled

--- a/charts/loki-stack/values.yaml
+++ b/charts/loki-stack/values.yaml
@@ -13,7 +13,7 @@ grafana:
     datasources:
       enabled: true
   image:
-    tag: 8.1.6
+    tag: 8.3.4
 
 prometheus:
   enabled: false


### PR DESCRIPTION
Signed-off-by: Akram Weheba <akram.weheba@netscout.com>

Bumped Grafana minor version to 3. 

Addresses CVE-2021-43798 vulnerability in 8.1.6 and default new Grafana alerting.