### PR TITLE
[mimir-distributed] add named port memberlist to pod container

### DIFF
--- a/charts/mimir-distributed/CHANGELOG.md
+++ b/charts/mimir-distributed/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the Pull Request that introduced the change.
 
+## 2.0.12
+
+* [ENHANCEMENT] Add memberlist named port to container spec.
+
 ## 2.0.11
 
 * [ENHANCEMENT] Turn `ruler` and `override-exporter` into optional components. #1304

--- a/charts/mimir-distributed/CHANGELOG.md
+++ b/charts/mimir-distributed/CHANGELOG.md
@@ -13,7 +13,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## 2.0.12
 
-* [ENHANCEMENT] Add memberlist named port to container spec.
+* [ENHANCEMENT] Add memberlist named port to container spec. #1311
 
 ## 2.0.11
 

--- a/charts/mimir-distributed/Chart.yaml
+++ b/charts/mimir-distributed/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.0.11
+version: 2.0.12
 appVersion: 2.0.0
 description: "Grafana Mimir"
 engine: gotpl

--- a/charts/mimir-distributed/README.md
+++ b/charts/mimir-distributed/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/v2.0.x/)
 
 # mimir-distributed
 
-![Version: 2.0.11](https://img.shields.io/badge/Version-2.0.11-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.0.12](https://img.shields.io/badge/Version-2.0.12-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Mimir
 

--- a/charts/mimir-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/charts/mimir-distributed/templates/admin-api/admin-api-dep.yaml
@@ -77,6 +77,9 @@ spec:
             - name: grpc
               containerPort: {{ include "mimir.serverGrpcListenPort" . }}
               protocol: TCP
+            - name: memberlist
+              containerPort: {{ include "mimir.memberlistBindPort" . }}
+              protocol: TCP
           livenessProbe:
             {{- toYaml .Values.admin_api.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
+++ b/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
@@ -80,6 +80,9 @@ spec:
             - name: grpc
               containerPort: {{ include "mimir.serverGrpcListenPort" . }}
               protocol: TCP
+            - name: memberlist
+              containerPort: {{ include "mimir.memberlistBindPort" . }}
+              protocol: TCP
           livenessProbe:
             {{- toYaml .Values.alertmanager.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -137,6 +137,9 @@ spec:
             - name: grpc
               containerPort: {{ include "mimir.serverGrpcListenPort" . }}
               protocol: TCP
+            - name: memberlist
+              containerPort: {{ include "mimir.memberlistBindPort" . }}
+              protocol: TCP
           livenessProbe:
             {{- toYaml .Values.alertmanager.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -130,6 +130,9 @@ spec:
             - name: grpc
               containerPort: {{ include "mimir.serverGrpcListenPort" . }}
               protocol: TCP
+            - name: memberlist
+              containerPort: {{ include "mimir.memberlistBindPort" . }}
+              protocol: TCP
           livenessProbe:
             {{- toYaml .Values.compactor.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -76,6 +76,9 @@ spec:
             - name: grpc
               containerPort: {{ include "mimir.serverGrpcListenPort" . }}
               protocol: TCP
+            - name: memberlist
+              containerPort: {{ include "mimir.memberlistBindPort" . }}
+              protocol: TCP
           livenessProbe:
             {{- toYaml .Values.distributor.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -133,6 +133,9 @@ spec:
             - name: grpc
               containerPort: {{ include "mimir.serverGrpcListenPort" . }}
               protocol: TCP
+            - name: memberlist
+              containerPort: {{ include "mimir.memberlistBindPort" . }}
+              protocol: TCP
           livenessProbe:
             {{- toYaml .Values.ingester.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/charts/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/charts/mimir-distributed/templates/querier/querier-dep.yaml
@@ -76,6 +76,9 @@ spec:
             - name: grpc
               containerPort: {{ include "mimir.serverGrpcListenPort" . }}
               protocol: TCP
+            - name: memberlist
+              containerPort: {{ include "mimir.memberlistBindPort" . }}
+              protocol: TCP
           livenessProbe:
             {{- toYaml .Values.querier.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -77,6 +77,9 @@ spec:
             - name: grpc
               containerPort: {{ include "mimir.serverGrpcListenPort" . }}
               protocol: TCP
+            - name: memberlist
+              containerPort: {{ include "mimir.memberlistBindPort" . }}
+              protocol: TCP
           livenessProbe:
             {{- toYaml .Values.ruler.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -129,7 +129,10 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: {{ include "mimir.serverGrpcListenPort" . }}
-              protocol: TCP            
+              protocol: TCP
+            - name: memberlist
+              containerPort: {{ include "mimir.memberlistBindPort" . }}
+              protocol: TCP
           livenessProbe:
             {{- toYaml .Values.store_gateway.livenessProbe | nindent 12 }}
           readinessProbe:


### PR DESCRIPTION
Signed-off-by: Miguel Ángel Ortuño <ortuman@gmail.com>

Add memberlist container named port to all components that depend on it.