### PR TITLE
[tempo-distributed] fix: indentation of annotations

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.16.9
+version: 0.16.10
 appVersion: 1.3.2
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.16.9](https://img.shields.io/badge/Version-0.16.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.2](https://img.shields.io/badge/AppVersion-1.3.2-informational?style=flat-square)
+![Version: 0.16.10](https://img.shields.io/badge/Version-0.16.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.2](https://img.shields.io/badge/AppVersion-1.3.2-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/memcached/statefulset-memcached.yaml
+++ b/charts/tempo-distributed/templates/memcached/statefulset-memcached.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "tempo.memcachedLabels" . | nindent 4 }}
   {{- with .Values.memcached.annotations }}
   annotations:
-    {{ toYaml . | indent 4 }}
+  {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.memcached.replicas }}

--- a/charts/tempo-distributed/templates/querier/deployment-querier.yaml
+++ b/charts/tempo-distributed/templates/querier/deployment-querier.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "tempo.labels" . | nindent 4 }}
   {{- with .Values.querier.annotations }}
   annotations:
-    {{ toYaml . | indent 4 }}
+  {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   minReadySeconds: 10

--- a/charts/tempo-distributed/templates/querier/service-querier.yaml
+++ b/charts/tempo-distributed/templates/querier/service-querier.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "tempo.querierLabels" . | nindent 4 }}
   {{- with .Values.querier.annotations }}
   annotations:
-    {{ toYaml . | indent 4 }}
+  {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   ports:


### PR DESCRIPTION
Hey folks. It's my first contribution. I hope I followed all the contribution guidelines.

Annotations seem to have been incorrectly rendering the templates

**statefulset-memcached.yaml**
```
Error: YAML parse error on tempo-distributed/charts/tempo-distributed/templates/memcached/statefulset-memcached.yaml: error converting YAML to JSON: yaml: line 14: did not find expected key
helm.go:84: [debug] error converting YAML to JSON: yaml: line 14: did not find expected key
```

```yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: tempo-tempo-distributed-memcached
  namespace: default
  labels:
    helm.sh/chart: tempo-distributed-0.16.9
    app.kubernetes.io/name: tempo-distributed
    app.kubernetes.io/instance: tempo
    app.kubernetes.io/version: "1.3.2"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: memcached
  annotations:
        prometheus.io/port: "9150"
    prometheus.io/scrape: "true"
```

**deployment-queries.yaml**
```
Error: YAML parse error on tempo-distributed/charts/tempo-distributed/templates/querier/deployment-querier.yaml: error converting YAML to JSON: yaml: line 13: did not find expected key
helm.go:84: [debug] error converting YAML to JSON: yaml: line 13: did not find expected key
```

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: tempo-tempo-distributed-querier
  namespace: default
  labels:
    helm.sh/chart: tempo-distributed-0.16.9
    app.kubernetes.io/name: tempo-distributed
    app.kubernetes.io/instance: tempo
    app.kubernetes.io/version: "1.3.2"
    app.kubernetes.io/managed-by: Helm
  annotations:
        prometheus.io/port: "3100"
    prometheus.io/scrape: "true"
```

**service-querier.yaml**

```
Error: YAML parse error on tempo-distributed/charts/tempo-distributed/templates/querier/service-querier.yaml: error converting YAML to JSON: yaml: line 14: did not find expected key
helm.go:84: [debug] error converting YAML to JSON: yaml: line 14: did not find expected key
```

```yaml
apiVersion: v1
kind: Service
metadata:
  name: tempo-tempo-distributed-querier
  namespace: default
  labels:
    helm.sh/chart: tempo-distributed-0.16.9
    app.kubernetes.io/name: tempo-distributed
    app.kubernetes.io/instance: tempo
    app.kubernetes.io/version: "1.3.2"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: querier
  annotations:
        prometheus.io/port: "3100"
    prometheus.io/scrape: "true"
```