### PR TITLE
[mimir-distributed] Update charts/mimir-distributed/templates/nginx/_helpers.tpl

### DIFF
--- a/charts/mimir-distributed/templates/nginx/_helpers.tpl
+++ b/charts/mimir-distributed/templates/nginx/_helpers.tpl
@@ -1,4 +1,11 @@
 {{/*
+nginx fullname
+*/}}
+{{- define "mimir.nginxFullname" -}}
+{{ include "mimir.fullname" . }}-nginx
+{{- end }}
+
+{{/*
 nginx auth secret name
 */}}
 {{- define "mimir.nginxAuthSecret" -}}


### PR DESCRIPTION
Correct nginx _helpers.tpl to define  mimir.nginxFullname based off mimir.fullname . Currently helm deployment will fail if ingress is enabled in value file as noted in Issue #1244 

Signed-off-by: Brandon.Abernathy@BecksHybrids.com
