### PR TITLE
[loki] max_entries_limit_per_query to it's default value

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 2.11.0
+version: 2.11.1
 appVersion: v2.5.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -75,6 +75,7 @@ config:
     enforce_metric_name: false
     reject_old_samples: true
     reject_old_samples_max_age: 168h
+    max_entries_limit_per_query: 5000
   schema_config:
     configs:
     - from: 2020-10-24


### PR DESCRIPTION
This PR relates to https://github.com/grafana/helm-charts/pull/966

Query limit is changed via max_entries_limit https://grafana.com/docs/loki/latest/configuration/#limits_config which default value is 5000 but not affecting here when using Dashboard sidecar as the datasource is limited by default to 1000.

This PR allows to override both values and setting default Loki and Loki Datasource default, lowest of them will apply when using sidecar.

Signed-off-by: Guillermo Caracuel <guillermo.caracuel@predictiva.io>