### PR TITLE
[loki-stack] max_entries_limit_per_query to it's current value

### DIFF
--- a/charts/loki-stack/Chart.yaml
+++ b/charts/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 2.6.2
+version: 2.6.3
 appVersion: v2.1.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki-stack/templates/datasources.yaml
+++ b/charts/loki-stack/templates/datasources.yaml
@@ -21,6 +21,8 @@ data:
       url: http://{{(include "loki.serviceName" .)}}:{{ .Values.loki.service.port }}
       version: 1
       isDefault: {{ .Values.loki.isDefault }}
+      jsonData:
+        maxLines: {{ .Values.grafana.sidecar.datasources.enabled }}
 {{- end }}
 {{- if .Values.prometheus.enabled }}
     - name: Prometheus

--- a/charts/loki-stack/templates/datasources.yaml
+++ b/charts/loki-stack/templates/datasources.yaml
@@ -22,7 +22,7 @@ data:
       version: 1
       isDefault: {{ .Values.loki.isDefault }}
       jsonData:
-        maxLines: {{ .Values.grafana.sidecar.datasources.enabled }}
+        maxLines: {{ .Values.grafana.sidecar.datasources.maxLines }}
 {{- end }}
 {{- if .Values.prometheus.enabled }}
     - name: Prometheus

--- a/charts/loki-stack/values.yaml
+++ b/charts/loki-stack/values.yaml
@@ -13,6 +13,7 @@ grafana:
   sidecar:
     datasources:
       enabled: true
+      maxLines: 1000
   image:
     tag: 8.3.5
 


### PR DESCRIPTION
This PR relates to https://github.com/grafana/helm-charts/pull/966

Query limit is changed via max_entries_limit https://grafana.com/docs/loki/latest/configuration/#limits_config which default value is 5000 but not affecting here when using Dashboard sidecar as the datasource is limited by default to 1000.

This PR allows to override both values and setting default Loki and Loki Datasource default, lowest of them will apply when using sidecar.