### PR TITLE
[loki-distributed] Insert index_gateway_client into the correct position

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.4.2
-version: 0.46.4
+version: 0.46.5
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.46.4](https://img.shields.io/badge/Version-0.46.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
+![Version: 0.46.5](https://img.shields.io/badge/Version-0.46.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -106,11 +106,11 @@ loki:
     {{- end}}
     {{- if .Values.loki.storageConfig}}
     storage_config:
-    {{- toYaml .Values.loki.storageConfig | nindent 2}}
     {{- if .Values.indexGateway.enabled}}
-      index_gateway_client:
-        server_address: dns:///{{ include "loki.indexGatewayFullname" . }}:9095
+    {{- $indexGatewayClient := dict "server_address" (printf "dns:///%s:9095" (include "loki.indexGatewayFullname" .)) }}
+    {{- $_ := set .Values.loki.storageConfig.boltdb_shipper "index_gateway_client" $indexGatewayClient }}
     {{- end}}
+    {{- toYaml .Values.loki.storageConfig | nindent 2}}
     {{- end}}
 
     chunk_store_config:


### PR DESCRIPTION
#### What this PR does / why we need it:

In previous versions, when using `index_gateway_client`, it was not inserted in the correct position.

This PR will set it correctly when `indexGateway.enabled: true`.

If `indexGateway.enabled: true` is set:
```yaml
    storage_config:
      boltdb_shipper:
        active_index_directory: /var/loki/index
        cache_location: /var/loki/cache
        cache_ttl: 168h
        index_gateway_client:
          server_address: dns:///loki-distriburted-loki-distributed-index-gateway:9095
        shared_store: filesystem
      filesystem:
        directory: /var/loki/chunks
```

If `indexGateway.enabled: true` is NOT set:
```yaml
    storage_config:
      boltdb_shipper:
        active_index_directory: /var/loki/index
        cache_location: /var/loki/cache
        cache_ttl: 168h
        shared_store: filesystem
      filesystem:
        directory: /var/loki/chunks
```


#### Which issue this PR fixes

  - fixes #1003 
  - [community issue](https://community.grafana.com/t/loki-distributed-helm-install-field-index-gateway-client-not-found-in-type-storage-config/59745/2)
