### PR TITLE
[mimir-distributed] Make GEM gateway svc port configurable

### DIFF
--- a/charts/mimir-distributed/CHANGELOG.md
+++ b/charts/mimir-distributed/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the Pull Request that introduced the change.
 
+## 2.0.7
+
+* [ENHANCEMENT] Add option to modify the port for the GEM gateway service. #1267
+
 ## 2.0.6
 
 * [ENHANCEMENT] Add option for an ingress on GEM gateway. #1266

--- a/charts/mimir-distributed/CHANGELOG.md
+++ b/charts/mimir-distributed/CHANGELOG.md
@@ -13,7 +13,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## 2.0.7
 
-* [ENHANCEMENT] Add option to modify the port for the GEM gateway service. #1267
+* [ENHANCEMENT] Add option to modify the port for the GEM gateway service. #1270
 
 ## 2.0.6
 

--- a/charts/mimir-distributed/Chart.yaml
+++ b/charts/mimir-distributed/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.0.6
+version: 2.0.7
 appVersion: 2.0.0
 description: "Grafana Mimir"
 engine: gotpl

--- a/charts/mimir-distributed/README.md
+++ b/charts/mimir-distributed/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/v2.0.x/)
 
 # mimir-distributed
 
-![Version: 2.0.6](https://img.shields.io/badge/Version-2.0.6-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.0.7](https://img.shields.io/badge/Version-2.0.7-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Mimir
 

--- a/charts/mimir-distributed/templates/gateway/gateway-svc.yaml
+++ b/charts/mimir-distributed/templates/gateway/gateway-svc.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: {{ include "mimir.serverHttpListenPort" . }}
+    - port: {{ .Values.gateway.service.port | default (include "mimir.serverHttpListenPort" . ) }}
       protocol: TCP
       name: http-metrics
       targetPort: http-metrics

--- a/charts/mimir-distributed/values.yaml
+++ b/charts/mimir-distributed/values.yaml
@@ -1460,6 +1460,8 @@ gateway:
   service:
     annotations: {}
     labels: {}
+    # If the port is left undefined, the service will listen on the same port as the pod
+    # port: 80
 
   strategy:
     type: RollingUpdate

--- a/charts/mimir-distributed/values.yaml
+++ b/charts/mimir-distributed/values.yaml
@@ -1460,8 +1460,8 @@ gateway:
   service:
     annotations: {}
     labels: {}
-    # If the port is left undefined, the service will listen on the same port as the pod
-    # port: 80
+    # -- If the port is left undefined, the service will listen on the same port as the pod
+    port: null
 
   strategy:
     type: RollingUpdate


### PR DESCRIPTION
The non-enterprise version of the chart has an nginx working as a
reverse proxy. That can have the exposed service port overridden in the
values.yaml. The enterprise equivalent does not allow this.

This PR changes the enterprise gateway to allow custom exposed ports.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>