### PR TITLE
[grafana] add liveness and readiness probes to sidecars

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.26.6
+version: 6.27.6
 appVersion: 8.5.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -149,6 +149,14 @@ initContainers:
       - name: SKIP_TLS_VERIFY
         value: "{{ .Values.sidecar.skipTlsVerify }}"
       {{- end }}
+{{- if .Values.sidecar.livenessProbe }}
+    livenessProbe:
+{{ toYaml .Values.livenessProbe | indent 6 }}
+{{- end }}
+{{- if .Values.sidecar.readinessProbe }}
+    readinessProbe:
+{{ toYaml .Values.readinessProbe | indent 6 }}
+{{- end }}
     resources:
 {{ toYaml .Values.sidecar.resources | indent 6 }}
 {{- if .Values.sidecar.securityContext }}
@@ -221,6 +229,14 @@ containers:
       - name: WATCH_CLIENT_TIMEOUT
         value: "{{ .Values.sidecar.dashboards.watchClientTimeout }}"
       {{- end }}
+{{- if .Values.sidecar.livenessProbe }}
+    livenessProbe:
+{{ toYaml .Values.livenessProbe | indent 6 }}
+{{- end }}
+{{- if .Values.sidecar.readinessProbe }}
+    readinessProbe:
+{{ toYaml .Values.readinessProbe | indent 6 }}
+{{- end }}
     resources:
 {{ toYaml .Values.sidecar.resources | indent 6 }}
 {{- if .Values.sidecar.securityContext }}
@@ -287,6 +303,14 @@ containers:
       - name: REQ_METHOD
         value: POST
       {{- end }}
+{{- if .Values.sidecar.livenessProbe }}
+    livenessProbe:
+{{ toYaml .Values.livenessProbe | indent 6 }}
+{{- end }}
+{{- if .Values.sidecar.readinessProbe }}
+    readinessProbe:
+{{ toYaml .Values.readinessProbe | indent 6 }}
+{{- end }}
     resources:
 {{ toYaml .Values.sidecar.resources | indent 6 }}
 {{- if .Values.sidecar.securityContext }}
@@ -350,6 +374,14 @@ containers:
       - name: REQ_METHOD
         value: POST
       {{- end }}
+{{- if .Values.sidecar.livenessProbe }}
+    livenessProbe:
+{{ toYaml .Values.livenessProbe | indent 6 }}
+{{- end }}
+{{- if .Values.sidecar.readinessProbe }}
+    readinessProbe:
+{{ toYaml .Values.readinessProbe | indent 6 }}
+{{- end }}
     resources:
 {{ toYaml .Values.sidecar.resources | indent 6 }}
 {{- if .Values.sidecar.securityContext }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -654,6 +654,8 @@ sidecar:
   # skipTlsVerify Set to true to skip tls verification for kube api calls
   # skipTlsVerify: true
   enableUniqueFilenames: false
+  readinessProbe: {}
+  livenessProbe: {}
   dashboards:
     enabled: false
     SCProvider: true


### PR DESCRIPTION
Adding optional liveness and readiness probes to the k8s-sidecar. This is needed for deploying into environments that require the use of liveness/readiness probes for all running containers. If the probe configuration is passed, it is added to each sidecar that is enabled.

Example:

```yaml
sidecar:
  livenessProbe:
    exec:
      command:
        - /bin/true
  readinessProbe:
    exec:
      command:
        - /bin/true
```