### PR TITLE
[mimir-distributed] Bump helm-docs version to not force contributors on older vesion

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Check Docs
         run: |
-          docker run --rm --volume "$(pwd):/helm-docs" -u "$(id -u)" jnorwood/helm-docs:v1.4.0
+          docker run --rm --volume "$(pwd):/helm-docs" -u "$(id -u)" jnorwood/helm-docs:v1.8.1
           if ! git diff --exit-code; then
               echo "Documentation not up to date. Please run helm-docs and commit changes!" >&2
               exit 1

--- a/.helmdocsignore
+++ b/.helmdocsignore
@@ -4,3 +4,9 @@ charts/loki
 charts/loki-stack
 charts/enterprise-metrics
 charts/enterprise-logs
+# TODO get rid of this list after all docs migrated to helm-docs:1.8.1
+charts/agent-operator
+charts/enterprise-logs-simple
+charts/loki-distributed
+charts/loki-simple-scalable
+charts/tempo-distributed

--- a/charts/mimir-distributed/CHANGELOG.md
+++ b/charts/mimir-distributed/CHANGELOG.md
@@ -11,13 +11,17 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the Pull Request that introduced the change.
 
+## 2.0.3
+
+* [ENHANCEMENT] Update README.md with helm-docs version 1.8.1 instead of old 1.4.0. #1230
+
 ## 2.0.2
 
 * [ENHANCEMENT] Update Grafana Enterprise Metrics docker image tag to v2.0.1 #1241
 
 ## 2.0.1
 
-* [BUGFIX] Honor `global.clusterDomain` when referencing internal services, e.g. alertmanager or nginx gateway.
+* [BUGFIX] Honor `global.clusterDomain` when referencing internal services, e.g. alertmanager or nginx gateway. #1227
 
 ## 2.0.0
 

--- a/charts/mimir-distributed/Chart.yaml
+++ b/charts/mimir-distributed/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.0.2
+version: 2.0.3
 appVersion: 2.0.0
 description: "Grafana Mimir"
 engine: gotpl

--- a/charts/mimir-distributed/README.md
+++ b/charts/mimir-distributed/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/v2.0.x/)
 
 # mimir-distributed
 
-![Version: 2.0.2](https://img.shields.io/badge/Version-2.0.2-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.0.3](https://img.shields.io/badge/Version-2.0.3-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Mimir
 
@@ -14,10 +14,10 @@ Kubernetes: `^1.10.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | memcached | 5.5.2 |
-| https://charts.bitnami.com/bitnami | memcached | 5.5.2 |
-| https://charts.bitnami.com/bitnami | memcached | 5.5.2 |
-| https://helm.min.io/ | minio | 8.0.10 |
+| https://charts.bitnami.com/bitnami | memcached(memcached) | 5.5.2 |
+| https://charts.bitnami.com/bitnami | memcached-queries(memcached) | 5.5.2 |
+| https://charts.bitnami.com/bitnami | memcached-metadata(memcached) | 5.5.2 |
+| https://helm.min.io/ | minio(minio) | 8.0.10 |
 
 ## Dependencies
 


### PR DESCRIPTION
Start updating charts for helm-docs 1.8.1. We can only update and release one chart at a time , so put ones that fail linting on helmdocsignore for now.

Old version renders chart dependencies differently:
old: | https://helm.min.io/ | minio | 8.0.10 |

new: | https://helm.min.io/ | minio(minio) | 8.0.10 |

Old version missing chart alias.

Signed-off-by: György Krajcsovits <gyorgy.krajcsovits@grafana.com>