### PR TITLE
[mimir-distributed] Bump PodDisruptionBudget to policy/v1

### DIFF
--- a/charts/mimir-distributed/Chart.yaml
+++ b/charts/mimir-distributed/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.1.6
+version: 0.1.7
 appVersion: 2.0.0
 description: "Grafana Mimir"
 engine: gotpl

--- a/charts/mimir-distributed/README.md
+++ b/charts/mimir-distributed/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/v2.0.x/)
 
 # mimir-distributed
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Mimir
 
@@ -14,10 +14,10 @@ Kubernetes: `^1.10.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | memcached | 5.5.2 |
-| https://charts.bitnami.com/bitnami | memcached | 5.5.2 |
-| https://charts.bitnami.com/bitnami | memcached | 5.5.2 |
-| https://helm.min.io/ | minio | 8.0.10 |
+| https://charts.bitnami.com/bitnami | memcached(memcached) | 5.5.2 |
+| https://charts.bitnami.com/bitnami | memcached-queries(memcached) | 5.5.2 |
+| https://charts.bitnami.com/bitnami | memcached-metadata(memcached) | 5.5.2 |
+| https://helm.min.io/ | minio(minio) | 8.0.10 |
 
 ### Storage
 

--- a/charts/mimir-distributed/scripts/create-pdb
+++ b/charts/mimir-distributed/scripts/create-pdb
@@ -40,7 +40,7 @@ snake_cased="$(snake_case "$1")"
 
 cat <<EOF
 {{- if .Values.${snake_cased}.podDisruptionBudget -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "mimir.${camel_cased}Fullname" . }}

--- a/charts/mimir-distributed/templates/alertmanager/alertmanager-pdb.yaml
+++ b/charts/mimir-distributed/templates/alertmanager/alertmanager-pdb.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.alertmanager.enabled -}}
 {{- if .Values.alertmanager.podDisruptionBudget -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "mimir.alertmanagerFullname" . }}

--- a/charts/mimir-distributed/templates/compactor/compactor-pdb.yaml
+++ b/charts/mimir-distributed/templates/compactor/compactor-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.compactor.podDisruptionBudget -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "mimir.compactorFullname" . }}

--- a/charts/mimir-distributed/templates/distributor/distributor-pdb.yaml
+++ b/charts/mimir-distributed/templates/distributor/distributor-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.distributor.podDisruptionBudget -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "mimir.distributorFullname" . }}

--- a/charts/mimir-distributed/templates/ingester/ingester-pdb.yaml
+++ b/charts/mimir-distributed/templates/ingester/ingester-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingester.podDisruptionBudget -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "mimir.ingesterFullname" . }}

--- a/charts/mimir-distributed/templates/nginx/nginx-pdb.yaml
+++ b/charts/mimir-distributed/templates/nginx/nginx-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.nginx.podDisruptionBudget -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "mimir.nginxFullname" . }}

--- a/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-pdb.yaml
+++ b/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.overrides_exporter.podDisruptionBudget -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "mimir.overridesExporterFullname" . }}

--- a/charts/mimir-distributed/templates/querier/querier-pdb.yaml
+++ b/charts/mimir-distributed/templates/querier/querier-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.querier.podDisruptionBudget -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "mimir.querierFullname" . }}

--- a/charts/mimir-distributed/templates/query-frontend/query-frontend-pdb.yaml
+++ b/charts/mimir-distributed/templates/query-frontend/query-frontend-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.query_frontend.podDisruptionBudget -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "mimir.queryFrontendFullname" . }}

--- a/charts/mimir-distributed/templates/ruler/ruler-pdb.yaml
+++ b/charts/mimir-distributed/templates/ruler/ruler-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ruler.podDisruptionBudget -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "mimir.rulerFullname" . }}

--- a/charts/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
+++ b/charts/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.store_gateway.podDisruptionBudget -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "mimir.storeGatewayFullname" . }}


### PR DESCRIPTION
# Description
Hello,

We updated our Kubernetes cluster to 1.21 and we checked some deprecated like `PodSecurityPolicy` and `PodDisruptionBudget`.

To avoid _warnings_ during deployment, I updated `PodDisruptionBudget` from `v1beta` to `v1` following Kubernetes changelogs.

Readme is updated following helm-docs this command: `docker run --rm --volume "$(pwd):/helm-docs" -u $(id -u) jnorwood/helm-docs:v1.4.0`

Thx 