### PR TITLE
[tempo] Deploy tempo ServiceAccount in release namespace

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 0.14.0
+version: 0.14.1
 appVersion: 1.3.1
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
+![Version: 0.14.1](https://img.shields.io/badge/Version-0.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 

--- a/charts/tempo/templates/serviceaccount.yaml
+++ b/charts/tempo/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "tempo.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
The tempo Helm Chart can currently not be deployed in a namespace other than default, as the ServiceAccount is not deployed to the release namespace.