### PR TITLE
[loki-simple-scalable] Make enterprise a configurable option

### DIFF
--- a/charts/loki-simple-scalable/Chart.lock
+++ b/charts/loki-simple-scalable/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: minio
+  repository: https://helm.min.io/
+  version: 8.0.9
+digest: sha256:87380dcd409a28ba7ece02fff63993a66077cba05350dbae0b60b3dd410d04df
+generated: "2022-04-22T16:01:21.40225696-06:00"

--- a/charts/loki-simple-scalable/Chart.yaml
+++ b/charts/loki-simple-scalable/Chart.yaml
@@ -3,12 +3,18 @@ name: loki-simple-scalable
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.5.0
-version: 0.4.0
+version: 1.0.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki
   - https://grafana.com/oss/loki/
   - https://grafana.com/docs/loki/latest/
 icon: https://grafana.com/docs/loki/latest/logo_and_name.png
+dependencies:
+  - name: minio
+    alias: minio
+    version: 8.0.9
+    repository: https://helm.min.io/
+    condition: minio.enabled
 maintainers:
   - name: trevorwhitney

--- a/charts/loki-simple-scalable/ci/default-values.yaml
+++ b/charts/loki-simple-scalable/ci/default-values.yaml
@@ -1,0 +1,8 @@
+---
+loki:
+  commonConfig:
+    replication_factor: 1
+read:
+  replicas: 1
+write:
+  replicas: 1

--- a/charts/loki-simple-scalable/ci/enterprise.yaml
+++ b/charts/loki-simple-scalable/ci/enterprise.yaml
@@ -1,0 +1,25 @@
+---
+enterprise:
+  enabled: true
+  config: |
+    auth:
+      type: trust
+    auth_enabled: false
+    cluster_name: {{ .Release.Name }}
+    license:
+      path: /etc/loki/license/license.jwt
+loki:
+  commonConfig:
+    replication_factor: 1
+storage:
+  type: local
+read:
+  replicas: 1
+  persistence:
+    enabled: true
+    size: 100Mi
+write:
+  replicas: 1
+  persistence:
+    enabled: true
+    size: 100Mi

--- a/charts/loki-simple-scalable/ci/ingress-values.yaml
+++ b/charts/loki-simple-scalable/ci/ingress-values.yaml
@@ -1,3 +1,4 @@
+---
 gateway:
   ingress:
     enabled: true
@@ -7,3 +8,10 @@ gateway:
         paths:
           - path: /
             pathType: Prefix
+loki:
+  commonConfig:
+    replication_factor: 1
+read:
+  replicas: 1
+write:
+  replicas: 1

--- a/charts/loki-simple-scalable/ci/persistence-values.yaml
+++ b/charts/loki-simple-scalable/ci/persistence-values.yaml
@@ -1,12 +1,18 @@
 read:
+  replicas: 1
   persistence:
     enabled: true
     size: 100Mi
 
 write:
+  replicas: 1
   persistence:
     enabled: true
     size: 100Mi
+
+loki:
+  commonConfig:
+    replication_factor: 1
 
 gateway:
   nginxConfig:

--- a/charts/loki-simple-scalable/templates/_helpers.tpl
+++ b/charts/loki-simple-scalable/templates/_helpers.tpl
@@ -2,7 +2,8 @@
 Expand the name of the chart.
 */}}
 {{- define "loki.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- $default := ternary "enterprise-logs" "loki" .Values.enterprise.enabled }}
+{{- coalesce .Values.nameOverride $default | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -14,7 +15,7 @@ If release name contains chart name it will be used as a full name.
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- $name := include "loki.name" . }}
 {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -74,22 +75,76 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
+Base template for building docker image reference
+*/}}
+{{- define "loki.baseImage" }}
+{{- $registry := .global.registry | default .service.registry -}}
+{{- $repository := .service.repository -}}
+{{- $tag := .service.tag | default .defaultVersion | toString -}}
+{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- end -}}
+
+{{/*
 Docker image name for Loki
 */}}
 {{- define "loki.lokiImage" -}}
-{{- $registry := coalesce .global.registry .service.registry .loki.registry -}}
-{{- $repository := coalesce .service.repository .loki.repository -}}
-{{- $tag := coalesce .service.tag .loki.tag .defaultVersion | toString -}}
-{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- $dict := dict "service" .Values.loki.image "global" .Values.global.image "defaultVersion" .Chart.AppVersion -}}
+{{- include "loki.baseImage" $dict -}}
+{{- end -}}
+
+{{/*
+Docker image name for enterprise logs
+*/}}
+{{- define "loki.enterpriseImage" -}}
+{{- $dict := dict "service" .Values.enterprise.image "global" .Values.global.image "defaultVersion" .Values.enterprise.version -}}
+{{- include "loki.baseImage" $dict -}}
+{{/* {{- printf "foo" -}} */}}
 {{- end -}}
 
 {{/*
 Docker image name
 */}}
 {{- define "loki.image" -}}
-{{- $registry := coalesce .global.registry .service.registry -}}
-{{- $tag := .service.tag | toString -}}
-{{- printf "%s/%s:%s" $registry .service.repository (.service.tag | toString) -}}
+{{- if .Values.enterprise.enabled -}}{{- include "loki.enterpriseImage" . -}}{{- else -}}{{- include "loki.lokiImage" . -}}{{- end -}}
+{{- end -}}
+
+{{/*
+Generated storage config for loki common config
+*/}}
+{{- define "loki.commonStorageConfig" -}}
+{{- if .Values.minio.enabled -}}
+s3:
+  endpoint: {{ include "loki.minio" $ }}
+  bucketnames: {{ $.Values.loki.storage.bucketNames.chunks }}
+  secret_access_key: supersecret
+  access_key_id: enterprise-logs
+  s3forcepathstyle: true
+  insecure: true
+{{- else if eq .Values.loki.storage.type "s3" -}}
+{{- with .Values.loki.storage.s3 }}
+s3:
+  endpoint: {{ .endpoint }}
+  bucketnames: {{ $.Values.loki.storage.bucketNames.chunks }}
+  secret_access_key: {{ .secretAccessKey }}
+  access_key_id: {{ .accessKeyId }}
+  s3forcepathstyle: {{ .s3ForcePathStyle }}
+  insecure: {{ .insecure }}
+{{- end -}}
+{{- else if eq .Values.loki.storage.type "gcs" -}}
+{{- with .Values.loki.storage.gcs }}
+gcs:
+  bucket_name: {{ $.Values.loki.storage.bucketNames.chunks }}
+  chunk_buffer_size: {{ .chunkBufferSize }}
+  request_timeout: {{ .requestTimeout }}
+  enable_http2: {{ .enableHttp2}}
+{{- end -}}
+{{- else -}}
+{{- with .Values.loki.storage.local }}
+filesystem:
+  chunks_directory: {{ .chunksDirectory }}
+  rules_directory: {{ .rulesDirectory }}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -140,4 +195,13 @@ Return if ingress supports pathType.
 */}}
 {{- define "loki.ingress.supportsPathType" -}}
   {{- or (eq (include "loki.ingress.isStable" .) "true") (and (eq (include "loki.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
+{{- end -}}
+
+{{/*
+Create the service endpoint including port for MinIO.
+*/}}
+{{- define "loki.minio" -}}
+{{- if .Values.minio.enabled -}}
+{{- printf "%s-%s.%s.svc:%s" .Release.Name "minio" .Release.Namespace (.Values.minio.service.port | toString) -}}
+{{- end -}}
 {{- end -}}

--- a/charts/loki-simple-scalable/templates/_helpers.tpl
+++ b/charts/loki-simple-scalable/templates/_helpers.tpl
@@ -123,6 +123,7 @@ s3:
 {{- else if eq .Values.loki.storage.type "s3" -}}
 {{- with .Values.loki.storage.s3 }}
 s3:
+  s3: {{ .s3 }}
   endpoint: {{ .endpoint }}
   bucketnames: {{ $.Values.loki.storage.bucketNames.chunks }}
   secret_access_key: {{ .secretAccessKey }}

--- a/charts/loki-simple-scalable/templates/gateway/_helpers-gateway.tpl
+++ b/charts/loki-simple-scalable/templates/gateway/_helpers-gateway.tpl
@@ -33,7 +33,7 @@ gateway Docker image
 */}}
 {{- define "loki.gatewayImage" -}}
 {{- $dict := dict "service" .Values.gateway.image "global" .Values.global.image -}}
-{{- include "loki.image" $dict -}}
+{{- include "loki.baseImage" $dict -}}
 {{- end }}
 
 {{/*

--- a/charts/loki-simple-scalable/templates/gateway/configmap-gateway.yaml
+++ b/charts/loki-simple-scalable/templates/gateway/configmap-gateway.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "loki.gatewayLabels" . | nindent 4 }}
 data:
   nginx.conf: |
-    {{- tpl .Values.gateway.nginxConfig.file . | nindent 4 }}
+    {{- tpl (ternary .Values.enterprise.nginxConfig.file .Values.gateway.nginxConfig.file .Values.enterprise.enabled) . | nindent 4 }}
 {{- end }}

--- a/charts/loki-simple-scalable/templates/gateway/deployment-gateway.yaml
+++ b/charts/loki-simple-scalable/templates/gateway/deployment-gateway.yaml
@@ -30,12 +30,12 @@ spec:
       labels:
         {{- include "loki.gatewaySelectorLabels" . | nindent 8 }}
     spec:
-      serviceAccountName: {{ include "loki.serviceAccountName" . }}
+      serviceAccountName: {{ include "loki.serviceAccountName" . -}}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- include "loki.gatewayPriorityClassName" . | nindent 6 }}
+      {{- end -}}
+      {{- include "loki.gatewayPriorityClassName" . | nindent 6 -}}
       securityContext:
         {{- toYaml .Values.gateway.podSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.gateway.terminationGracePeriodSeconds }}

--- a/charts/loki-simple-scalable/templates/read/_helpers-read.tpl
+++ b/charts/loki-simple-scalable/templates/read/_helpers-read.tpl
@@ -22,14 +22,6 @@ app.kubernetes.io/component: read
 {{- end }}
 
 {{/*
-read image
-*/}}
-{{- define "loki.readImage" -}}
-{{- $dict := dict "loki" .Values.loki.image "service" .Values.read.image "global" .Values.global.image "defaultVersion" .Chart.AppVersion -}}
-{{- include "loki.lokiImage" $dict -}}
-{{- end }}
-
-{{/*
 read priority class name
 */}}
 {{- define "loki.readPriorityClassName" -}}

--- a/charts/loki-simple-scalable/templates/read/statefulset-read.yaml
+++ b/charts/loki-simple-scalable/templates/read/statefulset-read.yaml
@@ -41,7 +41,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.read.terminationGracePeriodSeconds }}
       containers:
         - name: loki
-          image: {{ include "loki.readImage" . }}
+          image: {{ include "loki.image" . }}
           imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
           args:
             - -config.file=/etc/loki/config/config.yaml
@@ -78,6 +78,10 @@ spec:
               mountPath: /tmp
             - name: data
               mountPath: /var/loki
+            {{- if .Values.enterprise.enabled }}
+            - name: license
+              mountPath: /etc/loki/license
+            {{- end}}
             {{- with .Values.read.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -106,6 +110,15 @@ spec:
           configMap:
             name: {{ include "loki.fullname" . }}
           {{- end }}
+        {{- if .Values.enterprise.enabled }}
+        - name: license
+          secret:
+          {{- if .Values.useExternalLicense }}
+            secretName: {{ .Values.externalLicenseName }}
+          {{- else }}
+            secretName: enterprise-logs-license
+          {{- end }}
+        {{- end }}
         {{- with .Values.read.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/loki-simple-scalable/templates/secret-license.yaml
+++ b/charts/loki-simple-scalable/templates/secret-license.yaml
@@ -1,0 +1,10 @@
+{{- if and (not .Values.useExternalLicense) .Values.enterprise.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: enterprise-logs-license
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+data:
+  license.jwt: {{ .Values.enterprise.license.contents | b64enc }}
+{{- end }}

--- a/charts/loki-simple-scalable/templates/tokengen/_helpers.yaml
+++ b/charts/loki-simple-scalable/templates/tokengen/_helpers.yaml
@@ -1,0 +1,22 @@
+{{/*
+tokengen fullname
+*/}}
+{{- define "enterprise-logs.tokengenFullname" -}}
+{{ include "loki.fullname" . }}-tokengen
+{{- end }}
+
+{{/*
+tokengen common labels
+*/}}
+{{- define "enterprise-logs.tokengenLabels" -}}
+{{ include "loki.labels" . }}
+app.kubernetes.io/component: tokengen
+{{- end }}
+
+{{/*
+tokengen selector labels
+*/}}
+{{- define "enterprise-logs.tokengenSelectorLabels" -}}
+{{ include "loki.selectorLabels" . }}
+app.kubernetes.io/component: tokengen
+{{- end }}

--- a/charts/loki-simple-scalable/templates/tokengen/job-tokengen.yaml
+++ b/charts/loki-simple-scalable/templates/tokengen/job-tokengen.yaml
@@ -1,0 +1,110 @@
+{{ if and .Values.tokengen.enable .Values.enterprise.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "enterprise-logs.tokengenFullname" . }}
+  labels:
+    {{- include "enterprise-logs.tokengenLabels" . | nindent 4 }}
+    {{- with .Values.tokengen.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.tokengen.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    "helm.sh/hook": post-install
+spec:
+  backoffLimit: 6
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        {{- include "enterprise-logs.tokengenSelectorLabels" . | nindent 8 }}
+        {{- with .Values.tokengen.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- with .Values.tokengen.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.tokengen.priorityClassName }}
+      priorityClassName: {{ .Values.tokengen.priorityClassName }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.tokengen.securityContext | nindent 8 }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      initContainers:
+        - name: loki
+          image: {{ template "loki.image" . }}
+          imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
+          args:
+            - -config.file=/etc/loki/config/config.yaml
+            - -target=tokengen
+            - -tokengen.token-file=/shared/admin-token
+            {{- with .Values.tokengen.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            {{- if .Values.tokengen.extraVolumeMounts }}
+              {{ toYaml .Values.tokengen.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+            - name: shared
+              mountPath: /shared
+            - name: config
+              mountPath: /etc/loki/config
+            - name: license
+              mountPath: /etc/loki/license
+          env:
+            {{- if .Values.tokengen.env }}
+              {{ toYaml .Values.tokengen.env | nindent 12 }}
+            {{- end }}
+      containers:
+        - name: create-secret
+          image: bitnami/kubectl
+          imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
+          command:
+            - /bin/bash
+            - -euc
+            - kubectl create secret generic {{ .Values.tokengen.adminTokenSecret }} --from-file=token=/shared/admin-token --from-literal=grafana-token="$(base64 <(echo :$(cat /shared/admin-token)))"
+          volumeMounts:
+            {{- if .Values.tokengen.extraVolumeMounts }}
+              {{ toYaml .Values.tokengen.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+            - name: shared
+              mountPath: /shared
+            - name: config
+              mountPath: /etc/loki/config
+            - name: license
+              mountPath: /etc/loki/license
+      restartPolicy: OnFailure
+      serviceAccount: {{ template "enterprise-logs.tokengenFullname" . }}
+      serviceAccountName: {{ template "enterprise-logs.tokengenFullname" . }}
+      volumes:
+        - name: config
+          {{- if .Values.useExternalConfig }}
+          secret:
+            secretName: {{ .Values.externalConfigName }}
+          {{- else }}
+          configMap:
+            name: {{ include "loki.fullname" . }}
+          {{- end }}
+        - name: license
+          secret:
+          {{- if .Values.useExternalLicense }}
+            secretName: {{ .Values.externalLicenseName }}
+          {{- else }}
+            secretName: enterprise-logs-license
+          {{- end }}
+        - name: shared
+          emptyDir: {}
+        {{- if .Values.tokengen.extraVolumes }}
+        {{ toYaml .Values.tokengen.extraVolumes | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/charts/loki-simple-scalable/templates/tokengen/role-tokengen.yaml
+++ b/charts/loki-simple-scalable/templates/tokengen/role-tokengen.yaml
@@ -1,0 +1,20 @@
+{{ if and .Values.tokengen.enable .Values.enterprise.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "enterprise-logs.tokengenFullname" . }}
+  labels:
+    {{- include "enterprise-logs.tokengenLabels" . | nindent 4 }}
+    {{- with .Values.tokengen.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.tokengen.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    "helm.sh/hook": post-install
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+{{- end }}

--- a/charts/loki-simple-scalable/templates/tokengen/rolebinding-tokengen.yaml
+++ b/charts/loki-simple-scalable/templates/tokengen/rolebinding-tokengen.yaml
@@ -1,0 +1,23 @@
+{{ if and .Values.tokengen.enable .Values.enterprise.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "enterprise-logs.tokengenFullname" . }}
+  labels:
+    {{- include "enterprise-logs.tokengenLabels" . | nindent 4 }}
+    {{- with .Values.tokengen.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.tokengen.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    "helm.sh/hook": post-install
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "enterprise-logs.tokengenFullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "enterprise-logs.tokengenFullname" . }}
+{{- end }}

--- a/charts/loki-simple-scalable/templates/tokengen/serviceaccount-tokengen.yaml
+++ b/charts/loki-simple-scalable/templates/tokengen/serviceaccount-tokengen.yaml
@@ -1,0 +1,16 @@
+{{ if and .Values.tokengen.enable .Values.enterprise.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "enterprise-logs.tokengenFullname" . }}
+  labels:
+    {{- include "enterprise-logs.tokengenLabels" . | nindent 4 }}
+    {{- with .Values.tokengen.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.tokengen.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    "helm.sh/hook": post-install
+{{- end }}

--- a/charts/loki-simple-scalable/templates/write/_helpers-write.tpl
+++ b/charts/loki-simple-scalable/templates/write/_helpers-write.tpl
@@ -22,14 +22,6 @@ app.kubernetes.io/component: write
 {{- end }}
 
 {{/*
-write image
-*/}}
-{{- define "loki.writeImage" -}}
-{{- $dict := dict "loki" .Values.loki.image "service" .Values.write.image "global" .Values.global.image "defaultVersion" .Chart.AppVersion -}}
-{{- include "loki.lokiImage" $dict -}}
-{{- end }}
-
-{{/*
 write priority class name
 */}}
 {{- define "loki.writePriorityClassName" -}}

--- a/charts/loki-simple-scalable/templates/write/statefulset-write.yaml
+++ b/charts/loki-simple-scalable/templates/write/statefulset-write.yaml
@@ -42,7 +42,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.write.terminationGracePeriodSeconds }}
       containers:
         - name: loki
-          image: {{ include "loki.writeImage" . }}
+          image: {{ include "loki.image" . }}
           imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
           args:
             - -config.file=/etc/loki/config/config.yaml
@@ -77,6 +77,10 @@ spec:
               mountPath: /etc/loki/config
             - name: data
               mountPath: /var/loki
+            {{- if .Values.enterprise.enabled }}
+            - name: license
+              mountPath: /etc/loki/license
+            {{- end}}
             {{- with .Values.write.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -103,6 +107,15 @@ spec:
           configMap:
             name: {{ include "loki.fullname" . }}
           {{- end }}
+        {{- if .Values.enterprise.enabled }}
+        - name: license
+          secret:
+          {{- if .Values.useExternalLicense }}
+            secretName: {{ .Values.externalLicenseName }}
+          {{- else }}
+            secretName: enterprise-logs-license
+          {{- end }}
+        {{- end }}
         {{- with .Values.write.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/loki-simple-scalable/values.yaml
+++ b/charts/loki-simple-scalable/values.yaml
@@ -60,10 +60,15 @@ loki:
   # -- Config file contents for Loki
   # @default -- See values.yaml
   config: |
+    {{- if .Values.enterprise.enabled}}
+    {{- tpl .Values.enterprise.config . }}
+    {{- else }}
     auth_enabled: false
+    {{- end }}
 
     server:
       http_listen_port: 3100
+      grpc_listen_port: 9095
 
     memberlist:
       join_members:
@@ -72,6 +77,8 @@ loki:
     {{- if .Values.loki.commonConfig}}
     common:
     {{- toYaml .Values.loki.commonConfig | nindent 2}}
+      storage:
+      {{- include "loki.commonStorageConfig" . | nindent 4}}
     {{- end}}
 
     limits_config:
@@ -79,25 +86,44 @@ loki:
       reject_old_samples: true
       reject_old_samples_max_age: 168h
       max_cache_freshness_per_query: 10m
+      split_queries_by_interval: 15m
 
     {{- if .Values.loki.schemaConfig}}
     schema_config:
     {{- toYaml .Values.loki.schemaConfig | nindent 2}}
     {{- end}}
 
-    {{- if .Values.loki.storageConfig}}
-    storage_config:
-    {{- toYaml .Values.loki.storageConfig | nindent 2}}
-    {{- end}}
+    {{- if or .Values.minio.enabled (eq .Values.loki.storage.type "s3") (eq .Values.loki.storage.type "gcs") }}
+    ruler:
+      storage:
+        s3:
+          bucketnames: {{ .Values.loki.storage.bucketNames.ruler }}
+    {{- end -}}
 
   # -- Check https://grafana.com/docs/loki/latest/configuration/#common_config for more info on how to provide a common configuration
   commonConfig:
     path_prefix: /var/loki
     replication_factor: 1
-    storage:
-      filesystem:
-        chunks_directory: /var/loki/chunks
-        rules_directory: /var/loki/rules
+
+  storage:
+    bucketNames:
+      chunks: chunks
+      ruler: ruler
+      admin: admin
+    type: s3
+    s3:
+      endpoint: https://amazonaws.com
+      secretAccessKey: supersecret
+      accessKeyId: accesskey
+      s3ForcePathStyle: false
+      insecure: false
+    gcs:
+      chunkBufferSize: 0
+      requestTimeout: "0s"
+      enableHttp2: true
+    local:
+      chunks_directory: /var/loki/chunks
+      rules_directory: /var/loki/rules
 
   # -- Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas
   schemaConfig:
@@ -110,17 +136,190 @@ loki:
           prefix: loki_index_
           period: 24h
 
-  # -- Check https://grafana.com/docs/loki/latest/configuration/#storage_config for more info on how to configure storages
-  storageConfig: {}
-  # -- Uncomment to configure each storage individually
-  # boltdb_shipper: {}
-  # filesystem: {}
-  # azure: {}
-  # gcs: {}
-  # s3: {}
-
   # -- Structured loki configuration, takes precedence over `loki.config`, `loki.schemaConfig`, `loki.storageConfig`
   structuredConfig: {}
+
+enterprise:
+  # Enable enterprise features, license must be provided
+  enabled: false
+
+  # Default verion of GEL to deploy
+  version: v1.4.0
+
+  # -- Grafana Enterprise Logs license
+  # In order to use Grafana Enterprise Logs features, you will need to provide
+  # the contents of your Grafana Enterprise Logs license, either by providing the
+  # contents of the license.jwt, or the name Kubernetes Secret that contains your
+  # license.jwt.
+  # To set the license contents, use the flag `--set-file 'license.contents=./license.jwt'`
+  license:
+    contents: "NOTAVALIDLICENSE"
+
+  # enterprise specific sections of the config.yaml file
+  config: |
+    {{- if or .Values.minio.enabled (eq .Values.loki.storage.type "s3") (eq .Values.loki.storage.type "gcs") }}
+    admin_client:
+      storage:
+        s3:
+          bucket_name: {{ .Values.loki.storage.bucketNames.admin }}
+    {{- end }}
+    auth:
+      type: enterprise
+    auth_enabled: true
+    cluster_name: {{ .Release.Name }}
+    license:
+      path: /etc/loki/license/license.jwt
+
+  image:
+    # -- The Docker registry
+    registry: docker.io
+    # -- Docker image repository
+    repository: grafana/enterprise-logs
+    # -- Overrides the image tag whose default is the chart's appVersion
+    tag: v1.4.0
+    # -- Docker image pull policy
+    pullPolicy: IfNotPresent
+
+  nginxConfig:
+    file: |
+      worker_processes  5;  ## Default: 1
+      error_log  /dev/stderr;
+      pid        /tmp/nginx.pid;
+      worker_rlimit_nofile 8192;
+
+      events {
+        worker_connections  4096;  ## Default: 1024
+      }
+
+      http {
+        client_body_temp_path /tmp/client_temp;
+        proxy_temp_path       /tmp/proxy_temp_path;
+        fastcgi_temp_path     /tmp/fastcgi_temp;
+        uwsgi_temp_path       /tmp/uwsgi_temp;
+        scgi_temp_path        /tmp/scgi_temp;
+
+        default_type application/octet-stream;
+        log_format   {{ .Values.gateway.nginxConfig.logFormat }}
+
+        {{- if .Values.gateway.verboseLogging }}
+        access_log   /dev/stderr  main;
+        {{- else }}
+
+        map $status $loggable {
+          ~^[23]  0;
+          default 1;
+        }
+        access_log   /dev/stderr  main  if=$loggable;
+        {{- end }}
+
+        sendfile     on;
+        tcp_nopush   on;
+        resolver {{ .Values.global.dnsService }}.{{ .Values.global.dnsNamespace }}.svc.{{ .Values.global.clusterDomain }};
+
+        {{- with .Values.gateway.nginxConfig.httpSnippet }}
+        {{ . | nindent 2 }}
+        {{- end }}
+
+        server {
+          listen             8080;
+
+          {{- if .Values.gateway.basicAuth.enabled }}
+          auth_basic           "Loki";
+          auth_basic_user_file /etc/nginx/secrets/.htpasswd;
+          {{- end }}
+
+          location = / {
+            return 200 'OK';
+            auth_basic off;
+          }
+
+          location = /api/prom/push {
+            proxy_pass       http://{{ include "loki.writeFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+          }
+
+          location = /api/prom/tail {
+            proxy_pass       http://{{ include "loki.readFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+          }
+
+          location ~ /api/prom/.* {
+            proxy_pass       http://{{ include "loki.readFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+          }
+
+          location = /loki/api/v1/push {
+            proxy_pass       http://{{ include "loki.writeFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+          }
+
+          location = /loki/api/v1/tail {
+            proxy_pass       http://{{ include "loki.readFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+          }
+
+          location ~ /loki/api/.* {
+            proxy_pass       http://{{ include "loki.readFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+          }
+
+          location ~ /admin/api/.* {
+            proxy_pass       http://{{ include "loki.writeFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+          }
+
+          location ~ /compactor/.* {
+            proxy_pass       http://{{ include "loki.readFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+          }
+
+          location ~ /distributor/.* {
+            proxy_pass       http://{{ include "loki.writeFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+          }
+
+          location ~ /ring {
+            proxy_pass       http://{{ include "loki.writeFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+          }
+
+          location ~ /ingester/.* {
+            proxy_pass       http://{{ include "loki.writeFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+          }
+
+          location ~ /ruler/.* {
+            proxy_pass       http://{{ include "loki.readFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+          }
+
+          location ~ /scheduler/.* {
+            proxy_pass       http://{{ include "loki.readFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+          }
+
+          {{- with .Values.gateway.nginxConfig.serverSnippet }}
+          {{ . | nindent 4 }}
+          {{- end }}
+        }
+      }
+
+# -- Configuration for `tokengen` target
+tokengen:
+  # -- Whether the job should be part of the deployment
+  enable: true
+  # -- Name of the secret to store the admin token in
+  adminTokenSecret: "gel-admin-token"
+  # -- Additional CLI arguments for the `tokengen` target
+  extraArgs: []
+  # -- Additional Kubernetes environment
+  env: []
+  # -- Additional labels for the `tokengen` Job
+  labels: {}
+  # -- Additional annotations for the `tokengen` Job
+  annotations: {}
+  # -- Additional volumes for Pods
+  extraVolumes: []
+  # -- Additional volume mounts for Pods
+  extraVolumeMounts: []
+  # -- Run containers as user `enterprise-logs(uid=10001)`
+  securityContext:
+    runAsNonRoot: true
+    runAsGroup: 10001
+    runAsUser: 10001
+    fsGroup: 10001
+
 serviceAccount:
   # -- Specifies whether a ServiceAccount should be created
   create: true
@@ -601,3 +800,27 @@ networkPolicy:
     podSelector: {}
     # -- Specifies the namespace the discovery Pods are running in
     namespaceSelector: {}
+
+# -------------------------------------
+# Configuration for `minio` child chart
+# -------------------------------------
+minio:
+  enabled: true
+  accessKey: enterprise-logs
+  secretKey: supersecret
+  buckets:
+    - name: chunks
+      policy: none
+      purge: false
+    - name: ruler
+      policy: none
+      purge: false
+    - name: admin
+      policy: none
+      purge: false
+  persistence:
+    size: 5Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi

--- a/charts/loki-simple-scalable/values.yaml
+++ b/charts/loki-simple-scalable/values.yaml
@@ -103,7 +103,7 @@ loki:
   # -- Check https://grafana.com/docs/loki/latest/configuration/#common_config for more info on how to provide a common configuration
   commonConfig:
     path_prefix: /var/loki
-    replication_factor: 1
+    replication_factor: 3
 
   storage:
     bucketNames:
@@ -112,6 +112,7 @@ loki:
       admin: admin
     type: s3
     s3:
+      s3: null
       endpoint: https://amazonaws.com
       secretAccessKey: supersecret
       accessKeyId: accesskey
@@ -388,7 +389,7 @@ prometheusRule:
 # Configuration for the write
 write:
   # -- Number of replicas for the write
-  replicas: 1
+  replicas: 3
   image:
     # -- The Docker registry for the write image. Overrides `loki.image.registry`
     registry: null
@@ -451,7 +452,7 @@ write:
 # Configuration for the read node(s)
 read:
   # -- Number of replicas for the read
-  replicas: 1
+  replicas: 3
   autoscaling:
     # -- Enable autoscaling for the read, this is only used if `queryIndex.enabled: true`
     enabled: false
@@ -805,7 +806,7 @@ networkPolicy:
 # Configuration for `minio` child chart
 # -------------------------------------
 minio:
-  enabled: true
+  enabled: false
   accessKey: enterprise-logs
   secretKey: supersecret
   buckets:


### PR DESCRIPTION
This PR combines `enterprise-logs-simple` and `loki-simple-scalable` with the goal of

1. Making it easier to maintain charts by having fewer to maintain
2. Making it easier to switch between OSS Loki and GEL by simply toggling a config option

Setting `enterprise.enabled = true` will change the following:
1. Use the `enterprise-logs` image instead of the `loki` image
2. Mount a license to the pods. A license can be added via the `enterprise.license` setting
3. Add additional routes to the gateway's nginx config to include Admin endpoints exposed by GEL

This is in line with the strategy we are following for Mimir chart as well (see #1203)