### PR TITLE
[grafana] Add the ability to configure lifecycle hooks

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.26.3
+version: 6.26.4
 appVersion: 8.4.6
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -139,6 +139,7 @@ This version requires Helm >= 3.1.0.
 | `podAnnotations`                          | Pod annotations                               | `{}`                                                    |
 | `podLabels`                               | Pod labels                                    | `{}`                                                    |
 | `podPortName`                             | Name of the grafana port on the pod           | `grafana`                                               |
+| `lifecycleHooks`                          | Lifecycle hooks for podStart and preStop [Example](https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/#define-poststart-and-prestop-handlers)     | `{}`                                                    |
 | `sidecar.image.repository`                | Sidecar image repository                      | `quay.io/kiwigrid/k8s-sidecar`                          |
 | `sidecar.image.tag`                       | Sidecar image tag                             | `1.15.6`                                                |
 | `sidecar.image.sha`                       | Sidecar image sha (optional)                  | `""`                                                    |

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -561,6 +561,9 @@ containers:
 {{ toYaml .Values.livenessProbe | indent 6 }}
     readinessProbe:
 {{ toYaml .Values.readinessProbe | indent 6 }}
+{{- if .Values.grafana.lifecycleHooks }}
+    lifecycle: {{ tpl (.Values.lifecycleHooks | toYaml) . | nindent 6 }}
+{{- end }}
     resources:
 {{ toYaml .Values.resources | indent 6 }}
 {{- with .Values.extraContainers }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -458,6 +458,12 @@ extraVolumeMounts: []
   #   readOnly: true
   #   hostPath: /usr/shared/
 
+## Container Lifecycle Hooks. Execute a specific bash command or make an HTTP request
+lifecycleHooks: {}
+  # postStart:
+  #   exec:
+  #     command: []
+
 ## Pass the plugins you want installed as a list.
 ##
 plugins: []


### PR DESCRIPTION
Thought it might be useful to have the ability to, for example, call the Grafana API at the start of the pod so I added lifecycle hooks to the _pod.tpl file