### PR TITLE
[mimir-distributed] Add ingress to GEM gateway

### DIFF
--- a/charts/mimir-distributed/CHANGELOG.md
+++ b/charts/mimir-distributed/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the Pull Request that introduced the change.
 
+## 2.0.6
+
+* [ENHANCEMENT] Add option for an ingress on GEM gateway. #1266
+
 ## 2.0.5
 
 * [BUGFIX] Use new component name system for gateway ingress. This regression has been introduced with #1203. #1260

--- a/charts/mimir-distributed/Chart.yaml
+++ b/charts/mimir-distributed/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.0.5
+version: 2.0.6
 appVersion: 2.0.0
 description: "Grafana Mimir"
 engine: gotpl

--- a/charts/mimir-distributed/README.md
+++ b/charts/mimir-distributed/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/v2.0.x/)
 
 # mimir-distributed
 
-![Version: 2.0.5](https://img.shields.io/badge/Version-2.0.5-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.0.6](https://img.shields.io/badge/Version-2.0.6-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Mimir
 

--- a/charts/mimir-distributed/gem.yaml
+++ b/charts/mimir-distributed/gem.yaml
@@ -1,1 +1,0 @@
-useGEMLabels: true

--- a/charts/mimir-distributed/templates/gateway/_helpers.tpl
+++ b/charts/mimir-distributed/templates/gateway/_helpers.tpl
@@ -1,0 +1,33 @@
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "mimir.ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19-0" .Capabilities.KubeVersion.Version) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Return if ingress is stable.
+*/}}
+{{- define "mimir.ingress.isStable" -}}
+  {{- eq (include "mimir.ingress.apiVersion" .) "networking.k8s.io/v1" -}}
+{{- end -}}
+
+{{/*
+Return if ingress supports ingressClassName.
+*/}}
+{{- define "mimir.ingress.supportsIngressClassName" -}}
+  {{- or (eq (include "mimir.ingress.isStable" .) "true") (and (eq (include "mimir.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
+{{- end -}}
+
+{{/*
+Return if ingress supports pathType.
+*/}}
+{{- define "mimir.ingress.supportsPathType" -}}
+  {{- or (eq (include "mimir.ingress.isStable" .) "true") (and (eq (include "mimir.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
+{{- end -}}

--- a/charts/mimir-distributed/templates/gateway/gateway-ingress.yaml
+++ b/charts/mimir-distributed/templates/gateway/gateway-ingress.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.enterprise.enabled -}}
+{{- if .Values.gateway.ingress.enabled -}}
+{{- $ingressApiIsStable := eq (include "mimir.ingress.isStable" .) "true" -}}
+{{- $ingressSupportsIngressClassName := eq (include "mimir.ingress.supportsIngressClassName" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "mimir.ingress.supportsPathType" .) "true" -}}
+apiVersion: {{ include "mimir.ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "gateway") }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" . "component" "gateway") | nindent 4 }}
+  {{- with .Values.gateway.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and $ingressSupportsIngressClassName .Values.gateway.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.gateway.ingress.ingressClassName }}
+  {{- end -}}
+  {{- if .Values.gateway.ingress.tls }}
+  tls:
+    {{- range .Values.gateway.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      {{- with .secretName }}
+      secretName: {{ . }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.gateway.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if $ingressSupportsPathType }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if $ingressApiIsStable }}
+              service:
+                name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "gateway") }}
+                port:
+                  number: {{ $.Values.gateway.service.port }}
+              {{- else }}
+              serviceName: {{ include "mimir.resourceName" (dict "ctx" $ "component" "gateway") }}
+              servicePort: {{ $.Values.gateway.service.port }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/mimir-distributed/values.yaml
+++ b/charts/mimir-distributed/values.yaml
@@ -1506,7 +1506,7 @@ gateway:
     # -- Ingress Class Name. MAY be required for Kubernetes versions >= 1.18
     # ingressClassName: gateway
     # -- Annotations for the gateway ingress
-    annotations: { }
+    annotations: {}
     # -- Hosts configuration for the gateway ingress
     hosts:
       - host: gateway.gem.example.com

--- a/charts/mimir-distributed/values.yaml
+++ b/charts/mimir-distributed/values.yaml
@@ -1498,3 +1498,24 @@ gateway:
   affinity: {}
   tolerations: []
   terminationGracePeriodSeconds: 60
+
+  # Ingress configuration
+  ingress:
+    # -- Specifies whether an ingress for the gateway should be created
+    enabled: true
+    # -- Ingress Class Name. MAY be required for Kubernetes versions >= 1.18
+    # ingressClassName: gateway
+    # -- Annotations for the gateway ingress
+    annotations: { }
+    # -- Hosts configuration for the gateway ingress
+    hosts:
+      - host: gateway.gem.example.com
+        paths:
+          - path: /
+            # -- pathType (e.g. ImplementationSpecific, Prefix, .. etc.) might also be required by some Ingress Controllers
+            # pathType: Prefix
+    # -- TLS configuration for the gateway ingress
+    tls:
+      - secretName: gem-gateway-tls
+        hosts:
+          - gateway.gem.example.com


### PR DESCRIPTION
The GEM gateway does not come with an option to create an ingress resource. On the other hand, the nginx component comes with this option.

The config and templates were copied almost verbatim from the nginx ingress.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>