### PR TITLE
[tempo-distributed] Add ingester configurations

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.16.8
+version: 0.16.9
 appVersion: 1.3.2
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.16.8](https://img.shields.io/badge/Version-0.16.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.2](https://img.shields.io/badge/AppVersion-1.3.2-informational?style=flat-square)
+![Version: 0.16.9](https://img.shields.io/badge/Version-0.16.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.2](https://img.shields.io/badge/AppVersion-1.3.2-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -175,6 +175,9 @@ The memcached default args are removed and should be provided manually. The sett
 | ingester.resources | object | `{}` | Resource requests and limits for the ingester |
 | ingester.terminationGracePeriodSeconds | int | `300` | Grace period to allow the ingester to shutdown before it is killed. Especially for the ingestor, this must be increased. It must be long enough so ingesters can be gracefully shutdown flushing/transferring all data and to successfully leave the member ring on shutdown. |
 | ingester.tolerations | list | `[]` | Tolerations for ingester pods |
+| ingester.maxBlockBytes | int | `nil` | Maximum size of a block before cutting it |
+| ingester.maxBlockDuration | string | `nil` | Maximum length of time before cutting a block |
+| ingester.completeBlockTimeout | string | `nil` | Duration to keep blocks in the ingester after they have been flushed |
 | memcached.affinity | string | Hard node and soft zone anti-affinity | Affinity for memcached pods. Passed through `tpl` and, thus, to be configured as string |
 | memcached.enabled | bool | `true` | Specified whether the memcached cachce should be enabled |
 | memcached.extraArgs | list | `[]` | Additional CLI args for memcached |

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -457,6 +457,15 @@ config: |
         kvstore:
           store: memberlist
       tokens_file_path: /var/tempo/tokens.json
+    {{- if .Values.ingester.maxBlockBytes }}
+    max_block_bytes: {{ .Values.ingester.maxBlockBytes }}
+    {{- end }}
+    {{- if .Values.ingester.maxBlockDuration }}
+    max_block_duration: {{ .Values.ingester.maxBlockDuration }}
+    {{- end }}
+    {{- if .Values.ingester.completeBlockTimeout }}
+    complete_block_timeout: {{ .Values.ingester.completeBlockTimeout }}
+    {{- end }}
   memberlist:
     abort_if_cluster_join_fails: false
     join_members:


### PR DESCRIPTION
Hi,

These fields are [present in official tempo documentation](https://grafana.com/docs/tempo/latest/configuration/#ingester).

I tried using those fields by manually modifying `tempo-distributed` `ConfigMap`, and I checked `status/config` [endpoint](https://grafana.com/docs/tempo/latest/api_docs/#status) on ingesters. There, it can be seen that fields are properly consumed by ingesters.

I would like to expose these fields through the chart because memory footprint of ingesters can be significantly altered with some tweaking.

Also, if this PR gets accepted, I would be willing to publish more PRs, and expose more fields which are documented, but not yet exposed.