### PR TITLE
[loki-distributed] Fix metric duplication

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.4.2
-version: 0.47.0
+version: 0.47.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.47.0](https://img.shields.io/badge/Version-0.47.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
+![Version: 0.47.1](https://img.shields.io/badge/Version-0.47.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/templates/index-gateway/service-index-gateway-headless.yaml
+++ b/charts/loki-distributed/templates/index-gateway/service-index-gateway-headless.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "loki.indexGatewayFullname" . }}-headless
   labels:
     {{- include "loki.indexGatewaySelectorLabels" . | nindent 4 }}
+    prometheus.io/service-monitor: "false"
 spec:
   type: ClusterIP
   clusterIP: None

--- a/charts/loki-distributed/templates/index-gateway/servicemonitor-index-gateway.yaml
+++ b/charts/loki-distributed/templates/index-gateway/servicemonitor-index-gateway.yaml
@@ -25,6 +25,11 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.indexGatewaySelectorLabels" $ | nindent 6 }}
+    matchExpressions:
+      - key: prometheus.io/service-monitor
+        operator: NotIn
+        values:
+          - "false"
   endpoints:
     - port: http
       {{- with .interval }}

--- a/charts/loki-distributed/templates/ingester/service-ingester-headless.yaml
+++ b/charts/loki-distributed/templates/ingester/service-ingester-headless.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "loki.ingesterFullname" . }}-headless
   labels:
     {{- include "loki.ingesterSelectorLabels" . | nindent 4 }}
+    prometheus.io/service-monitor: "false"
 spec:
   type: ClusterIP
   clusterIP: None

--- a/charts/loki-distributed/templates/ingester/servicemonitor-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/servicemonitor-ingester.yaml
@@ -24,6 +24,11 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.ingesterSelectorLabels" $ | nindent 6 }}
+    matchExpressions:
+      - key: prometheus.io/service-monitor
+        operator: NotIn
+        values:
+          - "false"
   endpoints:
     - port: http
       {{- with .interval }}

--- a/charts/loki-distributed/templates/querier/service-querier-headless.yaml
+++ b/charts/loki-distributed/templates/querier/service-querier-headless.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "loki.querierFullname" . }}-headless
   labels:
     {{- include "loki.querierSelectorLabels" . | nindent 4 }}
+    prometheus.io/service-monitor: "false"
 spec:
   type: ClusterIP
   clusterIP: None

--- a/charts/loki-distributed/templates/querier/servicemonitor-querier.yaml
+++ b/charts/loki-distributed/templates/querier/servicemonitor-querier.yaml
@@ -24,6 +24,11 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.querierSelectorLabels" $ | nindent 6 }}
+    matchExpressions:
+      - key: prometheus.io/service-monitor
+        operator: NotIn
+        values:
+          - "false"
   endpoints:
     - port: http
       {{- with .interval }}


### PR DESCRIPTION
This PR fixes the metric duplication caused by having an additional headless service for some of the Loki components by adding a label to the headless service to disable the `ServiceMonitor` using it to discover targets.

Closes #597.