### PR TITLE
[enterprise-logs-simple] new helm chart for GEL in simple scalable mode

### DIFF
--- a/charts/enterprise-logs-simple/CHANGELOG.md
+++ b/charts/enterprise-logs-simple/CHANGELOG.md
@@ -11,63 +11,6 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
-## 2.0.1
-
-- [BUGFIX] Configure Loki WAL directory that was absent in the 2.0.0 change #1033
-
-## 2.0.0
-
-- [CHANGE] Expect GEL configuration as a string rather than structured data in the values.yaml file #943
-
-## 1.4.0
-
-- [CHANGE] Bump GEL version to v1.3.0
-
-## 1.3.5
-
-- [BUGFIX] Use correct subPath configuration for the compactor's storage mount.
-- [BUGFIX] Fixed issue that prevented users from mounting extra persistent volumes for the compactor.
-- [CHANGE] Configure `securityContext.fsGroup` value for Admin API pod based on the value `adminApi.securityContext.runAsGroup`.
-
-## 1.3.4
-
-- [CHANGE] Remove selector and config hash annotations from the tokengen job that make it hard to update the helm chart after deploying that job
-
-## 1.3.3
-
-- [BUGFIX] Bumped version of `loki-distributed` chart to 0.39.3 that defines default WAL location. #863
-
-## 1.3.2
-
-- [BUGFIX] Fixed issue that caused GEL version not to be updated in the templates of the loki-distributed child chart. #863
-
-## 1.3.1
-
-- [BUGFIX] Fixed error in template rendering when MinIO is disabled.
-
-## 1.3.0
-
-- [CHANGE] Bump GEL version to v1.2.0
-
-## 1.2.1
-
-- [BUGFIX] Fixed the dev cluster MinIO endpoints in the default configuration. #826
-
-## 1.2.0
-
-- [CHANGE] Removed unused deployment of `memcached-index-writes` StatefulSet when using `small.yaml` values file.
-
-## 1.1.1
-
-- [BUGFIX] Ensure that Pods run as non-root user `enterprise-logs` (`uid=10001,gid=10001`). #690
-
-## 1.1.0
-
-* [CHANGE] Updated `loki-distributed` chart dependency to `^0.37.3`. #684
-* [CHANGE] Removed table manager deployment, because GEL uses boltdb-shipper and compactor. #684
-* [ENHANCEMENT] Enabled deployment of `index-gateway`. #684
-* [ENHANCEMENT] Enabled persistent volume for `querier` service. #684
-
 ## 1.0.0
 
-* [FEATURE] Initial version of the `enterprise-logs` (GEL) Helm chart. #629
+* [FEATURE] Initial version of the `enterprise-logs-simple` (GEL) Helm chart. #629

--- a/charts/enterprise-logs-simple/CHANGELOG.md
+++ b/charts/enterprise-logs-simple/CHANGELOG.md
@@ -1,0 +1,73 @@
+# Changelog
+
+All notable changes to this library will be documented in this file.
+
+Entries should be ordered as follows:
+
+- [CHANGE]
+- [FEATURE]
+- [ENHANCEMENT]
+- [BUGFIX]
+
+Entries should include a reference to the pull request that introduced the change.
+
+## 2.0.1
+
+- [BUGFIX] Configure Loki WAL directory that was absent in the 2.0.0 change #1033
+
+## 2.0.0
+
+- [CHANGE] Expect GEL configuration as a string rather than structured data in the values.yaml file #943
+
+## 1.4.0
+
+- [CHANGE] Bump GEL version to v1.3.0
+
+## 1.3.5
+
+- [BUGFIX] Use correct subPath configuration for the compactor's storage mount.
+- [BUGFIX] Fixed issue that prevented users from mounting extra persistent volumes for the compactor.
+- [CHANGE] Configure `securityContext.fsGroup` value for Admin API pod based on the value `adminApi.securityContext.runAsGroup`.
+
+## 1.3.4
+
+- [CHANGE] Remove selector and config hash annotations from the tokengen job that make it hard to update the helm chart after deploying that job
+
+## 1.3.3
+
+- [BUGFIX] Bumped version of `loki-distributed` chart to 0.39.3 that defines default WAL location. #863
+
+## 1.3.2
+
+- [BUGFIX] Fixed issue that caused GEL version not to be updated in the templates of the loki-distributed child chart. #863
+
+## 1.3.1
+
+- [BUGFIX] Fixed error in template rendering when MinIO is disabled.
+
+## 1.3.0
+
+- [CHANGE] Bump GEL version to v1.2.0
+
+## 1.2.1
+
+- [BUGFIX] Fixed the dev cluster MinIO endpoints in the default configuration. #826
+
+## 1.2.0
+
+- [CHANGE] Removed unused deployment of `memcached-index-writes` StatefulSet when using `small.yaml` values file.
+
+## 1.1.1
+
+- [BUGFIX] Ensure that Pods run as non-root user `enterprise-logs` (`uid=10001,gid=10001`). #690
+
+## 1.1.0
+
+* [CHANGE] Updated `loki-distributed` chart dependency to `^0.37.3`. #684
+* [CHANGE] Removed table manager deployment, because GEL uses boltdb-shipper and compactor. #684
+* [ENHANCEMENT] Enabled deployment of `index-gateway`. #684
+* [ENHANCEMENT] Enabled persistent volume for `querier` service. #684
+
+## 1.0.0
+
+* [FEATURE] Initial version of the `enterprise-logs` (GEL) Helm chart. #629

--- a/charts/enterprise-logs-simple/CHANGELOG.md
+++ b/charts/enterprise-logs-simple/CHANGELOG.md
@@ -13,4 +13,4 @@ Entries should include a reference to the pull request that introduced the chang
 
 ## 1.0.0
 
-* [FEATURE] Initial version of the `enterprise-logs-simple` (GEL) Helm chart. #629
+* [FEATURE] Initial version of the `enterprise-logs-simple` (GEL) Helm chart. #1123

--- a/charts/enterprise-logs-simple/Chart.lock
+++ b/charts/enterprise-logs-simple/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: loki-simple-scalable
+  repository: https://grafana.github.io/helm-charts
+  version: 0.2.0
+- name: minio
+  repository: https://helm.min.io/
+  version: 8.0.9
+digest: sha256:1dd683a6d16f6d41f7f6d931ff7fc007133d689ca063b40960f9dd9534fc5e35
+generated: "2022-03-18T17:16:26.514173687-06:00"

--- a/charts/enterprise-logs-simple/Chart.yaml
+++ b/charts/enterprise-logs-simple/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v2"
 name: "enterprise-logs-simple"
 type: application
-version: "0.0.1"
+version: "1.0.0"
 appVersion: "v1.3.0"
 kubeVersion: "^1.10.0-0"
 description: "Grafana Enterprise Logs (Simple Scalable)"

--- a/charts/enterprise-logs-simple/Chart.yaml
+++ b/charts/enterprise-logs-simple/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: "v2"
+name: "enterprise-logs-simple"
+type: application
+version: "0.0.1"
+appVersion: "v1.3.0"
+kubeVersion: "^1.10.0-0"
+description: "Grafana Enterprise Logs (Simple Scalable)"
+home: "https://grafana.com/products/enterprise/logs/"
+dependencies:
+- name: loki-simple-scalable
+  version: ^0.2.0
+  repository: https://grafana.github.io/helm-charts
+- name: minio
+  alias: minio
+  version: 8.0.9
+  repository: https://helm.min.io/
+  condition: minio.enabled

--- a/charts/enterprise-logs-simple/README.md
+++ b/charts/enterprise-logs-simple/README.md
@@ -1,0 +1,107 @@
+# Grafana Enterprise Logs Simple Helm Chart
+
+A Helm chart for deploying [Grafana Enterprise Logs](https://grafana.com/products/enterprise/logs/) in Simple Scalable deployment architecture to Kubernetes.
+
+## Dependencies
+
+This chart depends on the
+[`loki-simple-scalable`](https://github.com/grafana/helm-charts/tree/main/charts/loki-simple-scalable) Helm
+chart and extends it with Grafana Enterprise Logs components and configuration.
+It also depends on [`minio`](https://github.com/minio/charts/tree/master/minio) Helm chart, if the
+variable `minio.enabled` is set to `true` (only recommended for testing).
+
+## Requirements
+
+### License
+
+In order to use any enterprise features of Grafana Enterprise Logs, you need to provide the contents
+of a Grafana Enterprise Logs license file as the value for the `license.contents` variable. To
+obtain a Grafana Enterprise Logs license, refer to [Get a
+license](https://grafana.com/docs/enterprise-logs/latest/get-a-license/).
+
+### Storage
+
+Grafana Enterprise Logs requires an object storage backend to store logs and indexes as well as
+metadata objects.
+
+The default chart values will deploy [Minio](https://min.io) for initial set up. Production
+deployments must use a separately deployed object store or use a compatible storage from cloud
+providers, such as Amazon S3, Google Cloud Storage (GCS), or Microsoft Azure Blob Storage.
+
+## Installation
+
+To install the chart with licensed features enabled, using a local Grafana Enterprise Logs
+license file called `license.jwt`:
+
+```console
+$ # Add the repository
+$ helm repo add grafana https://grafana.github.io/helm-charts
+$ helm repo update
+$ # Perform install
+$ helm install <cluster name> grafana/enterprise-logs-simple \
+    --set-file 'license.contents=./license.jwt'
+```
+
+As part of this chart many different pods and services are installed which all have varying resource
+requirements. Please make sure that you have sufficient resources (CPU/memory) available in your
+cluster before installing Grafana Enterprise Logs Helm chart.
+
+### Scale values
+
+The default Helm chart values in the `values.yaml` file are configured to allow you to quickly test
+out Grafana Enterprise Logs. Alternative values files are included to provide a more realistic
+configuration that should facilitate a certain level of ingest and query load.
+
+#### `small.yaml`
+
+These values configure the Grafana Enterprise Logs cluster to handle production ingestion of
+~11MiB/s.
+
+To deploy a cluster using `small.yaml` values file:
+
+```console
+$ helm install <cluster name> grafana/enterprise-logs-simple \
+    --set-file 'license.contents=./license.jwt' \
+    -f small.yaml
+```
+
+### Updating the GEL version in custom values file
+
+If you need to update the GEL version in a custom values file that overrides
+the default vaules, you need to be careful to also override the version in the
+`loki-simple-scalable.loki.image` block. This is necessary, because that block
+controls the name and version of the image used in the
+[loki-enterprise](../loki-enterprise) child chart.
+
+Setting a version in a custom values file without duplicating the value can be
+achieved by using a YAML anchor and pointer, like so:
+
+```yaml
+image:
+  tag: &version v1.2.1
+
+...
+
+loki-simple-scalable:
+  loki:
+    image:
+      tag: *version
+```
+
+## Contributing/Releasing
+
+All changes require a bump to the chart version, as this enforced by CI. All changes to the chart
+itself should also have a corresponding changelog entry.
+
+When making a change and organizing a release, first ensure your changes are encapuslated in a
+commit with a [meaningful commit message](https://chris.beams.io/posts/git-commit/). In a separate
+commit, increase the chart version in the `Chart.yaml` file and add an entry in the `CHANGELOG.md`
+file under the new version.
+
+Finally, push your changes and open up a pull request with the prefix `[enterprise-logs]` in the
+title.
+
+### Updating the GEL version
+
+When updating the GEL version, it is necessary to change the value in both the
+`Chart.yaml` as well as in the `values.yaml`.

--- a/charts/enterprise-logs-simple/templates/_helpers.tpl
+++ b/charts/enterprise-logs-simple/templates/_helpers.tpl
@@ -1,0 +1,86 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "enterprise-logs.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "enterprise-logs.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "enterprise-logs.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "enterprise-logs.labels" -}}
+helm.sh/chart: {{ include "enterprise-logs.chart" . }}
+{{ include "enterprise-logs.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "enterprise-logs.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "enterprise-logs.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Docker image name
+*/}}
+{{- define "enterprise-logs.image" -}}
+{{- $tag := .Values.image.tag | toString -}}
+{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository $tag -}}
+{{- end -}}
+
+{{/*
+Create the app name of enterprise-logs clients. Defaults to the same logic as "enterprise-logs.fullname", and default client expects "prometheus".
+*/}}
+{{- define "client.name" -}}
+{{- if .Values.client.name -}}
+{{- .Values.client.name -}}
+{{- else if .Values.client.fullnameOverride -}}
+{{- .Values.client.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "prometheus" .Values.client.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the service endpoint including port for MinIO.
+*/}}
+{{- define "enterprise-logs.minio" -}}
+{{- if .Values.minio.enabled -}}
+{{- printf "%s-%s.%s.svc:%s" .Release.Name "minio" .Release.Namespace (.Values.minio.service.port | toString) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/enterprise-logs-simple/templates/secret-config.yaml
+++ b/charts/enterprise-logs-simple/templates/secret-config.yaml
@@ -1,0 +1,10 @@
+{{- if not .Values.useExternalConfig -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: enterprise-logs-config
+  labels:
+    {{- include "enterprise-logs.labels" . | nindent 4 }}
+data:
+  config.yaml: {{ tpl .Values.config . | b64enc }}
+{{- end }}

--- a/charts/enterprise-logs-simple/templates/secret-license.yaml
+++ b/charts/enterprise-logs-simple/templates/secret-license.yaml
@@ -1,0 +1,10 @@
+{{- if not .Values.useExternalLicense -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: enterprise-logs-license
+  labels:
+    {{- include "enterprise-logs.labels" . | nindent 4 }}
+data:
+  license.jwt: {{ .Values.license.contents | b64enc }}
+{{- end }}

--- a/charts/enterprise-logs-simple/templates/tokengen/_helpers.yaml
+++ b/charts/enterprise-logs-simple/templates/tokengen/_helpers.yaml
@@ -1,0 +1,22 @@
+{{/*
+tokengen fullname
+*/}}
+{{- define "enterprise-logs.tokengenFullname" -}}
+{{ include "enterprise-logs.fullname" . }}-tokengen
+{{- end }}
+
+{{/*
+tokengen common labels
+*/}}
+{{- define "enterprise-logs.tokengenLabels" -}}
+{{ include "enterprise-logs.labels" . }}
+app.kubernetes.io/component: tokengen
+{{- end }}
+
+{{/*
+tokengen selector labels
+*/}}
+{{- define "enterprise-logs.tokengenSelectorLabels" -}}
+{{ include "enterprise-logs.selectorLabels" . }}
+app.kubernetes.io/component: tokengen
+{{- end }}

--- a/charts/enterprise-logs-simple/templates/tokengen/job-tokengen.yaml
+++ b/charts/enterprise-logs-simple/templates/tokengen/job-tokengen.yaml
@@ -1,0 +1,117 @@
+{{ if .Values.tokengen.enable }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "enterprise-logs.tokengenFullname" . }}
+  labels:
+    {{- include "enterprise-logs.tokengenLabels" . | nindent 4 }}
+    {{- with .Values.tokengen.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.tokengen.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    "helm.sh/hook": post-install
+spec:
+  backoffLimit: 6
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        {{- include "enterprise-logs.tokengenSelectorLabels" . | nindent 8 }}
+        {{- with .Values.tokengen.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- with .Values.tokengen.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.tokengen.priorityClassName }}
+      priorityClassName: {{ .Values.tokengen.priorityClassName }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.tokengen.securityContext | nindent 8 }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      initContainers:
+        - name: enterprise-logs
+          image: {{ template "enterprise-logs.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - -config.file=/etc/loki/config/config.yaml
+            - -target=tokengen
+            {{- if .Values.minio.enabled }}
+            - -admin.client.backend-type=s3
+            - -admin.client.s3.endpoint={{ template "enterprise-logs.minio" . }}
+            - -admin.client.s3.bucket-name=enterprise-logs-admin
+            - -admin.client.s3.access-key-id={{ .Values.minio.accessKey }}
+            - -admin.client.s3.secret-access-key={{ .Values.minio.secretKey }}
+            - -admin.client.s3.insecure=true
+            {{- end }}
+            - -tokengen.token-file=/shared/admin-token
+            {{- with .Values.tokengen.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            {{- if .Values.tokengen.extraVolumeMounts }}
+              {{ toYaml .Values.tokengen.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+            - name: shared
+              mountPath: /shared
+            - name: config
+              mountPath: /etc/loki/config
+            - name: license
+              mountPath: /etc/enterprise-logs/license
+          env:
+            {{- if .Values.tokengen.env }}
+              {{ toYaml .Values.tokengen.env | nindent 12 }}
+            {{- end }}
+      containers:
+        - name: create-secret
+          image: bitnami/kubectl
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/bash
+            - -euc
+            - kubectl create secret generic {{ .Values.tokengen.adminTokenSecret }} --from-file=token=/shared/admin-token --from-literal=grafana-token="$(base64 <(echo :$(cat /shared/admin-token)))"
+          volumeMounts:
+            {{- if .Values.tokengen.extraVolumeMounts }}
+              {{ toYaml .Values.tokengen.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+            - name: shared
+              mountPath: /shared
+            - name: config
+              mountPath: /etc/loki/config
+            - name: license
+              mountPath: /etc/enterprise-logs/license
+      restartPolicy: OnFailure
+      serviceAccount: {{ template "enterprise-logs.tokengenFullname" . }}
+      serviceAccountName: {{ template "enterprise-logs.tokengenFullname" . }}
+      volumes:
+        - name: config
+          secret:
+          {{- if .Values.useExternalConfig }}
+            secretName: {{ .Values.externalConfigName }}
+          {{- else }}
+            secretName: enterprise-logs-config
+          {{- end }}
+        - name: license
+          secret:
+          {{- if .Values.useExternalLicense }}
+            secretName: {{ .Values.externalLicenseName }}
+          {{- else }}
+            secretName: enterprise-logs-license
+          {{- end }}
+        - name: shared
+          emptyDir: {}
+        {{- if .Values.tokengen.extraVolumes }}
+        {{ toYaml .Values.tokengen.extraVolumes | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/charts/enterprise-logs-simple/templates/tokengen/role-tokengen.yaml
+++ b/charts/enterprise-logs-simple/templates/tokengen/role-tokengen.yaml
@@ -1,0 +1,20 @@
+{{ if .Values.tokengen.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "enterprise-logs.tokengenFullname" . }}
+  labels:
+    {{- include "enterprise-logs.tokengenLabels" . | nindent 4 }}
+    {{- with .Values.tokengen.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.tokengen.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    "helm.sh/hook": post-install
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+{{- end }}

--- a/charts/enterprise-logs-simple/templates/tokengen/rolebinding-tokengen.yaml
+++ b/charts/enterprise-logs-simple/templates/tokengen/rolebinding-tokengen.yaml
@@ -1,0 +1,23 @@
+{{ if .Values.tokengen.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "enterprise-logs.tokengenFullname" . }}
+  labels:
+    {{- include "enterprise-logs.tokengenLabels" . | nindent 4 }}
+    {{- with .Values.tokengen.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.tokengen.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    "helm.sh/hook": post-install
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "enterprise-logs.tokengenFullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "enterprise-logs.tokengenFullname" . }}
+{{- end }}

--- a/charts/enterprise-logs-simple/templates/tokengen/serviceaccount-tokengen.yaml
+++ b/charts/enterprise-logs-simple/templates/tokengen/serviceaccount-tokengen.yaml
@@ -1,0 +1,16 @@
+{{ if .Values.tokengen.enable }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "enterprise-logs.tokengenFullname" . }}
+  labels:
+    {{- include "enterprise-logs.tokengenLabels" . | nindent 4 }}
+    {{- with .Values.tokengen.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.tokengen.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    "helm.sh/hook": post-install
+{{- end }}

--- a/charts/enterprise-logs-simple/values.yaml
+++ b/charts/enterprise-logs-simple/values.yaml
@@ -1,0 +1,352 @@
+# -----------------------------------------
+# Configuration for `enterprise-logs` chart
+# -----------------------------------------
+
+# -- Overrides the chart's name
+nameOverride: null
+
+# -- Overrides the chart's computed fullname
+fullnameOverride: null
+
+# -- Definition of the Docker image for Grafana Enterprise Logs
+# If the image block is overwritten in a custom values file, it is also
+# required to update the values in the `loki-simple-scalable.loki.image` block.
+# This can be done by copying the values, or like here, by using an anchor and
+# a pointer.
+image: &image # -- The container registry to use
+  registry: docker.io
+  # -- The image repository to use
+  repository: grafana/enterprise-logs
+  # -- The version of Grafana Enterprise Logs
+  tag: v1.3.0
+  # -- Defines the policy how and when images are pulled
+  pullPolicy: IfNotPresent
+  # -- Additional image pull secrets
+  pullSecrets: []
+
+# -- Definition of the ServiceAccount for containers
+# Any additional configuration of the ServiceAccount has to be done in
+# `loki-simple-scalable.serviceAccount`.
+serviceAccount:
+  # -- Specifies whether a ServiceAccount should be created
+  # If this value is changed to `false`, it also needs to be reflected in
+  # `loki-simple-scalable.serviceAccount.create`.
+  create: true
+
+# -- External config.yaml
+# A GEL configuration file may be provided as Kubernetes Secret outside of this Helm chart.
+useExternalConfig: false
+externalConfigName: enterprise-logs-config
+externalConfigVersion: "0"
+
+# -- External license.jwt
+# A GEL license file may be provided as Kubernetes Secret outside of this Helm chart.
+useExternalLicense: false
+externalLicenseName: enterprise-logs-license
+externalLicenseVersion: "0"
+
+# -- Grafana Enterprise Logs license
+# In order to use Grafana Enterprise Logs features, you will need to provide
+# the contents of your Grafana Enterprise Logs license, either by providing the
+# contents of the license.jwt, or the name Kubernetes Secret that contains your
+# license.jwt.
+# To set the license contents, use the flag `--set-file 'license.contents=./license.jwt'`
+license:
+  contents: "NOTAVALIDLICENSE"
+
+# -- Grafana Enterprise Logs configuration file
+config: |
+  auth:
+    type: enterprise
+
+  auth_enabled: true
+
+  common:
+    path_prefix: /var/loki
+    storage:
+      s3:
+        endpoint: {{ include "enterprise-logs.minio" . }}
+        bucketnames: enterprise-logs-tsdb
+        secret_access_key: supersecret
+        access_key_id: enterprise-logs
+        s3forcepathstyle: true
+        insecure: true
+
+  license:
+    path: /etc/enterprise-logs/license/license.jwt
+
+  cluster_name: {{ .Release.Name }}
+
+  server:
+    http_listen_port: 3100
+    grpc_listen_port: 9095
+
+  admin_client:
+    storage:
+      # TODO: type should not be necessary
+      type: s3
+      s3:
+        bucket_name: enterprise-logs-admin
+
+  ingester:
+    max_chunk_age: '2h'
+
+  ingester_client:
+    grpc_client_config:
+      max_recv_msg_size: 104857600
+      max_send_msg_size: 104857600
+
+  limits_config:
+    enforce_metric_name: false
+    reject_old_samples: true
+    reject_old_samples_max_age: 168h
+    max_cache_freshness_per_query: 10m
+
+  memberlist:
+    join_members:
+      - {{ include "loki.fullname" . }}-memberlist
+
+  querier:
+    query_ingesters_within: 2h
+
+  schema_config:
+    configs:
+      - from: 2021-01-01
+        store: boltdb-shipper
+        object_store: aws
+        schema: v11
+        index:
+          prefix: index_
+          period: 24h
+
+  ruler:
+    storage:
+      s3:
+        bucketnames: enterprise-logs-ruler
+    enable_alertmanager_discovery: false
+    enable_api: true
+    enable_sharding: true
+
+# -- Configuration for `tokengen` target
+tokengen:
+  # -- Whether the job should be part of the deployment
+  enable: true
+  # -- Name of the secret to store the admin token in
+  adminTokenSecret: 'gel-admin-token'
+  # -- Additional CLI arguments for the `tokengen` target
+  extraArgs: []
+  # -- Additional Kubernetes environment
+  env: []
+  # -- Additional labels for the `tokengen` Job
+  labels: {}
+  # -- Additional annotations for the `tokengen` Job
+  annotations: {}
+  # -- Additional volumes for Pods
+  extraVolumes: []
+  # -- Additional volume mounts for Pods
+  extraVolumeMounts: []
+  # -- Run containers as user `enterprise-logs(uid=10001)`
+  securityContext:
+    runAsNonRoot: true
+    runAsGroup: 10001
+    runAsUser: 10001
+    fsGroup: 10001
+
+# ------------------------------------------------
+# Configuration for `loki-simple-scalable` child chart
+# ------------------------------------------------
+loki-simple-scalable:
+  # -- In order to have consistent Pod names for both pods from the enterprise-logs and loki-simple-scalable chart, we override the name of the child chart to match the name of the parent chart.
+  nameOverride: enterprise-logs
+
+  # -- Definition of the ServiceAccount for containers
+  serviceAccount:
+    # -- Specifies whether a ServiceAccount should be created
+    create: true
+    # -- The name of the ServiceAccount to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: null
+    # -- Image pull secrets for the service account
+    imagePullSecrets: []
+    # -- Annotations for the service account
+    annotations: {}
+    # -- Set this toggle to false to opt out of automounting API credentials for the service account
+    automountServiceAccountToken: true
+
+  # RBAC configuration
+  rbac:
+    # -- If enabled, a PodSecurityPolicy is created
+    pspEnabled: true
+
+  # -- Override gateway nginx.conf to include admin-api routes
+  gateway:
+    enabled: true
+    nginxConfig:
+      file: |
+        worker_processes  5;  ## Default: 1
+        error_log  /dev/stderr;
+        pid        /tmp/nginx.pid;
+        worker_rlimit_nofile 8192;
+
+        events {
+          worker_connections  4096;  ## Default: 1024
+        }
+
+        http {
+          client_body_temp_path /tmp/client_temp;
+          proxy_temp_path       /tmp/proxy_temp_path;
+          fastcgi_temp_path     /tmp/fastcgi_temp;
+          uwsgi_temp_path       /tmp/uwsgi_temp;
+          scgi_temp_path        /tmp/scgi_temp;
+
+          default_type application/octet-stream;
+          log_format   {{ .Values.gateway.nginxConfig.logFormat }}
+
+          {{- if .Values.gateway.verboseLogging }}
+          access_log   /dev/stderr  main;
+          {{- else }}
+
+          map $status $loggable {
+            ~^[23]  0;
+            default 1;
+          }
+          access_log   /dev/stderr  main  if=$loggable;
+          {{- end }}
+
+          sendfile     on;
+          tcp_nopush   on;
+          resolver {{ .Values.global.dnsService }}.{{ .Values.global.dnsNamespace }}.svc.{{ .Values.global.clusterDomain }};
+
+          {{- with .Values.gateway.nginxConfig.httpSnippet }}
+          {{ . | nindent 2 }}
+          {{- end }}
+
+          server {
+            listen             8080;
+
+            {{- if .Values.gateway.basicAuth.enabled }}
+            auth_basic           "Loki";
+            auth_basic_user_file /etc/nginx/secrets/.htpasswd;
+            {{- end }}
+
+            location = / {
+              return 200 'OK';
+              auth_basic off;
+            }
+
+            location = /api/prom/push {
+              proxy_pass       http://{{ include "loki.writeFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+            }
+
+            location = /api/prom/tail {
+              proxy_pass       http://{{ include "loki.readFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection "upgrade";
+            }
+
+            location ~ /api/prom/.* {
+              proxy_pass       http://{{ include "loki.readFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+            }
+
+            location = /loki/api/v1/push {
+              proxy_pass       http://{{ include "loki.writeFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+            }
+
+            location = /loki/api/v1/tail {
+              proxy_pass       http://{{ include "loki.readFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection "upgrade";
+            }
+
+            location ~ /loki/api/.* {
+              proxy_pass       http://{{ include "loki.readFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+            }
+
+            location ~ /admin/api/.* {
+              proxy_pass       http://{{ include "loki.writeFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+            }
+
+            location ~ /compactor/.* {
+              proxy_pass       http://{{ include "loki.readFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+            }
+
+            location ~ /distributor/.* {
+              proxy_pass       http://{{ include "loki.writeFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+            }
+
+            location ~ /ring {
+              proxy_pass       http://{{ include "loki.writeFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+            }
+
+            location ~ /ingester/.* {
+              proxy_pass       http://{{ include "loki.writeFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+            }
+
+            location ~ /ruler/.* {
+              proxy_pass       http://{{ include "loki.readFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+            }
+
+            location ~ /scheduler/.* {
+              proxy_pass       http://{{ include "loki.readFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+            }
+
+            {{- with .Values.gateway.nginxConfig.serverSnippet }}
+            {{ . | nindent 4 }}
+            {{- end }}
+          }
+        }
+
+  # -- Configuration for the `write` target
+  write:
+    replicas: 3
+    extraVolumes:
+      # -- Create license volume from license secret
+      - name: license
+        secret:
+          secretName: enterprise-logs-license
+    extraVolumeMounts:
+      # -- Mount the license volume
+      - name: license
+        mountPath: /etc/enterprise-logs/license
+
+  # -- Configuration for the `read` target
+  read:
+    replicas: 3
+    extraVolumes:
+      # -- Create license volume from license secret
+      - name: license
+        secret:
+          secretName: enterprise-logs-license
+    extraVolumeMounts:
+      # -- Mount the license volume
+      - name: license
+        mountPath: /etc/enterprise-logs/license
+
+  loki:
+    config: null
+    existingSecretForConfig: enterprise-logs-config
+    image: *image
+
+# -------------------------------------
+# Configuration for `minio` child chart
+# -------------------------------------
+minio:
+  enabled: true
+  accessKey: enterprise-logs
+  secretKey: supersecret
+  buckets:
+    - name: enterprise-logs-tsdb
+      policy: none
+      purge: false
+    - name: enterprise-logs-admin
+      policy: none
+      purge: false
+    - name: enterprise-logs-ruler
+      policy: none
+      purge: false
+  persistence:
+    size: 5Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi

--- a/charts/loki-simple-scalable/Chart.yaml
+++ b/charts/loki-simple-scalable/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-simple-scalable
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.4.2
-version: 0.2.0
+version: 0.3.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-simple-scalable/templates/configmap.yaml
+++ b/charts/loki-simple-scalable/templates/configmap.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "loki.labels" . | nindent 4 }}
 data:
   config.yaml: |
-    {{- tpl (toYaml .Values.loki.config) . | nindent 4 }}
+    {{- tpl (mergeOverwrite (tpl .Values.loki.config . | fromYaml) .Values.loki.structuredConfig | toYaml) . | nindent 4 }}
 {{- end -}}

--- a/charts/loki-simple-scalable/values.yaml
+++ b/charts/loki-simple-scalable/values.yaml
@@ -59,7 +59,7 @@ loki:
   existingSecretForConfig: ""
   # -- Config file contents for Loki
   # @default -- See values.yaml
-  config:
+  config: |
     auth_enabled: false
 
     server:
@@ -75,10 +75,10 @@ loki:
       ring:
         kvstore:
           store: memberlist
+      {{- if .Values.loki.storageConfig}}
       storage:
-        filesystem:
-          chunks_directory: /var/loki/chunks
-          rules_directory: /var/loki/rules
+      {{- toYaml .Values.loki.storageConfig | nindent 2}}
+      {{ -end }}
 
     limits_config:
       enforce_metric_name: false
@@ -86,26 +86,34 @@ loki:
       reject_old_samples_max_age: 168h
       max_cache_freshness_per_query: 10m
 
+    {{- if .Values.loki.schemaConfig}}
     schema_config:
-      configs:
-        - from: 2020-09-07
-          store: boltdb-shipper
-          object_store: filesystem
-          schema: v11
-          index:
-            prefix: loki_index_
-            period: 24h
-  # -- Common storage config component of loki configuration file.
-  # The must be overriden with a valid object storage backend
-  # in order for queries to work.
-  # @default -- loki.defaultStorageConfig
-  storageConfig: {}
-  # -- Default storage config, used when no loki.storageConfig is provided.
-  # Required for CI, but queries will not work using these defaults.
-  defaultStorageConfig:
+    {{- toYaml .Values.loki.schemaConfig | nindent 2}}
+    {{- end}}
+
+  # -- Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas
+  schemaConfig:
+    configs:
+      - from: 2020-09-07
+        store: boltdb-shipper
+        object_store: filesystem
+        schema: v11
+        index:
+          prefix: loki_index_
+          period: 24h
+
+  # -- Check https://grafana.com/docs/loki/latest/configuration/#storage_config for more info on how to configure storages
+  storageConfig:
     filesystem:
       chunks_directory: /var/loki/chunks,
       rules_directory: /var/loki/rules
+  # -- Uncomment to configure each storage individually
+  # azure: {}
+  # gcs: {}
+  # s3: {}
+
+  # -- Structured loki configuration, takes precedence over `loki.config`, `loki.schemaConfig`, `loki.storageConfig`
+  structuredConfig: {}
 serviceAccount:
   # -- Specifies whether a ServiceAccount should be created
   create: true

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,65 @@
+http {
+  server {
+    listen             8080;
+
+    location = / {
+      return 200 'OK';
+    }
+
+    location = /api/prom/push {
+      proxy_pass       http://write:3100$request_uri;
+    }
+
+    location = /api/prom/tail {
+      proxy_pass       http://read:3100$request_uri;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+    }
+
+    location ~ /api/prom/.* {
+      proxy_pass       http://read:3100$request_uri;
+    }
+
+    location = /loki/api/v1/push {
+      proxy_pass       http://write:3100$request_uri;
+    }
+
+    location = /loki/api/v1/tail {
+      proxy_pass       http://read:3100$request_uri;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+    }
+
+    location ~ /loki/api/.* {
+      proxy_pass       http://read:3100$request_uri;
+    }
+
+    location ~ /admin/api/.* {
+      proxy_pass       http://write:3100$request_uri;
+    }
+
+    location ~ /compactor/.* {
+      proxy_pass       http://read:3100$request_uri;
+    }
+
+    location ~ /distributor/.* {
+      proxy_pass       http://write:3100$request_uri;
+    }
+
+    location ~ /ring {
+      proxy_pass       http://write:3100$request_uri;
+    }
+
+    location ~ /ingester/.* {
+      proxy_pass       http://write:3100$request_uri;
+    }
+
+    location ~ /ruler/.* {
+      proxy_pass       http://read:3100$request_uri;
+    }
+
+    location ~ /scheduler/.* {
+      proxy_pass       http://read:3100$request_uri;
+    }
+  }
+}


### PR DESCRIPTION
This chart wraps the `loki-simple-scalable` chart, adding a template for the tokengen job and adding admin api routes to the the nginx config for the gateway.