### PR TITLE
[grafana] set sizeLimit for k8s-sidecar emptyDir volume

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.27.0
+version: 6.28.0
 appVersion: 8.5.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -669,7 +669,12 @@ volumes:
 {{- end -}}
 {{- if .Values.sidecar.dashboards.enabled }}
   - name: sc-dashboard-volume
+{{- if .Values.sidecar.dashboards.sizeLimit }}
+    emptyDir:
+      sizeLimit: {{ .Values.sidecar.dashboards.sizeLimit }}
+{{- else }}
     emptyDir: {}
+{{- end -}}
 {{- if .Values.sidecar.dashboards.SCProvider }}
   - name: sc-dashboard-provider
     configMap:
@@ -678,15 +683,30 @@ volumes:
 {{- end }}
 {{- if .Values.sidecar.datasources.enabled }}
   - name: sc-datasources-volume
+{{- if .Values.sidecar.datasources.sizeLimit }}
+    emptyDir:
+      sizeLimit: {{ .Values.sidecar.datasources.sizeLimit }}
+{{- else }}
     emptyDir: {}
+{{- end -}}
 {{- end -}}
 {{- if .Values.sidecar.plugins.enabled }}
   - name: sc-plugins-volume
+{{- if .Values.sidecar.plugins.sizeLimit }}
+    emptyDir:
+      sizeLimit: {{ .Values.sidecar.plugins.sizeLimit }}
+{{- else }}
     emptyDir: {}
+{{- end -}}
 {{- end -}}
 {{- if .Values.sidecar.notifiers.enabled }}
   - name: sc-notifiers-volume
+{{- if .Values.sidecar.notifiers.sizeLimit }}
+    emptyDir:
+      sizeLimit: {{ .Values.sidecar.notifiers.sizeLimit }}
+{{- else }}
     emptyDir: {}
+{{- end -}}
 {{- end -}}
 {{- range .Values.extraSecretMounts }}
 {{- if .secretName }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -708,6 +708,8 @@ sidecar:
       foldersFromFilesStructure: false
     # Additional dashboard sidecar volume mounts
     extraMounts: []
+    # Sets the size limit of the dashboard sidecar emptyDir volume
+    sizeLimit: {}
   datasources:
     enabled: false
     # label that the configmaps with datasources are marked with
@@ -728,6 +730,8 @@ sidecar:
     # Deploy the datasource sidecar as an initContainer in addition to a container.
     # This is needed if skipReload is true, to load any datasources defined at startup time.
     initDatasources: false
+    # Sets the size limit of the datasource sidecar emptyDir volume
+    sizeLimit: {}
   plugins:
     enabled: false
     # label that the configmaps with plugins are marked with
@@ -748,6 +752,8 @@ sidecar:
     # Deploy the datasource sidecar as an initContainer in addition to a container.
     # This is needed if skipReload is true, to load any plugins defined at startup time.
     initPlugins: false
+    # Sets the size limit of the plugin sidecar emptyDir volume
+    sizeLimit: {}
   notifiers:
     enabled: false
     # label that the configmaps with notifiers are marked with
@@ -758,6 +764,8 @@ sidecar:
     searchNamespace: null
     # search in configmap, secret or both
     resource: both
+    # Sets the size limit of the notifier sidecar emptyDir volume
+    sizeLimit: {}
 
 ## Override the deployment namespace
 ##


### PR DESCRIPTION
Adding an optional sizeLimit for the k8s-sidecar emptyDir volumes. This sets the total amount of local storage required for the emptyDir volume. If not set, the default is nil which means that the limit is undefined.

Example:

```yaml
datasources:
  enabled: true
  sizeLimit: 1Gi
dashboards:
  enabled: true
  sizeLimit: 2Gi
```