### PR TITLE
[grafana] Create role rules on notifier toggle

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.21.8
+version: 6.21.9
 appVersion: 8.3.6
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/clusterrole.yaml
+++ b/charts/grafana/templates/clusterrole.yaml
@@ -9,9 +9,9 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
   name: {{ template "grafana.fullname" . }}-clusterrole
-{{- if or .Values.sidecar.dashboards.enabled (or .Values.sidecar.datasources.enabled .Values.rbac.extraClusterRoleRules) }}
+{{- if or .Values.sidecar.dashboards.enabled (or .Values.sidecar.datasources.enabled (or .Values.sidecar.notifiers.enabled .Values.rbac.extraClusterRoleRules)) }}
 rules:
-{{- if or .Values.sidecar.dashboards.enabled .Values.sidecar.datasources.enabled }}
+{{- if or .Values.sidecar.dashboards.enabled (or .Values.sidecar.notifiers.enabled .Values.sidecar.datasources.enabled )}}
 - apiGroups: [""] # "" indicates the core API group
   resources: ["configmaps", "secrets"]
   verbs: ["get", "watch", "list"]

--- a/charts/grafana/templates/clusterrole.yaml
+++ b/charts/grafana/templates/clusterrole.yaml
@@ -11,7 +11,7 @@ metadata:
   name: {{ template "grafana.fullname" . }}-clusterrole
 {{- if or .Values.sidecar.dashboards.enabled (or .Values.sidecar.datasources.enabled (or .Values.sidecar.notifiers.enabled .Values.rbac.extraClusterRoleRules)) }}
 rules:
-{{- if or .Values.sidecar.dashboards.enabled (or .Values.sidecar.notifiers.enabled .Values.sidecar.datasources.enabled )}}
+{{- if or .Values.sidecar.dashboards.enabled .Values.sidecar.notifiers.enabled .Values.sidecar.datasources.enabled }}
 - apiGroups: [""] # "" indicates the core API group
   resources: ["configmaps", "secrets"]
   verbs: ["get", "watch", "list"]

--- a/charts/grafana/templates/clusterrole.yaml
+++ b/charts/grafana/templates/clusterrole.yaml
@@ -9,7 +9,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
   name: {{ template "grafana.fullname" . }}-clusterrole
-{{- if or .Values.sidecar.dashboards.enabled (or .Values.sidecar.datasources.enabled (or .Values.sidecar.notifiers.enabled .Values.rbac.extraClusterRoleRules)) }}
+{{- if or .Values.sidecar.dashboards.enabled .Values.sidecar.datasources.enabled .Values.sidecar.notifiers.enabled .Values.rbac.extraClusterRoleRules }}
 rules:
 {{- if or .Values.sidecar.dashboards.enabled .Values.sidecar.notifiers.enabled .Values.sidecar.datasources.enabled }}
 - apiGroups: [""] # "" indicates the core API group

--- a/charts/grafana/templates/role.yaml
+++ b/charts/grafana/templates/role.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- if or .Values.rbac.pspEnabled (and .Values.rbac.namespaced (or .Values.sidecar.dashboards.enabled (or .Values.sidecar.datasources.enabled .Values.rbac.extraRoleRules))) }}
+{{- if or .Values.rbac.pspEnabled (and .Values.rbac.namespaced (or .Values.sidecar.dashboards.enabled (or .Values.sidecar.datasources.enabled (or .Values.sidecar.notifiers.enabled .Values.rbac.extraRoleRules)))) }}
 rules:
 {{- if .Values.rbac.pspEnabled }}
 - apiGroups:      ['extensions']
@@ -18,7 +18,7 @@ rules:
   verbs:          ['use']
   resourceNames:  [{{ template "grafana.fullname" . }}]
 {{- end }}
-{{- if and .Values.rbac.namespaced (or .Values.sidecar.dashboards.enabled .Values.sidecar.datasources.enabled) }}
+{{- if and .Values.rbac.namespaced (or .Values.sidecar.dashboards.enabled (or .Values.sidecar.notifiers.enabled .Values.sidecar.datasources.enabled)) }}
 - apiGroups: [""] # "" indicates the core API group
   resources: ["configmaps", "secrets"]
   verbs: ["get", "watch", "list"]

--- a/charts/grafana/templates/role.yaml
+++ b/charts/grafana/templates/role.yaml
@@ -18,7 +18,7 @@ rules:
   verbs:          ['use']
   resourceNames:  [{{ template "grafana.fullname" . }}]
 {{- end }}
-{{- if and .Values.rbac.namespaced (or .Values.sidecar.dashboards.enabled (or .Values.sidecar.notifiers.enabled .Values.sidecar.datasources.enabled)) }}
+{{- if and .Values.rbac.namespaced (or .Values.sidecar.dashboards.enabled .Values.sidecar.notifiers.enabled .Values.sidecar.datasources.enabled) }}
 - apiGroups: [""] # "" indicates the core API group
   resources: ["configmaps", "secrets"]
   verbs: ["get", "watch", "list"]

--- a/charts/grafana/templates/role.yaml
+++ b/charts/grafana/templates/role.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- if or .Values.rbac.pspEnabled (and .Values.rbac.namespaced (or .Values.sidecar.dashboards.enabled (or .Values.sidecar.datasources.enabled (or .Values.sidecar.notifiers.enabled .Values.rbac.extraRoleRules)))) }}
+{{- if or .Values.rbac.pspEnabled (and .Values.rbac.namespaced (or .Values.sidecar.dashboards.enabled  .Values.sidecar.datasources.enabled  .Values.sidecar.notifiers.enabled .Values.rbac.extraRoleRules)) }}
 rules:
 {{- if .Values.rbac.pspEnabled }}
 - apiGroups:      ['extensions']


### PR DESCRIPTION
I noticed that when using _only_ the notifiers sidecar (not alongside the dashboards or datasources sidecars), the rules necessary for both Role and ClusterRole are not created. I don't know if this is intentional or just not used very often, but in my case it was preventing me from deploying Grafana. Adding another bit `or` logic resolves this.