### PR TITLE
[loki-distributed] loki.rulerRulesDirName should be lower case

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.4.2
-version: 0.45.0
+version: 0.45.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.45.0](https://img.shields.io/badge/Version-0.45.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
+![Version: 0.45.1](https://img.shields.io/badge/Version-0.45.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/templates/ruler/_helpers-ruler.tpl
+++ b/charts/loki-distributed/templates/ruler/_helpers-ruler.tpl
@@ -33,7 +33,7 @@ ruler image
 format rules dir
 */}}
 {{- define "loki.rulerRulesDirName" -}}
-rules-{{ . | replace "_" "-" | trimSuffix "-" }}
+rules-{{ . | replace "_" "-" | trimSuffix "-" | lower }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
ConfigMap names cannot be upper case. So for example `Example-Tenant` does not work in ruler configuration:

```
ruler:
  directories:
    Example-Tenant:
       rules1.txt: |
          ...
```
... as the name is used in the ConfigMap name. 

This change will impact only the name of the configmap (e.g. `loki-ruler-rules-example-tenant`), the directory in filesystem be written as it should (e.g. `/etc/loki/rules/Example-Tenant`). 
