### PR TITLE
[loki-stack] Bump chart versions of all dependencies of Loki-stack chart

### DIFF
--- a/charts/loki-stack/Chart.yaml
+++ b/charts/loki-stack/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v1"
 name: loki-stack
-version: 2.6.3
-appVersion: v2.1.0
+version: 2.6.4
+appVersion: v2.4.2
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."
 home: https://grafana.com/loki

--- a/charts/loki-stack/requirements.yaml
+++ b/charts/loki-stack/requirements.yaml
@@ -2,28 +2,28 @@ dependencies:
 - name: "loki"
   condition: loki.enabled
   repository: "https://grafana.github.io/helm-charts"
-  version: "^2.3.0"
+  version: "^2.10.1"
 - name: "promtail"
   condition: promtail.enabled
   repository: "https://grafana.github.io/helm-charts"
-  version: "^2.2.0"
+  version: "^3.11.0"
 - name: "fluent-bit"
   condition: fluent-bit.enabled
   repository: "https://grafana.github.io/helm-charts"
-  version: "^2.2.0"
+  version: "^2.3.0"
 - name: "grafana"
   condition: grafana.enabled
-  version: "~6.21.2"
+  version: "~6.24.1"
   repository:  "https://grafana.github.io/helm-charts"
 - name: "prometheus"
   condition: prometheus.enabled
-  version: "~15.0.1"
+  version: "~15.5.3"
   repository:  "https://prometheus-community.github.io/helm-charts"
 - name: "filebeat"
   condition: filebeat.enabled
-  version: "~7.8.0"
+  version: "~7.17.1"
   repository:  "https://helm.elastic.co"
 - name: "logstash"
   condition: logstash.enabled
-  version: "~7.8.0"
+  version: "~7.17.1"
   repository:  "https://helm.elastic.co"

--- a/charts/loki-stack/values.yaml
+++ b/charts/loki-stack/values.yaml
@@ -4,6 +4,8 @@ loki:
 
 promtail:
   enabled: true
+  config:
+    lokiAddress: http://{{ .Release.Name }}:3100/loki/api/v1/push
 
 fluent-bit:
   enabled: false


### PR DESCRIPTION
This PR bumps the Promtail version in the `loki-stack` chart to 2.4.2. 