### PR TITLE
[enterprise-metrics] Update enterprise-metrics to 1.7.0

### DIFF
--- a/charts/enterprise-metrics/CHANGELOG.md
+++ b/charts/enterprise-metrics/CHANGELOG.md
@@ -9,6 +9,11 @@ Entries should be ordered as follows:
 - [BUGFIX]
 
 Entries should include a reference to the Pull Request that introduced the change.
+
+## 1.8.0
+
+* [FEATURE] Upgrade to [Grafana Enterprise Metrics v1.7.0](https://grafana.com/docs/metrics-enterprise/latest/downloads/#v170----january-6th-2022).
+
 ## 1.7.3
 
 * [BUGFIX] Alertmanager does not fail anymore to load configuration via the API. #945

--- a/charts/enterprise-metrics/Chart.yaml
+++ b/charts/enterprise-metrics/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: 1.7.3
-appVersion: v1.6.1
+version: 1.8.0
+appVersion: v1.7.0
 description: "Grafana Enterprise Metrics"
 engine: gotpl
 home: https://grafana.com/products/enterprise/metrics

--- a/charts/enterprise-metrics/values.yaml
+++ b/charts/enterprise-metrics/values.yaml
@@ -8,7 +8,7 @@
 # Since the image is unique for all microservices, so are image settings.
 image:
   repository: grafana/metrics-enterprise
-  tag: v1.6.1
+  tag: v1.7.0
   pullPolicy: IfNotPresent
   # Optionally specify an array of imagePullSecrets.
   # Secrets must be manually created in the namespace.


### PR DESCRIPTION
This PR updates the helm chart to deploy GEM 1.7.0, the latest release.