### PR TITLE
[mimir-distributed] add memberlist named pod port

### DIFF
--- a/charts/mimir-distributed/CHANGELOG.md
+++ b/charts/mimir-distributed/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the Pull Request that introduced the change.
 
+## 2.0.12
+
+* [ENHANCEMENT] Added memberlist named service port. #1305
+
 ## 2.0.10
 
 * [ENHANCEMENT] Reorder some values for consistency. #1302

--- a/charts/mimir-distributed/Chart.yaml
+++ b/charts/mimir-distributed/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.0.10
+version: 2.0.12
 appVersion: 2.0.0
 description: "Grafana Mimir"
 engine: gotpl

--- a/charts/mimir-distributed/README.md
+++ b/charts/mimir-distributed/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/v2.0.x/)
 
 # mimir-distributed
 
-![Version: 2.0.10](https://img.shields.io/badge/Version-2.0.10-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.0.12](https://img.shields.io/badge/Version-2.0.12-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Mimir
 

--- a/charts/mimir-distributed/templates/admin-api/admin-api-svc.yaml
+++ b/charts/mimir-distributed/templates/admin-api/admin-api-svc.yaml
@@ -21,6 +21,10 @@ spec:
       protocol: TCP
       name: grpc
       targetPort: grpc
+    - port: {{ include "mimir.memberlistBindPort" . }}
+      protocol: TCP
+      name: memberlist
+      targetPort: memberlist
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "admin-api" "memberlist" true) | nindent 4 }}
 {{- end -}}

--- a/charts/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
+++ b/charts/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
@@ -21,6 +21,10 @@ spec:
       protocol: TCP
       name: grpc
       targetPort: grpc
+    - port: {{ include "mimir.memberlistBindPort" . }}
+      protocol: TCP
+      name: memberlist
+      targetPort: memberlist
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "alertmanager" "memberlist" true) | nindent 4 }}
 {{- end -}}

--- a/charts/mimir-distributed/templates/compactor/compactor-svc.yaml
+++ b/charts/mimir-distributed/templates/compactor/compactor-svc.yaml
@@ -20,5 +20,9 @@ spec:
       protocol: TCP
       name: grpc
       targetPort: grpc
+    - port: {{ include "mimir.memberlistBindPort" . }}
+      protocol: TCP
+      name: memberlist
+      targetPort: memberlist
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "compactor" "memberlist" true) | nindent 4 }}

--- a/charts/mimir-distributed/templates/distributor/distributor-svc.yaml
+++ b/charts/mimir-distributed/templates/distributor/distributor-svc.yaml
@@ -20,5 +20,9 @@ spec:
       protocol: TCP
       name: grpc
       targetPort: grpc
+    - port: {{ include "mimir.memberlistBindPort" . }}
+      protocol: TCP
+      name: memberlist
+      targetPort: memberlist
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "distributor" "memberlist" true) | nindent 4 }}

--- a/charts/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/charts/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -20,5 +20,9 @@ spec:
       protocol: TCP
       name: grpc
       targetPort: grpc
+    - port: {{ include "mimir.memberlistBindPort" . }}
+      protocol: TCP
+      name: memberlist
+      targetPort: memberlist
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "ingester" "memberlist" true) | nindent 4 }}

--- a/charts/mimir-distributed/templates/querier/querier-svc.yaml
+++ b/charts/mimir-distributed/templates/querier/querier-svc.yaml
@@ -20,5 +20,9 @@ spec:
       protocol: TCP
       name: grpc
       targetPort: grpc
+    - port: {{ include "mimir.memberlistBindPort" . }}
+      protocol: TCP
+      name: memberlist
+      targetPort: memberlist
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "querier" "memberlist" true) | nindent 4 }}

--- a/charts/mimir-distributed/templates/ruler/ruler-svc.yaml
+++ b/charts/mimir-distributed/templates/ruler/ruler-svc.yaml
@@ -16,5 +16,9 @@ spec:
       protocol: TCP
       name: http-metrics
       targetPort: http-metrics
+    - port: {{ include "mimir.memberlistBindPort" . }}
+      protocol: TCP
+      name: memberlist
+      targetPort: memberlist
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "ruler" "memberlist" true) | nindent 4 }}

--- a/charts/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/charts/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -20,5 +20,9 @@ spec:
       protocol: TCP
       name: grpc
       targetPort: grpc
+    - port: {{ include "mimir.memberlistBindPort" . }}
+      protocol: TCP
+      name: memberlist
+      targetPort: memberlist
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "store-gateway" "memberlist" true) | nindent 4 }}


### PR DESCRIPTION
Signed-off-by: Miguel Ángel Ortuño <ortuman@gmail.com>

Add memberlist service named port to all components that depend on it.