### PR TITLE
Add files via upload

### DIFF
--- a/securitycontextconstraints.yaml
+++ b/securitycontextconstraints.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.rbac.sccEnabled }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ include "loki.fullname" . }}
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: []
+defaultAddCapabilities: null
+fsGroup: 
+  type: MustRunAs
+groups: []
+priority: null
+readOnlyRootFilesystem: true
+requiredDropCapabilities: 
+  - ALL
+runAsUser: 
+  type: MustRunAsNonRoot
+seLinuxContext: 
+  type: RunAsAny  
+seccompProfiles:
+  - '*'
+supplementalGroups: 
+  type: MustRunAs
+volumes: 
+  - configMap
+  - emptyDir
+  - persistentVolumeClaim
+  - secret
+{{ end }}
+


### PR DESCRIPTION
This adds support for OpenShift by defining the SCC policies required. This goes file securitycontextconstraints.yaml (OCP SCC version of podsecuritypolicy along with the values.yaml change for rbac.sccEnabled  and the role.yaml changes as well as rolebinding.yaml