### PR TITLE
[loki-simple-scalable] added OpenShift support

### DIFF
--- a/charts/loki-simple-scalable/Chart.yaml
+++ b/charts/loki-simple-scalable/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-simple-scalable
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.4.2
-version: 0.3.2
+version: 0.3.3
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-simple-scalable/README.md
+++ b/charts/loki-simple-scalable/README.md
@@ -1,6 +1,6 @@
 # loki-simple-scalable
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 
@@ -118,7 +118,8 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | prometheusRule.groups | list | `[]` | Contents of Prometheus rules file |
 | prometheusRule.labels | object | `{}` | Additional PrometheusRule labels |
 | prometheusRule.namespace | string | `nil` | Alternative namespace for the PrometheusRule resource |
-| rbac.pspEnabled | bool | `false` | If enabled, a PodSecurityPolicy is created |
+| rbac.pspEnabled | bool | `false` | If pspEnabled true, a PodSecurityPolicy is created for K8s that use psp. |
+| rbac.sccEnabled | bool | `false` | For OpenShift set pspEnabled to 'false' and sccEnabled to 'true' to use the SecurityContextConstraints. |
 | read.affinity | string | Hard node and soft zone anti-affinity | Affinity for read pods. Passed through `tpl` and, thus, to be configured as string |
 | read.autoscaling.enabled | bool | `false` | Enable autoscaling for the read, this is only used if `queryIndex.enabled: true` |
 | read.autoscaling.maxReplicas | int | `3` | Maximum autoscaling replicas for the read |

--- a/charts/loki-simple-scalable/templates/role.yaml
+++ b/charts/loki-simple-scalable/templates/role.yaml
@@ -1,17 +1,31 @@
-{{- if .Values.rbac.pspEnabled }}
+{{- if or .Values.rbac.pspEnabled .Values.rbac.sccEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "loki.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
+{{- if .Values.rbac.pspEnabled }}
 rules:
-  - apiGroups:      
+  - apiGroups:
       - policy
-    resources:      
+    resources:
       - podsecuritypolicies
-    verbs:          
+    verbs:
       - use
-    resourceNames:  
+    resourceNames:
       - {{ include "loki.fullname" . }}
+{{- end }}
+{{- if .Values.rbac.sccEnabled }}
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+    resourceNames:
+      - {{ include "loki.fullname" . }}
+{{- end }}
 {{- end }}

--- a/charts/loki-simple-scalable/templates/rolebinding.yaml
+++ b/charts/loki-simple-scalable/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.pspEnabled }}
+{{- if or .Values.rbac.pspEnabled .Values.rbac.sccEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -12,4 +12,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "loki.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/loki-simple-scalable/templates/securitycontextconstraints.yaml
+++ b/charts/loki-simple-scalable/templates/securitycontextconstraints.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.rbac.sccEnabled }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ include "loki.fullname" . }}
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: []
+defaultAddCapabilities: null
+fsGroup: 
+  type: RunAsAny
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities: 
+  - ALL
+runAsUser: 
+  type: RunAsAny
+seLinuxContext: 
+  type: MustRunAs
+seccompProfiles:
+  - '*'
+supplementalGroups: 
+  type: RunAsAny
+volumes: 
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - hostPath
+  - persistentVolumeClaim
+  - projected
+  - secret
+{{- end }}

--- a/charts/loki-simple-scalable/values.yaml
+++ b/charts/loki-simple-scalable/values.yaml
@@ -136,8 +136,10 @@ serviceAccount:
 
 # RBAC configuration
 rbac:
-  # -- If enabled, a PodSecurityPolicy is created
+  # -- If pspEnabled true, a PodSecurityPolicy is created for K8s that use psp.
   pspEnabled: false
+  # -- For OpenShift set pspEnabled to 'false' and sccEnabled to 'true' to use the SecurityContextConstraints.
+  sccEnabled: false
 
 # ServiceMonitor configuration
 serviceMonitor:


### PR DESCRIPTION
added SecurityContextConstraints that is used in OpenShift instead of PodSecurityPolicy