### PR TITLE
[grafana] Add back datasource sidecar initContainer

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.21.5
+version: 6.21.6
 appVersion: 8.3.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -77,6 +77,49 @@ initContainers:
         readOnly: {{ .readOnly }}
     {{- end }}
 {{- end }}
+{{- if and .Values.sidecar.datasources.enabled .Values.sidecar.datasources.initDatasources }}
+  - name: {{ template "grafana.name" . }}-init-sc-datasources
+    {{- if .Values.sidecar.image.sha }}
+    image: "{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
+    {{- else }}
+    image: "{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}"
+    {{- end }}
+    imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+    env:
+      - name: METHOD
+        value: "LIST"
+      - name: LABEL
+        value: "{{ .Values.sidecar.datasources.label }}"
+      {{- if .Values.sidecar.datasources.labelValue }}
+      - name: LABEL_VALUE
+        value: {{ quote .Values.sidecar.datasources.labelValue }}
+      {{- end }}
+      - name: FOLDER
+        value: "/etc/grafana/provisioning/datasources"
+      - name: RESOURCE
+        value: {{ quote .Values.sidecar.datasources.resource }}
+      {{- if .Values.sidecar.enableUniqueFilenames }}
+      - name: UNIQUE_FILENAMES
+        value: "{{ .Values.sidecar.enableUniqueFilenames }}"
+      {{- end }}
+      {{- if .Values.sidecar.datasources.searchNamespace }}
+      - name: NAMESPACE
+        value: "{{ .Values.sidecar.datasources.searchNamespace | join "," }}"
+      {{- end }}
+      {{- if .Values.sidecar.skipTlsVerify }}
+      - name: SKIP_TLS_VERIFY
+        value: "{{ .Values.sidecar.skipTlsVerify }}"
+      {{- end }}
+    resources:
+{{ toYaml .Values.sidecar.resources | indent 6 }}
+{{- if .Values.sidecar.securityContext }}
+    securityContext:
+{{- toYaml .Values.sidecar.securityContext | nindent 6 }}
+{{- end }}
+    volumeMounts:
+      - name: sc-datasources-volume
+        mountPath: "/etc/grafana/provisioning/datasources"
+{{- end }}
 {{- if .Values.sidecar.notifiers.enabled }}
   - name: {{ template "grafana.name" . }}-sc-notifiers
     {{- if .Values.sidecar.image.sha }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -691,6 +691,9 @@ sidecar:
     # Endpoint to send request to reload datasources
     reloadURL: "http://localhost:3000/api/admin/provisioning/datasources/reload"
     skipReload: false
+    # Deploy the datasource sidecar as an initContainer in addition to a container.
+    # This is needed if skipReload is true, to load any datasources defined at startup time.
+    initDatasources: false
   notifiers:
     enabled: false
     # label that the configmaps with notifiers are marked with


### PR DESCRIPTION
Brings back the datasource sidecar initContainer that was removed in https://github.com/grafana/helm-charts/commit/ee0914e19e680a6cde7a5a4e9bcb43f2bef9517a

```
POST request sent to http://localhost:3000/api/admin/provisioning/datasources/reload. Response: 401 Unauthorized {"message": "Unauthorized"}
```
Users not using Basic Auth need to set `datasources.skipReload` to `true` to avoid these 401s ([Admin API only works with basic auth](https://grafana.com/docs/grafana/latest/http_api/admin/#reload-provisioning-configurations)). However, this essentially disables automatic datasource reloading, and since the `initContainer` was also removed, grafana no longer loads any cm/secret-defined datasources (even those that may already exist) when it comes up. Restarting the pod manually fails to load any datasources since there is no longer an `initContainer` that first adds these datasources. The sidecar running in a container is only effective if the `reloadURL` can be hit.

For the `initContainer`, the `METHOD` cannot be `WATCH` as it causes the container to hang so I also hardcoded it to `LIST` which is the main difference from the [original `initContainer` definition](https://github.com/grafana/helm-charts/commit/ee0914e19e680a6cde7a5a4e9bcb43f2bef9517a#diff-23be7f77a732d6c6ecd4d8dfa6e944481ee2f7631d9061ce5aa128cb4b2ff410L80-L122) ([it was originally defaulted to `LIST`](https://github.com/grafana/helm-charts/commit/ee0914e19e680a6cde7a5a4e9bcb43f2bef9517a#diff-98c2472bc9183f58f15ae217e67d9bf3ee0e6e087dfb48ba82f6f073a4ba56b9L688) so not changing the default func)