### PR TITLE
loki.rulerRulesDirName should be lower case

### DIFF
--- a/charts/loki-distributed/templates/ruler/_helpers-ruler.tpl
+++ b/charts/loki-distributed/templates/ruler/_helpers-ruler.tpl
@@ -33,7 +33,7 @@ ruler image
 format rules dir
 */}}
 {{- define "loki.rulerRulesDirName" -}}
-rules-{{ . | replace "_" "-" | trimSuffix "-" }}
+rules-{{ . | replace "_" "-" | trimSuffix "-" | lower }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
ConfigMap names cannot be upper case. So for example `Example-Tenant` does not work in ruler configuration:

```
ruler:
  directories:
    Example-Tenant:
       rules1.txt: |
          ...
```
... as the name is used in the ConfigMap name. 

This change will impact only the name of the configmap (e.g. `loki-ruler-rules-example-tenant`), the directory in filesystem be written as it should (e.g. `/etc/loki/rules/Example-Tenant`). 

