### PR TITLE
[mimir-distributed] nginx gateway ingress use new component naming

### DIFF
--- a/charts/mimir-distributed/CHANGELOG.md
+++ b/charts/mimir-distributed/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the Pull Request that introduced the change.
 
+## 2.0.5
+
+* [BUGFIX] Use new component name system for gateway ingress. This regression has been introduced with #1203
+
 ## 2.0.4
 
 * [ENHANCEMENT] Determine PodDisruptionBudget APIVersion based on running version of k8s #1229

--- a/charts/mimir-distributed/CHANGELOG.md
+++ b/charts/mimir-distributed/CHANGELOG.md
@@ -13,7 +13,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## 2.0.5
 
-* [BUGFIX] Use new component name system for gateway ingress. This regression has been introduced with #1203
+* [BUGFIX] Use new component name system for gateway ingress. This regression has been introduced with #1203. #1260
 
 ## 2.0.4
 

--- a/charts/mimir-distributed/Chart.yaml
+++ b/charts/mimir-distributed/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.0.4
+version: 2.0.5
 appVersion: 2.0.0
 description: "Grafana Mimir"
 engine: gotpl

--- a/charts/mimir-distributed/README.md
+++ b/charts/mimir-distributed/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/v2.0.x/)
 
 # mimir-distributed
 
-![Version: 2.0.4](https://img.shields.io/badge/Version-2.0.4-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.0.5](https://img.shields.io/badge/Version-2.0.5-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Mimir
 

--- a/charts/mimir-distributed/templates/nginx/ingress.yaml
+++ b/charts/mimir-distributed/templates/nginx/ingress.yaml
@@ -43,11 +43,11 @@ spec:
             backend:
               {{- if $ingressApiIsStable }}
               service:
-                name: {{ include "mimir.nginxFullname" $ }}
+                name: {{ include "mimir.resourceName" (dict "ctx" . "component" "nginx") }}
                 port:
                   number: {{ $.Values.nginx.service.port }}
               {{- else }}
-              serviceName: {{ include "mimir.nginxFullname" $ }}
+              serviceName: {{ include "mimir.resourceName" (dict "ctx" . "component" "nginx") }}
               servicePort: {{ $.Values.nginx.service.port }}
               {{- end }}
           {{- end }}

--- a/charts/mimir-distributed/templates/nginx/ingress.yaml
+++ b/charts/mimir-distributed/templates/nginx/ingress.yaml
@@ -43,11 +43,11 @@ spec:
             backend:
               {{- if $ingressApiIsStable }}
               service:
-                name: {{ include "mimir.resourceName" (dict "ctx" . "component" "nginx") }}
+                name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "nginx") }}
                 port:
                   number: {{ $.Values.nginx.service.port }}
               {{- else }}
-              serviceName: {{ include "mimir.resourceName" (dict "ctx" . "component" "nginx") }}
+              serviceName: {{ include "mimir.resourceName" (dict "ctx" $ "component" "nginx") }}
               servicePort: {{ $.Values.nginx.service.port }}
               {{- end }}
           {{- end }}


### PR DESCRIPTION
Fixes the TPL crash currently preventing deploying the Chart with activated ingress object. 

Seems to be introduced with https://github.com/grafana/helm-charts/pull/1203

Signed-off-by: secustor <sebastian@poxhofer.at>