### PR TITLE
[enterprise-metrics] Add POD disruption budget PDB capability

### DIFF
--- a/charts/enterprise-metrics/templates/admin-api/admin-api-dep.yaml
+++ b/charts/enterprise-metrics/templates/admin-api/admin-api-dep.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "mimir.adminApiLabels" . | nindent 4 }}
     {{- if .Values.useGEMLabels }}{{- include "mimir.gemExtraLabels" . | nindent 4 }}{{- end }}
-  name: {{ template "mimir.adminApiFullname" . }}-admin-api
+  name: {{ template "mimir.adminApiFullname" . }}
 spec:
   replicas: {{ .Values.admin_api.replicas }}
   selector:

--- a/charts/enterprise-metrics/templates/admin-api/admin-api-dep.yaml
+++ b/charts/enterprise-metrics/templates/admin-api/admin-api-dep.yaml
@@ -116,20 +116,3 @@ spec:
             secretName: {{ .Values.license.secretName }}
         - name: storage
           emptyDir: {}
-        {{- if .Values.mimir.minio.enabled }}
-        - name: minio-configuration
-          projected:
-            sources:
-            - configMap:
-                name: {{ .Release.Name }}-minio
-            - secret:
-                name: {{ .Release.Name }}-minio
-        {{- if .Values.mimir.minio.tls.enabled }}
-        - name: cert-secret-volume-mc
-          secret:
-            secretName: {{ .Values.mimir.minio.tls.certSecret }}
-            items:
-            - key: {{ .Values.mimir.minio.tls.publicCrt }}
-              path: CAs/public.crt
-        {{- end }}
-        {{- end }}

--- a/charts/enterprise-metrics/templates/admin-api/admin-api-pdb.yaml
+++ b/charts/enterprise-metrics/templates/admin-api/admin-api-pdb.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.admin_api.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "mimir.adminApiFullname" . }}
+  labels:
+    {{- include "mimir.adminApiLabels" . | nindent 4 }}
+    {{- if .Values.useGEMLabels }}{{- include "mimir.gemExtraLabels" . | nindent 4 }}{{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "mimir.adminApiSelectorLabels" . | nindent 6 }}
+{{ toYaml .Values.admin_api.podDisruptionBudget | indent 2 }}
+{{- end -}}

--- a/charts/enterprise-metrics/templates/gateway/gateway-pdb.yaml
+++ b/charts/enterprise-metrics/templates/gateway/gateway-pdb.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.gateway.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "mimir.gatewayFullname" . }}
+  labels:
+    {{- include "mimir.gatewayLabels" . | nindent 4 }}
+    {{- if .Values.useGEMLabels }}{{- include "mimir.gemExtraLabels" . | nindent 4 }}{{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "mimir.gatewaySelectorLabels" . | nindent 6 }}
+{{ toYaml .Values.gateway.podDisruptionBudget | indent 2 }}
+{{- end -}}

--- a/charts/enterprise-metrics/values.yaml
+++ b/charts/enterprise-metrics/values.yaml
@@ -82,7 +82,7 @@ enterpriseMetrics:
     gateway:
       proxy:
         default:
-          url: http://{{ template "enterprise-metrics.fullname" . }}-admin-api.{{ .Release.Namespace }}.svc:{{ include "mimir.serverHttpListenPort" . }}            
+          url: http://{{ template "enterprise-metrics.fullname" . }}-admin-api.{{ .Release.Namespace }}.svc:{{ include "mimir.serverHttpListenPort" . }}
         admin_api:
           url: http://{{ template "enterprise-metrics.fullname" . }}-admin-api.{{ .Release.Namespace }}.svc:{{ include "mimir.serverHttpListenPort" . }}
         alertmanager:
@@ -248,6 +248,9 @@ admin_api:
   podLabels: {}
   podAnnotations: {}
 
+  # Pod Disruption Budget
+  podDisruptionBudget: {}
+
   securityContext: {}
 
   extraArgs: {}
@@ -291,6 +294,9 @@ gateway:
 
   podLabels: {}
   podAnnotations: {}
+
+  # Pod Disruption Budget
+  podDisruptionBudget: {}
 
   securityContext: {}
   initContainers: []


### PR DESCRIPTION
Reuse same template as in Mimir distributed.
Also fix:
 some trailing white-spaces,
 admin-api repeated in pod name,
 remove more of the bucket creation trick.


Signed-off-by: György Krajcsovits <gyorgy.krajcsovits@grafana.com>