### PR TITLE
[grafana] Bumped Grafana 8.3.4 -> 8.3.5

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.21.3
-appVersion: 8.3.4
+version: 6.21.4
+appVersion: 8.3.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -73,7 +73,7 @@ livenessProbe:
 
 image:
   repository: grafana/grafana
-  tag: 8.3.4
+  tag: 8.3.5
   sha: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Resolve medium CVEs.
https://grafana.com/blog/2022/02/08/grafana-7.5.15-and-8.3.5-released-with-moderate-severity-security-fixes/

Signed-off-by: Thomas Kooi <t.j.kooi@avisi.nl>