### PR TITLE
[grafana] Use `with` for serviceMonitor interval and scrapeTimeout

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.21.2
+version: 6.21.3
 appVersion: 8.3.4
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/servicemonitor.yaml
+++ b/charts/grafana/templates/servicemonitor.yaml
@@ -14,9 +14,12 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-  - interval: {{ .Values.serviceMonitor.interval }}
-    {{- if .Values.serviceMonitor.scrapeTimeout }}
-    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+  - port: {{ .Values.service.portName }}
+    {{- with .Values.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
     {{- end }}
     honorLabels: true
     port: {{ .Values.service.portName }}


### PR DESCRIPTION
I ran into a problem with kube-prometheus-stack setting interval to "", which gets rendered as `null`

Signed-off-by: Brian Glogower <xbglowx@gmail.com>