### PR TITLE
[loki-stack] bumped Grafana image from 8.3.4 -> 8.3.5 in loki-stack

### DIFF
--- a/charts/loki-stack/Chart.yaml
+++ b/charts/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 2.6.0
+version: 2.6.1
 appVersion: v2.1.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki-stack/values.yaml
+++ b/charts/loki-stack/values.yaml
@@ -13,7 +13,7 @@ grafana:
     datasources:
       enabled: true
   image:
-    tag: 8.3.4
+    tag: 8.3.5
 
 prometheus:
   enabled: false


### PR DESCRIPTION
Resolve medium CVEs.
https://grafana.com/blog/2022/02/08/grafana-7.5.15-and-8.3.5-released-with-moderate-severity-security-fixes/

Signed-off-by: Thomas Kooi <t.j.kooi@avisi.nl>