### PR TITLE
[grafana] deps: Bump grafana from 8.3.5 to 8.3.6, take 2

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.21.7
+version: 6.21.8
 appVersion: 8.3.6
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -73,7 +73,7 @@ livenessProbe:
 
 image:
   repository: grafana/grafana
-  tag: 8.3.5
+  tag: 8.3.6
   sha: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Sorry, I've made a mistake in #1051: just bump the `appVersion` field in Chart.yaml, not tag in values.yaml. This PR corrects it.