### PR TITLE
[grafana/grafana] add support for extraContainers volumeMounts

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.21.4
+version: 6.21.5
 appVersion: 8.3.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.


### PR DESCRIPTION
# Details:
## extraContainers
extraContainers for this moment does not have support for volumeMounts.
In this PR this feature is created.(in case extraContainers need volumes to be mounted).

## initChwon
At this memont grafana initialization (initChown) is enabled just is case persistence is enbled.
But there is the case when service depends on a external database(MariaDB) `GF_DATABASE_HOST`.


Signed-off-by: Ioachim Lihor <ioachim.lihor@radcom.com>