### PR TITLE
[mimir-distributed] add standard prometheus pod annotations

### DIFF
--- a/charts/mimir-distributed/CHANGELOG.md
+++ b/charts/mimir-distributed/CHANGELOG.md
@@ -11,6 +11,9 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the Pull Request that introduced the change.
 
+## 2.0.6
+* [ENHANCEMENT] Add standard prometheus pod annotations. #1181
+
 ## 2.0.5
 
 * [BUGFIX] Use new component name system for gateway ingress. This regression has been introduced with #1203. #1260

--- a/charts/mimir-distributed/Chart.yaml
+++ b/charts/mimir-distributed/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.0.5
+version: 2.0.6
 appVersion: 2.0.0
 description: "Grafana Mimir"
 engine: gotpl

--- a/charts/mimir-distributed/README.md
+++ b/charts/mimir-distributed/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/v2.0.x/)
 
 # mimir-distributed
 
-![Version: 2.0.5](https://img.shields.io/badge/Version-2.0.5-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.0.6](https://img.shields.io/badge/Version-2.0.6-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Mimir
 

--- a/charts/mimir-distributed/templates/_helpers.tpl
+++ b/charts/mimir-distributed/templates/_helpers.tpl
@@ -215,6 +215,14 @@ app.kubernetes.io/component: {{ .component }}
 {{- end -}}
 
 {{/*
+Common pod annotations
+*/}}
+{{- define "mimir.podAnnotations" -}}
+prometheus.io/scrape: "true"
+prometheus.io/port: "{{ include "mimir.serverHttpListenPort" . }}"
+{{- end -}}
+
+{{/*
 Alertmanager http prefix
 */}}
 {{- define "mimir.alertmanagerHttpPrefix" -}}

--- a/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
+++ b/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
@@ -28,6 +28,7 @@ spec:
 {{- else }}
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
 {{- end}}
+        {{- include "mimir.podAnnotations" . | nindent 8 }}
         {{- with .Values.alertmanager.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -51,6 +51,7 @@ spec:
         {{- else }}
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
+        {{- include "mimir.podAnnotations" . | nindent 8 }}
         {{- with .Values.alertmanager.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -49,6 +49,7 @@ spec:
         {{- else }}
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
+        {{- include "mimir.podAnnotations" . | nindent 8 }}
         {{- with .Values.compactor.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -26,6 +26,7 @@ spec:
 {{- else }}
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
 {{- end}}
+        {{- include "mimir.podAnnotations" . | nindent 8 }}
         {{- with .Values.distributor.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -51,6 +51,7 @@ spec:
         {{- else }}
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
+        {{- include "mimir.podAnnotations" . | nindent 8 }}
         {{- with .Values.ingester.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -26,6 +26,7 @@ spec:
         {{- else }}
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end}}
+        {{- include "mimir.podAnnotations" . | nindent 8 }}
         {{- with .Values.overrides_exporter.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/charts/mimir-distributed/templates/querier/querier-dep.yaml
@@ -26,6 +26,7 @@ spec:
 {{- else }}
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
 {{- end}}
+        {{- include "mimir.podAnnotations" . | nindent 8 }}
         {{- with .Values.querier.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/charts/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -26,6 +26,7 @@ spec:
 {{- else }}
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
 {{- end}}
+        {{- include "mimir.podAnnotations" . | nindent 8 }}
         {{- with .Values.query_frontend.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -26,6 +26,7 @@ spec:
 {{- else }}
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
 {{- end}}
+        {{- include "mimir.podAnnotations" . | nindent 8 }}
         {{- with .Values.ruler.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -49,6 +49,7 @@ spec:
         {{- else }}
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
+        {{- include "mimir.podAnnotations" . | nindent 8 }}
         {{- with .Values.store_gateway.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
By convention, prometheus scrape configs often use the
`prometheus.io/scrape` and `prometheus.io/port` pod annotations to
configure kubernetes pod scrape targets. Similar to prometheus pod
annotations for other charts in this repo, this patch adds these
annotations to the relevant pods in the mimir chart.

Based on https://github.com/cortexproject/cortex-helm-chart/pull/288.

Signed-off-by: Josh Carp <jm.carp@gmail.com>