### PR TITLE
[mimir-distributed] make ruler and override-exporter optional components

### DIFF
--- a/charts/mimir-distributed/CHANGELOG.md
+++ b/charts/mimir-distributed/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the Pull Request that introduced the change.
 
+## 2.0.11
+
+* [ENHANCEMENT] Turn `ruler` and `override-exporter` into optional components. #1304
+
 ## 2.0.10
 
 * [ENHANCEMENT] Reorder some values for consistency. #1302

--- a/charts/mimir-distributed/Chart.yaml
+++ b/charts/mimir-distributed/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.0.10
+version: 2.0.11
 appVersion: 2.0.0
 description: "Grafana Mimir"
 engine: gotpl

--- a/charts/mimir-distributed/README.md
+++ b/charts/mimir-distributed/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/v2.0.x/)
 
 # mimir-distributed
 
-![Version: 2.0.10](https://img.shields.io/badge/Version-2.0.10-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.0.11](https://img.shields.io/badge/Version-2.0.11-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Mimir
 

--- a/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.overrides_exporter.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -115,3 +116,4 @@ spec:
         {{- end }}
         - name: storage
           emptyDir: {}
+{{- end -}}

--- a/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-pdb.yaml
+++ b/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-pdb.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.overrides_exporter.enabled -}}
 {{- if .Values.overrides_exporter.podDisruptionBudget -}}
 apiVersion: {{ include "mimir.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
@@ -10,4 +11,5 @@ spec:
     matchLabels:
       {{- include "mimir.selectorLabels" (dict "ctx" . "component" "overrides-exporter") | nindent 6 }}
 {{ toYaml .Values.overrides_exporter.podDisruptionBudget | indent 2 }}
+{{- end -}}
 {{- end -}}

--- a/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
+++ b/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.overrides_exporter.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -22,3 +23,4 @@ spec:
       targetPort: grpc
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "overrides-exporter") | nindent 4 }}
+{{- end -}}

--- a/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ruler.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -115,3 +116,4 @@ spec:
 {{- end }}
         - name: storage
           emptyDir: {}
+{{- end -}}

--- a/charts/mimir-distributed/templates/ruler/ruler-pdb.yaml
+++ b/charts/mimir-distributed/templates/ruler/ruler-pdb.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ruler.enabled -}}
 {{- if .Values.ruler.podDisruptionBudget -}}
 apiVersion: {{ include "mimir.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
@@ -10,4 +11,5 @@ spec:
     matchLabels:
       {{- include "mimir.selectorLabels" (dict "ctx" . "component" "ruler" "memberlist" true) | nindent 6 }}
 {{ toYaml .Values.ruler.podDisruptionBudget | indent 2 }}
+{{- end -}}
 {{- end -}}

--- a/charts/mimir-distributed/templates/ruler/ruler-servmon.yaml
+++ b/charts/mimir-distributed/templates/ruler/ruler-servmon.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ruler.enabled -}}
 {{- with .Values.serviceMonitor }}
 {{- if .enabled }}
 apiVersion: monitoring.coreos.com/v1
@@ -48,5 +49,6 @@ spec:
       tlsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/mimir-distributed/templates/ruler/ruler-svc.yaml
+++ b/charts/mimir-distributed/templates/ruler/ruler-svc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ruler.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,3 +19,4 @@ spec:
       targetPort: http-metrics
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "ruler" "memberlist" true) | nindent 4 }}
+{{- end -}}

--- a/charts/mimir-distributed/values.yaml
+++ b/charts/mimir-distributed/values.yaml
@@ -532,6 +532,7 @@ ingester:
   env: []
 
 overrides_exporter:
+  enabled: true
   replicas: 1
 
   annotations: {}
@@ -588,6 +589,7 @@ overrides_exporter:
   env: []
 
 ruler:
+  enabled: true
   replicas: 1
 
   service:


### PR DESCRIPTION
Signed-off-by: Miguel Ángel Ortuño <ortuman@gmail.com>

Turn `ruler` and `override-exporter` into optional components. 