### PR TITLE
[grafana] enable configuration of parameters WATCH_SERVER_TIMEOUT and WATCH_CLI…

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.24.0
+version: 6.24.1
 appVersion: 8.4.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -213,6 +213,14 @@ containers:
       - name: SCRIPT
         value: "{{ .Values.sidecar.dashboards.script }}"
       {{- end }}
+      {{- if .Values.sidecar.dashboards.watchServerTimeout }}
+      - name: WATCH_SERVER_TIMEOUT
+        value: "{{ .Values.sidecar.dashboards.watchServerTimeout }}"
+      {{- end }}
+      {{- if .Values.sidecar.dashboards.watchClientTimeout }}
+      - name: WATCH_CLIENT_TIMEOUT
+        value: "{{ .Values.sidecar.dashboards.watchClientTimeout }}"
+      {{- end }}
     resources:
 {{ toYaml .Values.sidecar.resources | indent 6 }}
 {{- if .Values.sidecar.securityContext }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -660,6 +660,16 @@ sidecar:
     folderAnnotation: null
     # Absolute path to shell script to execute after a configmap got reloaded
     script: null
+    # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+    # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+    #watchServerTimeout: 3600
+    #
+    # watchClientTimeout: is a client-side timeout, configuring your local socket.
+    # If you have a network outage dropping all packets with no RST/FIN,
+    # this is how long your client waits before realizing & dropping the connection.
+    # defaults to 66sec (sic!)
+    #watchClientTimeout: 60
+    #
     # provider configuration that lets grafana manage the dashboards
     provider:
       # name of the provider, should be unique

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -662,13 +662,13 @@ sidecar:
     script: null
     # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
     # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
-    #watchServerTimeout: 3600
+    # watchServerTimeout: 3600
     #
     # watchClientTimeout: is a client-side timeout, configuring your local socket.
     # If you have a network outage dropping all packets with no RST/FIN,
     # this is how long your client waits before realizing & dropping the connection.
     # defaults to 66sec (sic!)
-    #watchClientTimeout: 60
+    # watchClientTimeout: 60
     #
     # provider configuration that lets grafana manage the dashboards
     provider:


### PR DESCRIPTION
enable configuration of parameters WATCH_SERVER_TIMEOUT and WATCH_CLIENT_TIMEOUT in kiwigrid sidecar container which looses its connection to Azure AKS API-Servers

see [new parameters with defaults in kiwigrid](https://github.com/kiwigrid/k8s-sidecar/pull/150/files)
see [original issue](https://github.com/kiwigrid/k8s-sidecar/issues/85)