### PR TITLE
[loki] docs: alerting uri goes to 404 -> /rules/

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 2.9.1
+version: 2.10.0
 appVersion: v2.4.2
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki/README.md
+++ b/charts/loki/README.md
@@ -67,4 +67,4 @@ spec:
 
 You can add your own alerting rules with `alerting_groups` in `values.yaml`. This will create a ConfigMap with your rules and additional volumes and mounts for Loki.
 
-This does **not** enable the Loki `ruler` component which does the evaluation of your rules. The `values.yaml` file does contain a simple example. For more details take a look at the official [alerting docs](https://grafana.com/docs/loki/latest/alerting/).
+This does **not** enable the Loki `ruler` component which does the evaluation of your rules. The `values.yaml` file does contain a simple example. For more details take a look at the official [alerting docs](https://grafana.com/docs/loki/latest/rules/).

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -102,7 +102,7 @@ config:
   compactor:
     working_directory: /data/loki/boltdb-shipper-compactor
     shared_store: filesystem
-# Needed for Alerting: https://grafana.com/docs/loki/latest/alerting/
+# Needed for Alerting: https://grafana.com/docs/loki/latest/rules/
 # This is just a simple example, for more details: https://grafana.com/docs/loki/latest/configuration/#ruler_config
 #  ruler:
 #    storage:
@@ -271,7 +271,7 @@ extraPorts: []
 # Extra env variables to pass to the loki container
 env: []
 
-# Specify Loki Alerting rules based on this documentation: https://grafana.com/docs/loki/latest/alerting/
+# Specify Loki Alerting rules based on this documentation: https://grafana.com/docs/loki/latest/rules/
 # When specified, you also need to add a ruler config section above. An example is shown in the alerting docs.
 alerting_groups: []
 #  - name: example


### PR DESCRIPTION
The alerting url https://grafana.com/docs/loki/latest/alerting throws a 404.

I think the document now lies under https://grafana.com/docs/loki/latest/rules/

---
Signed-off-by: Toni Tauro <toni.tauro@adfinis.com>