### PR TITLE
[enterprise-logs] Re-add WAL dir configuration lost in 2.0.0 update

### DIFF
--- a/charts/enterprise-logs/CHANGELOG.md
+++ b/charts/enterprise-logs/CHANGELOG.md
@@ -26,7 +26,7 @@ Entries should include a reference to the pull request that introduced the chang
 ## 1.3.5
 
 - [BUGFIX] Use correct subPath configuration for the compactor's storage mount.
-- [BUGFIX] Fixed issue that prevented users from mouting extra persistent volumes for the compactor.
+- [BUGFIX] Fixed issue that prevented users from mounting extra persistent volumes for the compactor.
 - [CHANGE] Configure `securityContext.fsGroup` value for Admin API pod based on the value `adminApi.securityContext.runAsGroup`.
 
 ## 1.3.4
@@ -35,7 +35,7 @@ Entries should include a reference to the pull request that introduced the chang
 
 ## 1.3.3
 
-- [BUGFIX] Bumped version of `loki-disctributed` chart to 0.39.3 that defines default WAL location. #863
+- [BUGFIX] Bumped version of `loki-distributed` chart to 0.39.3 that defines default WAL location. #863
 
 ## 1.3.2
 

--- a/charts/enterprise-logs/CHANGELOG.md
+++ b/charts/enterprise-logs/CHANGELOG.md
@@ -11,7 +11,13 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
-## Unreleased
+## 2.0.1
+
+- [BUGFIX] Configure Loki WAL directory that was absent in the 2.0.0 change #1033
+
+## 2.0.0
+
+- [CHANGE] Expect GEL configuration as a string rather than structured data in the values.yaml file #943
 
 ## 1.4.0
 

--- a/charts/enterprise-logs/Chart.yaml
+++ b/charts/enterprise-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v2"
 name: "enterprise-logs"
 type: application
-version: "2.0.0"
+version: "2.0.1"
 appVersion: "v1.3.0"
 kubeVersion: "^1.10.0-0"
 description: "Grafana Enterprise Logs"

--- a/charts/enterprise-logs/values.yaml
+++ b/charts/enterprise-logs/values.yaml
@@ -100,6 +100,8 @@ config: |
     chunk_block_size: 262144
     chunk_encoding: snappy
     chunk_retain_period: 1m
+    wal:
+      dir: /var/loki/wal
 
   ingester_client:
     grpc_client_config:


### PR DESCRIPTION
Need to add the following under the ingester section of `config: |` of the values.yaml file for enterprise-logs chart. Right now this setting is only in the loki-distributed helm chart values.yaml file 

```
wal:
     dir: /var/loki/wal
```

This results in the ingester pods crash looping with an error of readonly filesystem