### PR TITLE
fix(loki-distributed): indexGateway wrong storage_config

### DIFF
--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -108,8 +108,9 @@ loki:
     storage_config:
     {{- toYaml .Values.loki.storageConfig | nindent 2}}
     {{- if .Values.indexGateway.enabled}}
-      index_gateway_client:
-        server_address: dns:///{{ include "loki.indexGatewayFullname" . }}:9095
+      boltdb_shipper:
+        index_gateway_client:
+          server_address: dns:///{{ include "loki.indexGatewayFullname" . }}:9095
     {{- end}}
     {{- end}}
 


### PR DESCRIPTION
From documentation : https://grafana.com/docs/loki/latest/configuration/#storage_config

`index_gateway_client` is only available in `boltdb_shipper` configuration.