### PR TITLE
[agent-operator] Bump helm-docs use in agent-operator to 1.8.1

### DIFF
--- a/.helmdocsignore
+++ b/.helmdocsignore
@@ -5,7 +5,6 @@ charts/loki-stack
 charts/enterprise-metrics
 charts/enterprise-logs
 # TODO get rid of this list after all docs migrated to helm-docs:1.8.1
-charts/agent-operator
 charts/enterprise-logs-simple
 charts/loki-distributed
 charts/loki-simple-scalable

--- a/charts/agent-operator/Chart.yaml
+++ b/charts/agent-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: grafana-agent-operator
 description: A Helm chart for Grafana Agent Operator
 type: application
-version: 0.1.9
+version: 0.1.10
 appVersion: "0.24.1"
 home: https://grafana.com/docs/agent/latest/
 icon: https://raw.githubusercontent.com/grafana/agent/v0.24.1/docs/assets/logo_and_name.png

--- a/charts/agent-operator/README.md
+++ b/charts/agent-operator/README.md
@@ -1,6 +1,6 @@
 # grafana-agent-operator
 
-![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.1](https://img.shields.io/badge/AppVersion-0.24.1-informational?style=flat-square)
+![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.1](https://img.shields.io/badge/AppVersion-0.24.1-informational?style=flat-square)
 
 A Helm chart for Grafana Agent Operator
 
@@ -61,7 +61,7 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 | image.registry | string | `"docker.io"` | Image registry |
 | image.repository | string | `"grafana/agent-operator"` | Image repo |
 | image.tag | string | `"v0.24.1"` | Image tag |
-| kubeletService | object | `{"namespace":"default","serviceName":"kubelet"}` | If both are set, Agent Operator will create and maintain a service for scraping kubelets -- https://grafana.com/docs/agent/latest/operator/getting-started/#monitor-kubelets |
+| kubeletService | object | `{"namespace":"default","serviceName":"kubelet"}` | If both are set, Agent Operator will create and maintain a service for scraping kubelets https://grafana.com/docs/agent/latest/operator/getting-started/#monitor-kubelets |
 | nameOverride | string | `""` | Overrides the chart's name |
 | nodeSelector | object | `{}` | nodeSelector configuration |
 | podAnnotations | object | `{}` | Annotations for the Deployment Pods |

--- a/charts/agent-operator/values.yaml
+++ b/charts/agent-operator/values.yaml
@@ -36,7 +36,7 @@ image:
   pullSecrets: []
 
 # -- If both are set, Agent Operator will create and maintain a service for scraping kubelets
-# -- https://grafana.com/docs/agent/latest/operator/getting-started/#monitor-kubelets
+# https://grafana.com/docs/agent/latest/operator/getting-started/#monitor-kubelets
 kubeletService:
   namespace: default
   serviceName: kubelet


### PR DESCRIPTION
Use latest helm-docs 1.8.1 for README.md generation in agent-operator