### PR TITLE
[loki-simple-scalable] replace PR #979

### DIFF
--- a/charts/loki-simple-scalable/Chart.yaml
+++ b/charts/loki-simple-scalable/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-simple-scalable
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.4.2
-version: 0.3.3
+version: 0.3.4
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-simple-scalable/Chart.yaml
+++ b/charts/loki-simple-scalable/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-simple-scalable
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.4.2
-version: 0.2.1
+version: 0.3.3
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-simple-scalable/Chart.yaml
+++ b/charts/loki-simple-scalable/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-simple-scalable
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.4.2
-version: 0.3.2
+version: 0.2.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-simple-scalable/Chart.yaml
+++ b/charts/loki-simple-scalable/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: loki-simple-scalable
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
-appVersion: 2.5.1
-version: 0.4.0
+appVersion: 2.5.0
+version: 0.4.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-simple-scalable/README.md
+++ b/charts/loki-simple-scalable/README.md
@@ -1,6 +1,6 @@
 # loki-simple-scalable
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.1](https://img.shields.io/badge/AppVersion-2.5.1-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.1](https://img.shields.io/badge/AppVersion-2.5.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/charts/loki-simple-scalable/README.md
+++ b/charts/loki-simple-scalable/README.md
@@ -1,6 +1,6 @@
 # loki-simple-scalable
 
-![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
+![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/charts/loki-simple-scalable/README.md
+++ b/charts/loki-simple-scalable/README.md
@@ -80,6 +80,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | global.image.registry | string | `nil` | Overrides the Docker registry globally for all images |
 | global.priorityClassName | string | `nil` | Overrides the priorityClassName for all pods |
 | imagePullSecrets | list | `[]` | Image pull secrets for Docker images |
+| loki.commonConfig | object | `{"path_prefix":"/var/loki","replication_factor":1,"storage":{"filesystem":{"chunks_directory":"/var/loki/chunks","rules_directory":"/var/loki/rules"}}}` | Check https://grafana.com/docs/loki/latest/configuration/#common_config for more info on how to provide a common configuration |
 | loki.config | object | See values.yaml | Config file contents for Loki |
 | loki.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The SecurityContext for Loki containers |
 | loki.defaultStorageConfig | object | `{"filesystem":{"chunks_directory":"/var/loki/chunks,","rules_directory":"/var/loki/rules"}}` | Default storage config, used when no loki.storageConfig is provided. Required for CI, but queries will not work using these defaults. |

--- a/charts/loki-simple-scalable/README.md
+++ b/charts/loki-simple-scalable/README.md
@@ -35,7 +35,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | gateway.basicAuth.password | string | `nil` | The basic auth password for the gateway |
 | gateway.basicAuth.username | string | `nil` | The basic auth username for the gateway |
 | gateway.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The SecurityContext for gateway containers |
-| gateway.deploymentStrategy | object | `{"type":"RollingUpdate"}` | ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |
+| gateway.deploymentStrategy | object | `{"type":"RollingUpdate"}` | See `kubectl explain deployment.spec.strategy` for more. ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |
 | gateway.enabled | bool | `true` | Specifies whether the gateway should be enabled |
 | gateway.extraArgs | list | `[]` | Additional CLI args for the gateway |
 | gateway.extraEnv | list | `[]` | Environment variables to add to the gateway pods |
@@ -46,7 +46,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | gateway.image.registry | string | `"docker.io"` | The Docker registry for the gateway image |
 | gateway.image.repository | string | `"nginxinc/nginx-unprivileged"` | The gateway image repository |
 | gateway.image.tag | string | `"1.19-alpine"` | The gateway image tag |
-| gateway.ingress.annotations | object | `{}` | Annotations for the gateway ingress |
+| gateway.ingress.annotations | object | `{}` | Annotations for gateway ingress class name. MAY be required for Kubernetes versions >= 1.18 ingressClassName: nginx |
 | gateway.ingress.enabled | bool | `false` | Specifies whether an ingress for the gateway should be created |
 | gateway.ingress.hosts | list | `[{"host":"gateway.loki.example.com","paths":[{"path":"/"}]}]` | Hosts configuration for the gateway ingress |
 | gateway.ingress.tls | list | `[{"hosts":["gateway.loki.example.com"],"secretName":"loki-gateway-tls"}]` | TLS configuration for the gateway ingress |
@@ -95,7 +95,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | loki.readinessProbe.initialDelaySeconds | int | `30` |  |
 | loki.readinessProbe.timeoutSeconds | int | `1` |  |
 | loki.revisionHistoryLimit | int | `10` | The number of old ReplicaSets to retain to allow rollback |
-| loki.storageConfig | object | loki.defaultStorageConfig | Common storage config component of loki configuration file. The must be overriden with a valid object storage backend in order for queries to work. |
+| loki.storageConfig | object | `{}` | Common storage config component of loki configuration file. The must be overriden with a valid object storage backend in order for queries to work. |
 | nameOverride | string | `nil` | Overrides the chart's name |
 | networkPolicy.alertmanager.namespaceSelector | object | `{}` | Specifies the namespace the alertmanager is running in |
 | networkPolicy.alertmanager.podSelector | object | `{}` | Specifies the alertmanager Pods. As this is cross-namespace communication, you also need the namespaceSelector. |

--- a/charts/loki-simple-scalable/README.md
+++ b/charts/loki-simple-scalable/README.md
@@ -1,6 +1,6 @@
 # loki-simple-scalable
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 
@@ -80,9 +80,9 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | global.image.registry | string | `nil` | Overrides the Docker registry globally for all images |
 | global.priorityClassName | string | `nil` | Overrides the priorityClassName for all pods |
 | imagePullSecrets | list | `[]` | Image pull secrets for Docker images |
-| loki.commonConfig | object | `{"path_prefix":"/var/loki","replication_factor":1,"storage":{"filesystem":{"chunks_directory":"/var/loki/chunks","rules_directory":"/var/loki/rules"}}}` | Check https://grafana.com/docs/loki/latest/configuration/#common_config for more info on how to provide a common configuration |
-| loki.config | string | See values.yaml | Config file contents for Loki |
+| loki.config | object | See values.yaml | Config file contents for Loki |
 | loki.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The SecurityContext for Loki containers |
+| loki.defaultStorageConfig | object | `{"filesystem":{"chunks_directory":"/var/loki/chunks,","rules_directory":"/var/loki/rules"}}` | Default storage config, used when no loki.storageConfig is provided. Required for CI, but queries will not work using these defaults. |
 | loki.existingSecretForConfig | string | `""` | Specify an existing secret containing loki configuration. If non-empty, overrides `loki.config` |
 | loki.image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | loki.image.registry | string | `"docker.io"` | The Docker registry |
@@ -95,9 +95,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | loki.readinessProbe.initialDelaySeconds | int | `30` |  |
 | loki.readinessProbe.timeoutSeconds | int | `1` |  |
 | loki.revisionHistoryLimit | int | `10` | The number of old ReplicaSets to retain to allow rollback |
-| loki.schemaConfig | object | `{"configs":[{"from":"2020-09-07","index":{"period":"24h","prefix":"loki_index_"},"object_store":"filesystem","schema":"v11","store":"boltdb-shipper"}]}` | Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas |
-| loki.storageConfig | object | `{}` | Check https://grafana.com/docs/loki/latest/configuration/#storage_config for more info on how to configure storages |
-| loki.structuredConfig | object | `{}` | Structured loki configuration, takes precedence over `loki.config`, `loki.schemaConfig`, `loki.storageConfig` |
+| loki.storageConfig | object | loki.defaultStorageConfig | Common storage config component of loki configuration file. The must be overriden with a valid object storage backend in order for queries to work. |
 | nameOverride | string | `nil` | Overrides the chart's name |
 | networkPolicy.alertmanager.namespaceSelector | object | `{}` | Specifies the namespace the alertmanager is running in |
 | networkPolicy.alertmanager.podSelector | object | `{}` | Specifies the alertmanager Pods. As this is cross-namespace communication, you also need the namespaceSelector. |
@@ -159,6 +157,11 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | serviceMonitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | serviceMonitor.tlsConfig | string | `nil` | ServiceMonitor will use these tlsConfig settings to make the health check requests |
 | write.affinity | string | Hard node and soft zone anti-affinity | Affinity for write pods. Passed through `tpl` and, thus, to be configured as string |
+| write.autoscaling.enabled | bool | `false` | Enable autoscaling for the write |
+| write.autoscaling.maxReplicas | int | `3` | Maximum autoscaling replicas for the write |
+| write.autoscaling.minReplicas | int | `1` | Minimum autoscaling replicas for the write |
+| write.autoscaling.targetCPUUtilizationPercentage | int | `60` | Target CPU utilisation percentage for the write |
+| write.autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory utilisation percentage for the write |
 | write.extraArgs | list | `[]` | Additional CLI args for the write |
 | write.extraEnv | list | `[]` | Environment variables to add to the write pods |
 | write.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the write pods |

--- a/charts/loki-simple-scalable/README.md
+++ b/charts/loki-simple-scalable/README.md
@@ -1,6 +1,6 @@
 # loki-simple-scalable
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.1](https://img.shields.io/badge/AppVersion-2.5.1-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/charts/loki-simple-scalable/README.md
+++ b/charts/loki-simple-scalable/README.md
@@ -95,7 +95,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | loki.readinessProbe.initialDelaySeconds | int | `30` |  |
 | loki.readinessProbe.timeoutSeconds | int | `1` |  |
 | loki.revisionHistoryLimit | int | `10` | The number of old ReplicaSets to retain to allow rollback |
-| loki.storageConfig | object | `{}` | Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas |
+| loki.storageConfig | object | loki.defaultStorageConfig | Common storage config component of loki configuration file. The must be overriden with a valid object storage backend in order for queries to work. |
 | nameOverride | string | `nil` | Overrides the chart's name |
 | networkPolicy.alertmanager.namespaceSelector | object | `{}` | Specifies the namespace the alertmanager is running in |
 | networkPolicy.alertmanager.podSelector | object | `{}` | Specifies the alertmanager Pods. As this is cross-namespace communication, you also need the namespaceSelector. |

--- a/charts/loki-simple-scalable/README.md
+++ b/charts/loki-simple-scalable/README.md
@@ -1,6 +1,6 @@
 # loki-simple-scalable
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/charts/loki-simple-scalable/README.md
+++ b/charts/loki-simple-scalable/README.md
@@ -160,7 +160,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | write.affinity | string | Hard node and soft zone anti-affinity | Affinity for write pods. Passed through `tpl` and, thus, to be configured as string |
 | write.autoscaling.enabled | bool | `false` | Enable autoscaling for the write |
 | write.autoscaling.maxReplicas | int | `3` | Maximum autoscaling replicas for the write |
-| write.autoscaling.minReplicas | int | `1` | Minimum autoscaling replicas for the write |
+| write.autoscaling.minReplicas | int | `3` | Minimum autoscaling replicas for the write |
 | write.autoscaling.targetCPUUtilizationPercentage | int | `60` | Target CPU utilisation percentage for the write |
 | write.autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory utilisation percentage for the write |
 | write.extraArgs | list | `[]` | Additional CLI args for the write |

--- a/charts/loki-simple-scalable/README.md
+++ b/charts/loki-simple-scalable/README.md
@@ -35,7 +35,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | gateway.basicAuth.password | string | `nil` | The basic auth password for the gateway |
 | gateway.basicAuth.username | string | `nil` | The basic auth username for the gateway |
 | gateway.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The SecurityContext for gateway containers |
-| gateway.deploymentStrategy | object | `{"type":"RollingUpdate"}` | See `kubectl explain deployment.spec.strategy` for more -- ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |
+| gateway.deploymentStrategy | object | `{"type":"RollingUpdate"}` | ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |
 | gateway.enabled | bool | `true` | Specifies whether the gateway should be enabled |
 | gateway.extraArgs | list | `[]` | Additional CLI args for the gateway |
 | gateway.extraEnv | list | `[]` | Environment variables to add to the gateway pods |
@@ -46,7 +46,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | gateway.image.registry | string | `"docker.io"` | The Docker registry for the gateway image |
 | gateway.image.repository | string | `"nginxinc/nginx-unprivileged"` | The gateway image repository |
 | gateway.image.tag | string | `"1.19-alpine"` | The gateway image tag |
-| gateway.ingress.annotations | object | `{}` | Ingress Class Name. MAY be required for Kubernetes versions >= 1.18 ingressClassName: nginx -- Annotations for the gateway ingress |
+| gateway.ingress.annotations | object | `{}` | Annotations for the gateway ingress |
 | gateway.ingress.enabled | bool | `false` | Specifies whether an ingress for the gateway should be created |
 | gateway.ingress.hosts | list | `[{"host":"gateway.loki.example.com","paths":[{"path":"/"}]}]` | Hosts configuration for the gateway ingress |
 | gateway.ingress.tls | list | `[{"hosts":["gateway.loki.example.com"],"secretName":"loki-gateway-tls"}]` | TLS configuration for the gateway ingress |
@@ -95,7 +95,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | loki.readinessProbe.initialDelaySeconds | int | `30` |  |
 | loki.readinessProbe.timeoutSeconds | int | `1` |  |
 | loki.revisionHistoryLimit | int | `10` | The number of old ReplicaSets to retain to allow rollback |
-| loki.storageConfig | object | loki.defaultStorageConfig | Common storage config component of loki configuration file. The must be overriden with a valid object storage backend in order for queries to work. |
+| loki.storageConfig | object | `{}` | Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas |
 | nameOverride | string | `nil` | Overrides the chart's name |
 | networkPolicy.alertmanager.namespaceSelector | object | `{}` | Specifies the namespace the alertmanager is running in |
 | networkPolicy.alertmanager.podSelector | object | `{}` | Specifies the alertmanager Pods. As this is cross-namespace communication, you also need the namespaceSelector. |

--- a/charts/loki-simple-scalable/README.md
+++ b/charts/loki-simple-scalable/README.md
@@ -80,7 +80,6 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | global.image.registry | string | `nil` | Overrides the Docker registry globally for all images |
 | global.priorityClassName | string | `nil` | Overrides the priorityClassName for all pods |
 | imagePullSecrets | list | `[]` | Image pull secrets for Docker images |
-| loki.commonConfig | object | `{"path_prefix":"/var/loki","replication_factor":1,"storage":{"filesystem":{"chunks_directory":"/var/loki/chunks","rules_directory":"/var/loki/rules"}}}` | Check https://grafana.com/docs/loki/latest/configuration/#common_config for more info on how to provide a common configuration |
 | loki.config | object | See values.yaml | Config file contents for Loki |
 | loki.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The SecurityContext for Loki containers |
 | loki.defaultStorageConfig | object | `{"filesystem":{"chunks_directory":"/var/loki/chunks,","rules_directory":"/var/loki/rules"}}` | Default storage config, used when no loki.storageConfig is provided. Required for CI, but queries will not work using these defaults. |

--- a/charts/loki-simple-scalable/templates/configmap.yaml
+++ b/charts/loki-simple-scalable/templates/configmap.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "loki.labels" . | nindent 4 }}
 data:
   config.yaml: |
-    {{- tpl (mergeOverwrite (tpl .Values.loki.config . | fromYaml) .Values.loki.structuredConfig | toYaml) . | nindent 4 }}
+    {{- tpl (toYaml .Values.loki.config) . | nindent 4 }}
 {{- end -}}

--- a/charts/loki-simple-scalable/templates/read/hpa.yaml
+++ b/charts/loki-simple-scalable/templates/read/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.read.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "loki.readFullname" . }}
+  labels:
+    {{- include "loki.readLabels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ include "loki.readFullname" . }}
+  minReplicas: {{ .Values.read.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.read.autoscaling.maxReplicas }}
+  metrics:
+  {{- with .Values.read.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.read.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ . }}
+  {{- end }}
+{{- end }}

--- a/charts/loki-simple-scalable/templates/read/statefulset-read.yaml
+++ b/charts/loki-simple-scalable/templates/read/statefulset-read.yaml
@@ -6,7 +6,9 @@ metadata:
     {{- include "loki.readLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist
 spec:
+  {{- if not .Values.read.autoscaling.enabled }}
   replicas: {{ .Values.read.replicas }}
+  {{- end }}
   podManagementPolicy: Parallel
   updateStrategy:
     rollingUpdate:
@@ -74,8 +76,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config
-            - name: tmp
-              mountPath: /tmp
             - name: data
               mountPath: /var/loki
             {{- with .Values.read.extraVolumeMounts }}
@@ -96,8 +96,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-        - name: tmp
-          emptyDir: {}
         - name: config
           {{- if .Values.loki.existingSecretForConfig }}
           secret:

--- a/charts/loki-simple-scalable/templates/write/hpa.yaml
+++ b/charts/loki-simple-scalable/templates/write/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.write.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "loki.writeFullname" . }}
+  labels:
+    {{- include "loki.writeLabels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ include "loki.writeFullname" . }}
+  minReplicas: {{ .Values.write.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.write.autoscaling.maxReplicas }}
+  metrics:
+  {{- with .Values.write.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.write.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ . }}
+  {{- end }}
+{{- end }}

--- a/charts/loki-simple-scalable/templates/write/statefulset-write.yaml
+++ b/charts/loki-simple-scalable/templates/write/statefulset-write.yaml
@@ -6,8 +6,9 @@ metadata:
     {{- include "loki.writeLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist
 spec:
+  {{- if not .Values.write.autoscaling.enabled }}
   replicas: {{ .Values.write.replicas }}
-
+  {{- end }}
   podManagementPolicy: Parallel
   updateStrategy:
     rollingUpdate:

--- a/charts/loki-simple-scalable/values.yaml
+++ b/charts/loki-simple-scalable/values.yaml
@@ -59,7 +59,7 @@ loki:
   existingSecretForConfig: ""
   # -- Config file contents for Loki
   # @default -- See values.yaml
-  config: |
+  config:
     auth_enabled: false
 
     server:
@@ -67,12 +67,18 @@ loki:
 
     memberlist:
       join_members:
-        - {{ include "loki.fullname" . }}-memberlist
+        - "{{ include \"loki.fullname\" . }}-memberlist"
 
-    {{- if .Values.loki.commonConfig}}
     common:
-    {{- toYaml .Values.loki.commonConfig | nindent 2}}
-    {{- end}}
+      path_prefix: /var/loki
+      replication_factor: 1
+      ring:
+        kvstore:
+          store: memberlist
+      storage:
+        filesystem:
+          chunks_directory: /var/loki/chunks
+          rules_directory: /var/loki/rules
 
     limits_config:
       enforce_metric_name: false
@@ -80,47 +86,26 @@ loki:
       reject_old_samples_max_age: 168h
       max_cache_freshness_per_query: 10m
 
-    {{- if .Values.loki.schemaConfig}}
     schema_config:
-    {{- toYaml .Values.loki.schemaConfig | nindent 2}}
-    {{- end}}
-
-    {{- if .Values.loki.storageConfig}}
-    storage_config:
-    {{- toYaml .Values.loki.storageConfig | nindent 2}}
-    {{- end}}
-
-  # -- Check https://grafana.com/docs/loki/latest/configuration/#common_config for more info on how to provide a common configuration
-  commonConfig:
-    path_prefix: /var/loki
-    replication_factor: 1
-    storage:
-      filesystem:
-        chunks_directory: /var/loki/chunks
-        rules_directory: /var/loki/rules
-
-  # -- Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas
-  schemaConfig:
-    configs:
-      - from: 2020-09-07
-        store: boltdb-shipper
-        object_store: filesystem
-        schema: v11
-        index:
-          prefix: loki_index_
-          period: 24h
-
-  # -- Check https://grafana.com/docs/loki/latest/configuration/#storage_config for more info on how to configure storages
+      configs:
+        - from: 2020-09-07
+          store: boltdb-shipper
+          object_store: filesystem
+          schema: v11
+          index:
+            prefix: loki_index_
+            period: 24h
+  # -- Common storage config component of loki configuration file.
+  # The must be overriden with a valid object storage backend
+  # in order for queries to work.
+  # @default -- loki.defaultStorageConfig
   storageConfig: {}
-  # -- Uncomment to configure each storage individually
-  # boltdb_shipper: {}
-  # filesystem: {}
-  # azure: {}
-  # gcs: {}
-  # s3: {}
-
-  # -- Structured loki configuration, takes precedence over `loki.config`, `loki.schemaConfig`, `loki.storageConfig`
-  structuredConfig: {}
+  # -- Default storage config, used when no loki.storageConfig is provided.
+  # Required for CI, but queries will not work using these defaults.
+  defaultStorageConfig:
+    filesystem:
+      chunks_directory: /var/loki/chunks,
+      rules_directory: /var/loki/rules
 serviceAccount:
   # -- Specifies whether a ServiceAccount should be created
   create: true
@@ -188,6 +173,17 @@ prometheusRule:
 write:
   # -- Number of replicas for the write
   replicas: 1
+  autoscaling:
+    # -- Enable autoscaling for the write
+    enabled: false
+    # -- Minimum autoscaling replicas for the write
+    minReplicas: 1
+    # -- Maximum autoscaling replicas for the write
+    maxReplicas: 3
+    # -- Target CPU utilisation percentage for the write
+    targetCPUUtilizationPercentage: 60
+    # -- Target memory utilisation percentage for the write
+    targetMemoryUtilizationPercentage:
   image:
     # -- The Docker registry for the write image. Overrides `loki.image.registry`
     registry: null
@@ -451,7 +447,6 @@ gateway:
     # high CPU load.
     htpasswd: >-
       {{ htpasswd (required "'gateway.basicAuth.username' is required" .Values.gateway.basicAuth.username) (required "'gateway.basicAuth.password' is required" .Values.gateway.basicAuth.password) }}
-
     # -- Existing basic auth secret to use. Must contain '.htpasswd'
     existingSecret: null
   # Configures the readiness probe for the gateway

--- a/charts/loki-simple-scalable/values.yaml
+++ b/charts/loki-simple-scalable/values.yaml
@@ -99,15 +99,8 @@ loki:
   # -- Common storage config component of loki configuration file.
   # The must be overriden with a valid object storage backend
   # in order for queries to work.
-  # @default -- loki.defaultStorageConfig
-  # -- Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas
+
   storageConfig: {}
-  # -- Uncomment to configure each storage individually
-  # boltdb_shipper: {}
-  # filesystem: {}
-  # azure: {}
-  # gcs: {}
-  # s3: {}
   # -- Default storage config, used when no loki.storageConfig is provided.
   # Required for CI, but queries will not work using these defaults.
   defaultStorageConfig:
@@ -342,8 +335,8 @@ gateway:
     targetCPUUtilizationPercentage: 60
     # -- Target memory utilisation percentage for the gateway
     targetMemoryUtilizationPercentage:
-  # -- See `kubectl explain deployment.spec.strategy` for more
-  # -- ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  # -- See `kubectl explain deployment.spec.strategy` for more.
+  # ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
   deploymentStrategy:
     type: RollingUpdate
   image:
@@ -426,9 +419,8 @@ gateway:
   ingress:
     # -- Specifies whether an ingress for the gateway should be created
     enabled: false
-    # -- Ingress Class Name. MAY be required for Kubernetes versions >= 1.18
+    # -- Annotations for gateway ingress class name. MAY be required for Kubernetes versions >= 1.18
     # ingressClassName: nginx
-    # -- Annotations for the gateway ingress
     annotations: {}
     # -- Hosts configuration for the gateway ingress
     hosts:

--- a/charts/loki-simple-scalable/values.yaml
+++ b/charts/loki-simple-scalable/values.yaml
@@ -177,7 +177,7 @@ write:
     # -- Enable autoscaling for the write
     enabled: false
     # -- Minimum autoscaling replicas for the write
-    minReplicas: 1
+    minReplicas: 3
     # -- Maximum autoscaling replicas for the write
     maxReplicas: 3
     # -- Target CPU utilisation percentage for the write

--- a/charts/loki-simple-scalable/values.yaml
+++ b/charts/loki-simple-scalable/values.yaml
@@ -95,11 +95,19 @@ loki:
           index:
             prefix: loki_index_
             period: 24h
+
   # -- Common storage config component of loki configuration file.
   # The must be overriden with a valid object storage backend
   # in order for queries to work.
   # @default -- loki.defaultStorageConfig
+  # -- Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas
   storageConfig: {}
+  # -- Uncomment to configure each storage individually
+  # boltdb_shipper: {}
+  # filesystem: {}
+  # azure: {}
+  # gcs: {}
+  # s3: {}
   # -- Default storage config, used when no loki.storageConfig is provided.
   # Required for CI, but queries will not work using these defaults.
   defaultStorageConfig:


### PR DESCRIPTION
This replacement for PR #979 since unable to get DCO sign-off.

Original quote:
----
Adding hpa resources for read/write loki-simple-scaling services. read looks like it was intended to have this but wasnt finished (values with no template files) and write didnt have either.

I think this may need a warning about enabling autoscaling on writes when not using an object_store backend.