### PR TITLE
[mimir-distributed] remove rbac.create option

### DIFF
--- a/charts/mimir-distributed/CHANGELOG.md
+++ b/charts/mimir-distributed/CHANGELOG.md
@@ -13,7 +13,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## 2.0.13
 
-* [ENHANCEMENT] Merge rbac options into a single `rbacEnabled` flag. #1317
+* [ENHANCEMENT] Removed `rbac.create` option. #1317
 
 ## 2.0.12
 

--- a/charts/mimir-distributed/CHANGELOG.md
+++ b/charts/mimir-distributed/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the Pull Request that introduced the change.
 
+## 2.0.13
+
+* [ENHANCEMENT] Merge rbac options into a single `rbacEnabled` flag. #1317
+
 ## 2.0.12
 
 * [ENHANCEMENT] Add memberlist named port to container spec. #1311

--- a/charts/mimir-distributed/Chart.yaml
+++ b/charts/mimir-distributed/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.0.12
+version: 2.0.13
 appVersion: 2.0.0
 description: "Grafana Mimir"
 engine: gotpl

--- a/charts/mimir-distributed/README.md
+++ b/charts/mimir-distributed/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/v2.0.x/)
 
 # mimir-distributed
 
-![Version: 2.0.12](https://img.shields.io/badge/Version-2.0.12-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.0.13](https://img.shields.io/badge/Version-2.0.13-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Mimir
 

--- a/charts/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/charts/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbacEnabled }}
+{{- if .Values.rbac.pspEnabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/charts/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.pspEnabled }}
+{{- if .Values.rbacEnabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/mimir-distributed/templates/role.yaml
+++ b/charts/mimir-distributed/templates/role.yaml
@@ -1,15 +1,13 @@
-{{- if .Values.rbac.create }}
+{{- if .Values.rbacEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" .) }}
   labels:
     {{- include "mimir.labels" (dict "ctx" .) | nindent 4 }}
-{{- if .Values.rbac.pspEnabled }}
 rules:
 - apiGroups:      ['extensions']
   resources:      ['podsecuritypolicies']
   verbs:          ['use']
   resourceNames:  [{{ include "mimir.resourceName" (dict "ctx" .) }}]
-{{- end }}
 {{- end }}

--- a/charts/mimir-distributed/templates/role.yaml
+++ b/charts/mimir-distributed/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbacEnabled }}
+{{- if .Values.rbac.pspEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/mimir-distributed/templates/rolebinding.yaml
+++ b/charts/mimir-distributed/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbacEnabled }}
+{{- if .Values.rbac.pspEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/mimir-distributed/templates/rolebinding.yaml
+++ b/charts/mimir-distributed/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if .Values.rbacEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/mimir-distributed/values.yaml
+++ b/charts/mimir-distributed/values.yaml
@@ -223,7 +223,9 @@ mimir:
 # runtimeConfig provides a reloadable runtime configuration file for some specific configuration.
 runtimeConfig: {}
 
-rbacEnabled: true
+# RBAC configuration
+rbac:
+  pspEnabled: true
 
 # ServiceMonitor configuration
 serviceMonitor:

--- a/charts/mimir-distributed/values.yaml
+++ b/charts/mimir-distributed/values.yaml
@@ -223,9 +223,7 @@ mimir:
 # runtimeConfig provides a reloadable runtime configuration file for some specific configuration.
 runtimeConfig: {}
 
-rbac:
-  create: true
-  pspEnabled: true
+rbacEnabled: true
 
 # ServiceMonitor configuration
 serviceMonitor:


### PR DESCRIPTION
Signed-off-by: Miguel Ángel Ortuño <ortuman@gmail.com>

~~This PR merges `rbac.create` and `rbac.pspEnabled` options into a single `rbacEnabled` flag.~~

Removed `rbac.create` option.

fixes: #1300 