### PR TITLE
[mimir-distributed] exclude headless services from ServiceMonitors to prevent duplication of prometheus scrape targets

### DIFF
--- a/charts/mimir-distributed/CHANGELOG.md
+++ b/charts/mimir-distributed/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the Pull Request that introduced the change.
 
+## 2.0.14
+
+* [BUGFIX] exclude headless services from ServiceMonitors to prevent duplication of prometheus scrape targets #1308
+
 ## 2.0.13
 
 * [ENHANCEMENT] Removed `rbac.create` option. #1317

--- a/charts/mimir-distributed/Chart.yaml
+++ b/charts/mimir-distributed/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.0.13
+version: 2.0.14
 appVersion: 2.0.0
 description: "Grafana Mimir"
 engine: gotpl

--- a/charts/mimir-distributed/README.md
+++ b/charts/mimir-distributed/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/v2.0.x/)
 
 # mimir-distributed
 
-![Version: 2.0.13](https://img.shields.io/badge/Version-2.0.13-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.0.14](https://img.shields.io/badge/Version-2.0.14-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Mimir
 

--- a/charts/mimir-distributed/templates/alertmanager/alertmanager-servmon.yaml
+++ b/charts/mimir-distributed/templates/alertmanager/alertmanager-servmon.yaml
@@ -25,6 +25,11 @@ spec:
   selector:
     matchLabels:
       {{- include "mimir.selectorLabels" (dict "ctx" $ "component" "alertmanager" "memberlist" true) | nindent 6 }}
+    matchExpressions:
+      - key: prometheus.io/service-monitor
+        operator: NotIn
+        values:
+          - "false"
   endpoints:
     - port: http-metrics
       {{- with .interval }}

--- a/charts/mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
+++ b/charts/mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "alertmanager") }}-headless
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "alertmanager" "memberlist" true) | nindent 4 }}
+    prometheus.io/service-monitor: "false"
     {{- with .Values.alertmanager.service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/mimir-distributed/templates/ingester/ingester-servmon.yaml
+++ b/charts/mimir-distributed/templates/ingester/ingester-servmon.yaml
@@ -24,6 +24,11 @@ spec:
   selector:
     matchLabels:
       {{- include "mimir.selectorLabels" (dict "ctx" $ "component" "ingester" "memberlist" true) | nindent 6 }}
+    matchExpressions:
+      - key: prometheus.io/service-monitor
+        operator: NotIn
+        values:
+          - "false"
   endpoints:
     - port: http-metrics
       {{- with .interval }}

--- a/charts/mimir-distributed/templates/ingester/ingester-svc-headless.yaml
+++ b/charts/mimir-distributed/templates/ingester/ingester-svc-headless.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ingester") }}-headless
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "ingester" "memberlist" true) | nindent 4 }}
+    prometheus.io/service-monitor: "false"
     {{- with .Values.ingester.service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/mimir-distributed/templates/query-frontend/query-frontend-servmon.yaml
+++ b/charts/mimir-distributed/templates/query-frontend/query-frontend-servmon.yaml
@@ -24,6 +24,11 @@ spec:
   selector:
     matchLabels:
       {{- include "mimir.selectorLabels" (dict "ctx" $ "component" "query-frontend") | nindent 6 }}
+    matchExpressions:
+      - key: prometheus.io/service-monitor
+        operator: NotIn
+        values:
+          - "false"
   endpoints:
     - port: http-metrics
       {{- with .interval }}

--- a/charts/mimir-distributed/templates/query-frontend/query-frontend-svc-headless.yaml
+++ b/charts/mimir-distributed/templates/query-frontend/query-frontend-svc-headless.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "query-frontend") }}-headless
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "query-frontend") | nindent 4 }}
+    prometheus.io/service-monitor: "false"
     {{- with .Values.query_frontend.service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/mimir-distributed/templates/store-gateway/store-gateway-servmon.yaml
+++ b/charts/mimir-distributed/templates/store-gateway/store-gateway-servmon.yaml
@@ -24,6 +24,11 @@ spec:
   selector:
     matchLabels:
       {{- include "mimir.selectorLabels" (dict "ctx" $ "component" "store-gateway" "memberlist" true) | nindent 6 }}
+    matchExpressions:
+      - key: prometheus.io/service-monitor
+        operator: NotIn
+        values:
+          - "false"
   endpoints:
     - port: http-metrics
       {{- with .interval }}

--- a/charts/mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
+++ b/charts/mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "store-gateway") }}-headless
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "store-gateway" "memberlist" true) | nindent 4 }}
+    prometheus.io/service-monitor: "false"
     {{- with .Values.store_gateway.service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
this was how i fixed https://github.com/grafana/helm-charts/issues/1307 in our setup

I'm open to other, more elegant solutions, or a rename of the service label to something else.

Because the mimir-jsonnet only has a headless service, I was tempted to remove the non-headless service from the helm chart, but decided against that.