### PR TITLE
gateway: Set the HTTP version for proxying to HTTP/1.1

### DIFF
--- a/charts/enterprise-logs-simple/values.yaml
+++ b/charts/enterprise-logs-simple/values.yaml
@@ -232,6 +232,8 @@ loki-simple-scalable:
           uwsgi_temp_path       /tmp/uwsgi_temp;
           scgi_temp_path        /tmp/scgi_temp;
 
+          proxy_http_version    1.1;
+
           default_type application/octet-stream;
           log_format   {{ .Values.gateway.nginxConfig.logFormat }}
 

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -766,6 +766,8 @@ gateway:
         uwsgi_temp_path       /tmp/uwsgi_temp;
         scgi_temp_path        /tmp/scgi_temp;
 
+        proxy_http_version    1.1;
+
         default_type application/octet-stream;
         log_format   {{ .Values.gateway.nginxConfig.logFormat }}
 

--- a/charts/loki-simple-scalable/values.yaml
+++ b/charts/loki-simple-scalable/values.yaml
@@ -199,6 +199,8 @@ enterprise:
         uwsgi_temp_path       /tmp/uwsgi_temp;
         scgi_temp_path        /tmp/scgi_temp;
 
+        proxy_http_version    1.1;
+
         default_type application/octet-stream;
         log_format   {{ .Values.gateway.nginxConfig.logFormat }}
 
@@ -691,6 +693,8 @@ gateway:
         fastcgi_temp_path     /tmp/fastcgi_temp;
         uwsgi_temp_path       /tmp/uwsgi_temp;
         scgi_temp_path        /tmp/scgi_temp;
+
+        proxy_http_version    1.1;
 
         default_type application/octet-stream;
         log_format   {{ .Values.gateway.nginxConfig.logFormat }}

--- a/charts/mimir-distributed/values.yaml
+++ b/charts/mimir-distributed/values.yaml
@@ -1262,6 +1262,8 @@ nginx:
         uwsgi_temp_path       /tmp/uwsgi_temp;
         scgi_temp_path        /tmp/scgi_temp;
 
+        proxy_http_version    1.1;
+
         default_type application/octet-stream;
         log_format   {{ .Values.nginx.nginxConfig.logFormat }}
 

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -801,6 +801,8 @@ gateway:
         uwsgi_temp_path       /tmp/uwsgi_temp;
         scgi_temp_path        /tmp/scgi_temp;
 
+        proxy_http_version    1.1;
+
         default_type application/octet-stream;
         log_format   {{ .Values.gateway.nginxConfig.logFormat }}
 


### PR DESCRIPTION
By default nginx uses HTTP/1.0 for proxied requests : https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_http_version

This is suboptimal since promtail uses HTTP/1.1 and can cause issues with Istio which , by default, will reject anything lower than HTTP/1.1

Slack conversation for reference: https://grafana.slack.com/archives/CEPJRLQNL/p1651595415595109

Signed-off-by: Francesco Ciocchetti <primeroznl@gmail.com>
