### PR TITLE
[mimir-distributed] Added trailing / to broken link

### DIFF
--- a/charts/mimir-distributed/Chart.yaml
+++ b/charts/mimir-distributed/Chart.yaml
@@ -1,5 +1,5 @@
-apiVersion: v2
-version: 0.1.2
++apiVersion: v2
+version: 0.1.3
 appVersion: 2.0.0
 description: "Grafana Mimir"
 engine: gotpl

--- a/charts/mimir-distributed/Chart.yaml
+++ b/charts/mimir-distributed/Chart.yaml
@@ -1,4 +1,4 @@
-+apiVersion: v2
+apiVersion: v2
 version: 0.1.3
 appVersion: 2.0.0
 description: "Grafana Mimir"

--- a/charts/mimir-distributed/README.md
+++ b/charts/mimir-distributed/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/v2.0.x) 
 
 # mimir-distributed
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Mimir
 

--- a/charts/mimir-distributed/README.md
+++ b/charts/mimir-distributed/README.md
@@ -24,7 +24,7 @@ Kubernetes: `^1.10.0-0`
 Grafana Mimir requires an object storage backend to store metrics and indexes.
 
 The default chart values will deploy [Minio](https://min.io) for initial set up. Production deployments should use a separately deployed object store.
-See [Grafana Mimir documentation](https://grafana.com/docs/mimir/v2.0.x) for details on storage types and documentation.
+See [Grafana Mimir documentation](https://grafana.com/docs/mimir/v2.0.x/) for details on storage types and documentation.
 
 ## Installation
 


### PR DESCRIPTION
The link to https://grafana.com/docs/mimir/v2.0.x is broken without the trailing / it shows a 404 Not Found from nginx/1.17.9.
This commit adds this / at the end which allows access to the page.

Signed-off-by: Filip Grosse <Filip-Snoek@gmx.de>