### PR TITLE
[loki] feat: Add optional prometheusRule value/template

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 2.10.0
+version: 2.10.1
 appVersion: v2.4.2
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki/templates/prometheusrule.yaml
+++ b/charts/loki/templates/prometheusrule.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.serviceMonitor.enabled .Values.serviceMonitor.prometheusRule.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "loki.fullname" . }}
+{{- if .Values.serviceMonitor.prometheusRule.namespace }}
+  namespace: {{ .Values.serviceMonitor.prometheusRule.namespace | quote }}
+{{- end }}
+  labels:
+    app: {{ template "loki.name" . }}
+    chart: {{ template "loki.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  {{- if .Values.serviceMonitor.prometheusRule.additionalLabels }}
+    {{- toYaml .Values.serviceMonitor.prometheusRule.additionalLabels | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.serviceMonitor.prometheusRule.rules }}
+  groups:
+  - name: {{ template "loki.fullname" . }}
+    rules: {{- toYaml .Values.serviceMonitor.prometheusRule.rules | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -228,6 +228,45 @@ serviceMonitor:
   annotations: {}
   # scrapeTimeout: 10s
   # path: /metrics
+  prometheusRule:
+    enabled: false
+    additionalLabels: {}
+  #  namespace:
+    rules: []
+    #  Some examples from https://awesome-prometheus-alerts.grep.to/rules.html#loki
+    #  - alert: LokiProcessTooManyRestarts
+    #    expr: changes(process_start_time_seconds{job=~"loki"}[15m]) > 2
+    #    for: 0m
+    #    labels:
+    #      severity: warning
+    #    annotations:
+    #      summary: Loki process too many restarts (instance {{ $labels.instance }})
+    #      description: "A loki process had too many restarts (target {{ $labels.instance }})\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+    #  - alert: LokiRequestErrors
+    #    expr: 100 * sum(rate(loki_request_duration_seconds_count{status_code=~"5.."}[1m])) by (namespace, job, route) / sum(rate(loki_request_duration_seconds_count[1m])) by (namespace, job, route) > 10
+    #    for: 15m
+    #    labels:
+    #      severity: critical
+    #    annotations:
+    #      summary: Loki request errors (instance {{ $labels.instance }})
+    #      description: "The {{ $labels.job }} and {{ $labels.route }} are experiencing errors\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+    #  - alert: LokiRequestPanic
+    #    expr: sum(increase(loki_panic_total[10m])) by (namespace, job) > 0
+    #    for: 5m
+    #    labels:
+    #      severity: critical
+    #    annotations:
+    #      summary: Loki request panic (instance {{ $labels.instance }})
+    #      description: "The {{ $labels.job }} is experiencing {{ printf \"%.2f\" $value }}% increase of panics\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+    #  - alert: LokiRequestLatency
+    #    expr: (histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket{route!~"(?i).*tail.*"}[5m])) by (le)))  > 1
+    #    for: 5m
+    #    labels:
+    #      severity: critical
+    #    annotations:
+    #      summary: Loki request latency (instance {{ $labels.instance }})
+    #      description: "The {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf \"%.2f\" $value }}s 99th percentile latency\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
 
 initContainers: []
 ## Init containers to be added to the loki pod.


### PR DESCRIPTION
Adds an additional prometheusRule template for adding custom Rules which can be used by alertmanager to alert us.

It makes sure prometheusRules are only deployed if serviceMonitor is enabled

---


Signed-off-by: Toni Tauro <toni.tauro@adfinis.com>