### PR TITLE
[grafana] Cleanup helm test pod after success

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.26.2
+version: 6.26.3
 appVersion: 8.4.6
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/tests/test.yaml
+++ b/charts/grafana/templates/tests/test.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "grafana.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test-success
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   namespace: {{ template "grafana.namespace" . }}
 spec:
   serviceAccountName: {{ template "grafana.serviceAccountNameTest" . }}


### PR DESCRIPTION
The existing Grafana helm test doesn't cleanup the test pod after success. This causes pods to linger around the cluster. This change adds the necessary annotation to delete the test pod after success. See the official helm [documentation](https://helm.sh/docs/topics/charts_hooks/#hook-deletion-policies) for more information.