### PR TITLE
[mimir-distributed] naginx regex location blocks

### DIFF
--- a/charts/mimir-distributed/Chart.yaml
+++ b/charts/mimir-distributed/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.1.7
+version: 0.1.8
 appVersion: 2.0.0
 description: "Grafana Mimir"
 engine: gotpl

--- a/charts/mimir-distributed/README.md
+++ b/charts/mimir-distributed/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/v2.0.x/)
 
 # mimir-distributed
 
-![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Mimir
 

--- a/charts/mimir-distributed/values.yaml
+++ b/charts/mimir-distributed/values.yaml
@@ -1260,13 +1260,13 @@ nginx:
           location {{ template "mimir.prometheusHttpPrefix" . }}/api/v1/rules {
             proxy_pass      http://{{ template "mimir.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.cluster.local:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
           }
-          location = /api/v1/rules {
+          location /api/v1/rules {
             proxy_pass      http://{{ template "mimir.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.cluster.local:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
           }
           location {{ template "mimir.prometheusHttpPrefix" . }}/api/v1/alerts {
             proxy_pass      http://{{ template "mimir.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.cluster.local:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
           }
-          location = {{ template "mimir.prometheusHttpPrefix" . }}/rules {
+          location {{ template "mimir.prometheusHttpPrefix" . }}/rules {
             proxy_pass      http://{{ template "mimir.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.cluster.local:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
           }
           location = /ruler/ring {
@@ -1275,6 +1275,11 @@ nginx:
 
           # Rest of {{ template "mimir.prometheusHttpPrefix" . }} goes to the query frontend
           location {{ template "mimir.prometheusHttpPrefix" . }} {
+            proxy_pass      http://{{ template "mimir.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc.cluster.local:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+          }
+
+          # Buildinfo endpoint can go to any component
+          location = /api/v1/status/buildinfo {
             proxy_pass      http://{{ template "mimir.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc.cluster.local:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
           }
 


### PR DESCRIPTION
* `/distributor`
* `/alertmanager`
* `/multitenant_alertmanager`
* `/api/v1/rules`
* `/prometheus/rules`
* `/prometheus/config/v1/rules`

are all prefixes to endpoints, so the nginx proxy rules need to reflect that

This was the source of this bug report https://grafana.slack.com/archives/C039863E8P7/p1649793055645919