### PR TITLE
[tempo] specify grpc appProtocol for tempo service

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 0.13.2
+version: 0.14.0
 appVersion: 1.3.1
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 0.13.2](https://img.shields.io/badge/Version-0.13.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
+![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 

--- a/charts/tempo/templates/service.yaml
+++ b/charts/tempo/templates/service.yaml
@@ -53,7 +53,7 @@ spec:
     port: 14268
     protocol: TCP
     targetPort: 14268
-  - name: tempo-jaeger-grpc
+  - name: grpc-tempo-jaeger
     port: 14250
     protocol: TCP
     targetPort: 14250
@@ -69,7 +69,7 @@ spec:
     port: 4318
     protocol: TCP
     targetPort: 4318
-  - name: tempo-otlp-grpc
+  - name: grpc-tempo-otlp
     port: 4317
     protocol: TCP
     targetPort: 4317


### PR DESCRIPTION
Istio uses port name prefixes or `appProtocol` to determine the protocol.
Currently, the names have the protocol as a suffix, but using appProtocol felt like a smaller change.

Relates to https://github.com/grafana/helm-charts/issues/104.