### PR TITLE
fix(mimir-distributed): use new component naming in nginx helpers

### DIFF
--- a/charts/mimir-distributed/templates/nginx/_helpers.tpl
+++ b/charts/mimir-distributed/templates/nginx/_helpers.tpl
@@ -2,7 +2,7 @@
 nginx auth secret name
 */}}
 {{- define "mimir.nginxAuthSecret" -}}
-{{ .Values.nginx.basicAuth.existingSecret | default (include "mimir.nginxFullname" . ) }}
+{{ .Values.nginx.basicAuth.existingSecret | default (include "mimir.resourceName" (dict "ctx" . "component" "nginx") ) }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
This fixes deploying mimir with NGINX basic auth enabled, previously the old `mimir.nginxFullname` helper was used.