### PR TITLE
[enterprise-logs] Update values.yaml

### DIFF
--- a/charts/enterprise-logs/values.yaml
+++ b/charts/enterprise-logs/values.yaml
@@ -466,8 +466,9 @@ loki-distributed:
 
   # RBAC configuration
   rbac:
-    # -- If enabled, a PodSecurityPolicy is created
+    # -- If pspEnabled true, a PodSecurityPolicy is created for K8s that use psp. For OpenShift set pspEnabled to 'false' and sccEnabled to 'true' to create the SecurityContextConstraints
     pspEnabled: true
+    sccEnabled: false
 
   # -- Compactor is defined in parent chart
   compactor:


### PR DESCRIPTION
Change the values.yaml file, so one can choose pspEnabled for K8s that use PodSecurityPolicy (i.e. AKS, EKS, and GKE) when pspEnbabled set to 'true'. For OpenShift, which doesn't support / use PodSecurityPolicy, but instead uses SecurityContextContraints we can just set pspEnabled to 'false' and sccEnabled to 'true' and have the role, rolebinding and serviceAccount use the proper one (i.e. PSP or SCC). 