### PR TITLE
[loki-distributed] fix: s3 example documentation in README.md

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.4.2
-version: 0.47.3
+version: 0.47.4
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.47.3](https://img.shields.io/badge/Version-0.47.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
+![Version: 0.47.4](https://img.shields.io/badge/Version-0.47.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -494,8 +494,8 @@ loki:
       aws:
         s3: s3://eu-central-1
         bucketnames: my-loki-s3-bucket
-    boltdb_shipper:
-      shared_storage: s3
+      boltdb_shipper:
+        shared_store: s3
     schema_config:
       configs:
         - from: 2020-09-07

--- a/charts/loki-distributed/README.md.gotmpl
+++ b/charts/loki-distributed/README.md.gotmpl
@@ -121,8 +121,8 @@ loki:
       aws:
         s3: s3://eu-central-1
         bucketnames: my-loki-s3-bucket
-    boltdb_shipper:
-      shared_storage: s3
+      boltdb_shipper:
+        shared_store: s3
     schema_config:
       configs:
         - from: 2020-09-07


### PR DESCRIPTION
using the example documentation for s3 results in failure to parse the yaml config. this pr updates the example with the correct fields.


ref this output from the loki components when using the example config:
```
failed parsing config: /etc/loki/config/config.yaml: yaml: unmarshal errors:
  line 2: field boltdb_shipper not found in type loki.ConfigWrapper
```
and then also
```
failed parsing config: /etc/loki/config/config.yaml: yaml: unmarshal errors:
  line 81: field shared_storage not found in type shipper.Config
```