### PR TITLE
[mimir-distributed] fix prod values capped-small and capped-large

### DIFF
--- a/charts/mimir-distributed/Chart.yaml
+++ b/charts/mimir-distributed/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.1.6
+version: 0.1.7
 appVersion: 2.0.0
 description: "Grafana Mimir"
 engine: gotpl

--- a/charts/mimir-distributed/README.md
+++ b/charts/mimir-distributed/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/v2.0.x/)
 
 # mimir-distributed
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Mimir
 

--- a/charts/mimir-distributed/capped-large.yaml
+++ b/charts/mimir-distributed/capped-large.yaml
@@ -60,6 +60,16 @@ ingester:
     limits:
       cpu: 4
       memory: 15Gi
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: target
+                operator: In
+                values:
+                  - ingester
+          topologyKey: 'kubernetes.io/hostname'
 
 memcached:
   enabled: true

--- a/charts/mimir-distributed/capped-large.yaml
+++ b/charts/mimir-distributed/capped-large.yaml
@@ -13,10 +13,6 @@
 # object storage service for production deployments.
 # Ingesters are configured with a replication factor of 3 to ensure that a single ingester failur does not
 # result in data loss.
-config:
-  ingester:
-    ring:
-      replication_factor: 3
 
 alertmanager:
   persistentVolume:

--- a/charts/mimir-distributed/capped-small.yaml
+++ b/charts/mimir-distributed/capped-small.yaml
@@ -60,6 +60,16 @@ ingester:
     limits:
       cpu: 4
       memory: 15Gi
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: target
+                operator: In
+                values:
+                  - ingester
+          topologyKey: 'kubernetes.io/hostname'
 
 memcached:
   enabled: true

--- a/charts/mimir-distributed/capped-small.yaml
+++ b/charts/mimir-distributed/capped-small.yaml
@@ -13,10 +13,6 @@
 # object storage service for production deployments.
 # Ingesters are configured with a replication factor of 3 to ensure that a single ingester failur does not
 # result in data loss.
-config:
-  ingester:
-    ring:
-      replication_factor: 3
 
 alertmanager:
   persistentVolume:


### PR DESCRIPTION
Removes wrong, redundant config snippet and adds affinity rules - should be the same as small and large yaml.