### PR TITLE
[agent-operator] Fix Grafana Agent finalizers errors on OpenShift

### DIFF
--- a/charts/agent-operator/Chart.yaml
+++ b/charts/agent-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: grafana-agent-operator
 description: A Helm chart for Grafana Agent Operator
 type: application
-version: 0.1.10
+version: 0.1.11
 appVersion: "0.24.1"
 home: https://grafana.com/docs/agent/latest/
 icon: https://raw.githubusercontent.com/grafana/agent/v0.24.1/docs/assets/logo_and_name.png

--- a/charts/agent-operator/README.md
+++ b/charts/agent-operator/README.md
@@ -1,6 +1,6 @@
 # grafana-agent-operator
 
-![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.1](https://img.shields.io/badge/AppVersion-0.24.1-informational?style=flat-square)
+![Version: 0.1.11](https://img.shields.io/badge/Version-0.1.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.1](https://img.shields.io/badge/AppVersion-0.24.1-informational?style=flat-square)
 
 A Helm chart for Grafana Agent Operator
 

--- a/charts/agent-operator/templates/operator-clusterrole.yaml
+++ b/charts/agent-operator/templates/operator-clusterrole.yaml
@@ -20,7 +20,7 @@ rules:
   - metricsinstances/finalizers
   - logsinstances/finalizers
   - podlogs/finalizers
-  verbs: [get, list, watch, create, update, patch, delete]
+  verbs: [get, list, watch, update]
 - apiGroups: [monitoring.coreos.com]
   resources:
   - podmonitors
@@ -32,7 +32,7 @@ rules:
   - podmonitors/finalizers
   - probes/finalizers
   - servicemonitors/finalizers
-  verbs: [get, list, watch, create, update, patch, delete]
+  verbs: [get, list, watch, update]
 - apiGroups: [""]
   resources:
   - namespaces

--- a/charts/agent-operator/templates/operator-clusterrole.yaml
+++ b/charts/agent-operator/templates/operator-clusterrole.yaml
@@ -14,12 +14,25 @@ rules:
   - logsinstances
   - podlogs
   verbs: [get, list, watch]
+- apiGroups: [monitoring.grafana.com]
+  resources:
+  - grafanaagents/finalizers
+  - metricsinstances/finalizers
+  - logsinstances/finalizers
+  - podlogs/finalizers
+  verbs: [get, list, watch, create, update, patch, delete]
 - apiGroups: [monitoring.coreos.com]
   resources:
   - podmonitors
   - probes
   - servicemonitors
   verbs: [get, list, watch]
+- apiGroups: [monitoring.coreos.com]
+  resources:
+  - podmonitors/finalizers
+  - probes/finalizers
+  - servicemonitors/finalizers
+  verbs: [get, list, watch, create, update, patch, delete]
 - apiGroups: [""]
   resources:
   - namespaces


### PR DESCRIPTION
Closes https://github.com/grafana/agent/issues/1660

I just added all /finalizers resources because I don't know which are required for all usecases. Feel free to reduce them but this configuration now works on OKD 4.10 / Kubernetes v1.23.3-2003+e419edff267ffa-dirty with a GrafanaAgent and MetricsInstance resource.