### PR TITLE
[loki-distributed] Add metricRelabelings to ServiceMonitors

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.5.0
-version: 0.48.0
+version: 0.48.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.48.0](https://img.shields.io/badge/Version-0.48.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 0.48.1](https://img.shields.io/badge/Version-0.48.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 
@@ -413,6 +413,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | serviceMonitor.enabled | bool | `false` | If enabled, ServiceMonitor resources for Prometheus Operator are created |
 | serviceMonitor.interval | string | `nil` | ServiceMonitor scrape interval |
 | serviceMonitor.labels | object | `{}` | Additional ServiceMonitor labels |
+| serviceMonitor.metricRelabelings | list | `[]` | ServiceMonitor metric relabel configs to apply to samples before ingestion https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint |
 | serviceMonitor.namespace | string | `nil` | Alternative namespace for ServiceMonitor resources |
 | serviceMonitor.namespaceSelector | object | `{}` | Namespace selector for ServiceMonitor resources |
 | serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig |

--- a/charts/loki-distributed/templates/compactor/servicemonitor-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/servicemonitor-compactor.yaml
@@ -37,6 +37,10 @@ spec:
       relabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/loki-distributed/templates/distributor/servicemonitor-distributor.yaml
+++ b/charts/loki-distributed/templates/distributor/servicemonitor-distributor.yaml
@@ -36,6 +36,10 @@ spec:
       relabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/loki-distributed/templates/index-gateway/servicemonitor-index-gateway.yaml
+++ b/charts/loki-distributed/templates/index-gateway/servicemonitor-index-gateway.yaml
@@ -42,6 +42,10 @@ spec:
       relabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/loki-distributed/templates/ingester/servicemonitor-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/servicemonitor-ingester.yaml
@@ -41,6 +41,10 @@ spec:
       relabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/loki-distributed/templates/memcached-chunks/servicemonitor-memcached-chunks.yaml
+++ b/charts/loki-distributed/templates/memcached-chunks/servicemonitor-memcached-chunks.yaml
@@ -37,6 +37,10 @@ spec:
       relabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/loki-distributed/templates/memcached-frontend/servicemonitor-memcached-frontend.yaml
+++ b/charts/loki-distributed/templates/memcached-frontend/servicemonitor-memcached-frontend.yaml
@@ -37,6 +37,10 @@ spec:
       relabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/loki-distributed/templates/memcached-index-queries/servicemonitor-memcached-index-queries.yaml
+++ b/charts/loki-distributed/templates/memcached-index-queries/servicemonitor-memcached-index-queries.yaml
@@ -37,6 +37,10 @@ spec:
       relabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/loki-distributed/templates/memcached-index-writes/servicemonitor-memcached-index-writes.yaml
+++ b/charts/loki-distributed/templates/memcached-index-writes/servicemonitor-memcached-index-writes.yaml
@@ -37,6 +37,10 @@ spec:
       relabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/loki-distributed/templates/querier/servicemonitor-querier.yaml
+++ b/charts/loki-distributed/templates/querier/servicemonitor-querier.yaml
@@ -41,6 +41,10 @@ spec:
       relabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/loki-distributed/templates/query-frontend/servicemonitor-query-frontend.yaml
+++ b/charts/loki-distributed/templates/query-frontend/servicemonitor-query-frontend.yaml
@@ -36,6 +36,10 @@ spec:
       relabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/loki-distributed/templates/ruler/servicemonitor-ruler.yaml
+++ b/charts/loki-distributed/templates/ruler/servicemonitor-ruler.yaml
@@ -37,6 +37,10 @@ spec:
       relabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/loki-distributed/templates/table-manager/servicemonitor-table-manager.yaml
+++ b/charts/loki-distributed/templates/table-manager/servicemonitor-table-manager.yaml
@@ -37,6 +37,10 @@ spec:
       relabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -222,6 +222,9 @@ serviceMonitor:
   # -- ServiceMonitor relabel configs to apply to samples before scraping
   # https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
   relabelings: []
+  # -- ServiceMonitor metric relabel configs to apply to samples before ingestion
+  # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint
+  metricRelabelings: []
   # -- ServiceMonitor will use http by default, but you can pick https as well
   scheme: http
   # -- ServiceMonitor will use these tlsConfig settings to make the health check requests


### PR DESCRIPTION
Add possibility to define `metricRelabelings` for `ServiceMonitor` CRDs as described in the [specification](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint).