### PR TITLE
[promtail] make extra client configs an array of configs

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.4.2
-version: 3.11.0
+version: 4.0.0
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 3.11.0](https://img.shields.io/badge/Version-3.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
+![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 
@@ -72,7 +72,7 @@ The new release which will pick up again from the existing `positions.yaml`.
 | config.lokiAddress | string | `"http://loki-gateway/loki/api/v1/push"` | The Loki address to post logs to. Must be reference in `config.file` to configure `client.url`. See default config in `values.yaml` |
 | config.serverPort | int | `3101` | The port of the Promtail server Must be reference in `config.file` to configure `server.http_listen_port` See default config in `values.yaml` |
 | config.snippets | object | See `values.yaml` | A section of reusable snippets that can be reference in `config.file`. Custom snippets may be added in order to reduce redundancy. This is especially helpful when multiple `kubernetes_sd_configs` are use which usually have large parts in common. |
-| config.snippets.extraClientConfigs | string | empty | You can put here any keys that will be directly added to the config file's 'client' block. |
+| config.snippets.extraClientConfigs | list | empty | You can put here any keys that will be directly added to the config file's 'client' block. |
 | config.snippets.extraRelabelConfigs | list | `[]` | You can put here any additional relabel_configs to "kubernetes-pods" job |
 | config.snippets.extraScrapeConfigs | string | empty | You can put here any additional scrape configs you want to add to the config file. |
 | containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The security context for containers |

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -290,7 +290,7 @@ config:
 
     # -- You can put here any keys that will be directly added to the config file's 'client' block.
     # @default -- empty
-    extraClientConfigs: ""
+    extraClientConfigs: []
 
     # -- You can put here any additional scrape configs you want to add to the config file.
     # @default -- empty
@@ -344,9 +344,11 @@ config:
       log_level: {{ .Values.config.logLevel }}
       http_listen_port: {{ .Values.config.serverPort }}
 
-    client:
-      url: {{ tpl .Values.config.lokiAddress . }}
-      {{- tpl .Values.config.snippets.extraClientConfigs . | nindent 2 }}
+    clients:
+      - url: {{ tpl .Values.config.lokiAddress . }}
+      {{- with .Values.config.snippets.extraClientConfigs }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
 
     positions:
       filename: /run/promtail/positions.yaml


### PR DESCRIPTION
This makes it easier to support multiple client configs in the promtail helm chart. The provided lokiAddress is used for the first client config, but I've changed is from `client:` with a single config to `clients:` to support multiple, with the rest being optionally provided as an array of client configs in the `extraClientConfigs` section.

Signed-off-by: Trevor Whitney <trevorjwhitney@gmail.com>