### PR TITLE
[loki-distributed] Update rolebinding.yaml

### DIFF
--- a/charts/loki-distributed/templates/rolebinding.yaml
+++ b/charts/loki-distributed/templates/rolebinding.yaml
@@ -12,4 +12,23 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "loki.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+
+{{- if .Values.rbac.sccEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: default:loki
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: scc:hostmount-anyuid
+subjects:
+- kind: ServiceAccount
+  name: loki
+  name: {{ include "loki.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
This adds support for OpenShift by defining the SCC policies required. This goes along with the values.yaml change for rbac.sccEnabled  and the role.yaml changes (PR https://github.com/grafana/helm-charts/pull/1078) as well as the new file securitycontextconstraints.yaml file