### PR TITLE
[grafana] bump chart to latest grafana version

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.26.5
-appVersion: 8.4.6
+version: 6.26.6
+appVersion: 8.5.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net


### PR DESCRIPTION
Bumping Grafana Helm Chart to version `8.5.0` 