### PR TITLE
[tempo-distributed] Fix ingester values

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.17.0
+version: 0.17.1
 appVersion: 1.4.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -469,14 +469,14 @@ config: |
         kvstore:
           store: memberlist
       tokens_file_path: /var/tempo/tokens.json
-    {{- if .Values.ingester.config.maxBlockBytes }}
-    max_block_bytes: {{ .Values.ingester.config.maxBlockBytes }}
+    {{- if .Values.ingester.config.max_block_bytes }}
+    max_block_bytes: {{ .Values.ingester.config.max_block_bytes }}
     {{- end }}
-    {{- if .Values.ingester.config.maxBlockDuration }}
-    max_block_duration: {{ .Values.ingester.config.maxBlockDuration }}
+    {{- if .Values.ingester.config.max_block_duration }}
+    max_block_duration: {{ .Values.ingester.config.max_block_duration }}
     {{- end }}
-    {{- if .Values.ingester.config.completeBlockTimeout }}
-    complete_block_timeout: {{ .Values.ingester.config.completeBlockTimeout }}
+    {{- if .Values.ingester.config.complete_block_timeout }}
+    complete_block_timeout: {{ .Values.ingester.config.complete_block_timeout }}
     {{- end }}
   memberlist:
     abort_if_cluster_join_fails: false


### PR DESCRIPTION
In the values, ingester.config.max_block_bytes was exposed but it was ingester.config.maxBlockBytes that was used in the configmap. Same goes for max_block_duration and complete_block_timeout.