### PR TITLE
[enterprise-logs] Support additional config

### DIFF
--- a/charts/enterprise-logs/Chart.yaml
+++ b/charts/enterprise-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v2"
 name: "enterprise-logs"
 type: application
-version: "2.2.0"
+version: "2.2.1"
 appVersion: "v1.4.0"
 kubeVersion: "^1.10.0-0"
 description: "Grafana Enterprise Logs"

--- a/charts/enterprise-logs/values.yaml
+++ b/charts/enterprise-logs/values.yaml
@@ -145,6 +145,13 @@ config: |
       s3:
         bucketnames: enterprise-logs-ruler
 
+  {{- if .Values.additionalConfig}}
+  {{.Values.additionalConfig}}
+  {{- end}}
+
+# Append some additional config to the default config. Expects a string or `null`
+additionalConfig: null
+
 # -- Check https://grafana.com/docs/loki/latest/configuration/#common_config for more info on how to provide a common configuration
 commonConfig:
   path_prefix: /var/loki


### PR DESCRIPTION
This allows overwriting a config options of the default config without loosing e.g. the schema configuration.

It is required by the AWS marketplace deployment: https://grafana.com/docs/enterprise-logs/latest/setup/aws-marketplace/