### PR TITLE
fix(grafana): fix template issue with existingClaim

### DIFF
--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -656,7 +656,7 @@ volumes:
 {{- if and .Values.persistence.enabled (eq .Values.persistence.type "pvc") }}
   - name: storage
     persistentVolumeClaim:
-      claimName: {{ tpl (.Values.persistence.existingClaim .) | default (include "grafana.fullname" .) }}
+      claimName: {{ tpl .Values.persistence.existingClaim . | default (include "grafana.fullname" .) }}
 {{- else if and .Values.persistence.enabled (eq .Values.persistence.type "statefulset") }}
 # nothing
 {{- else }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -293,7 +293,7 @@ persistence:
   ## Sub-directory of the PV to mount. Can be templated.
   # subPath: ""
   ## Name of an existing PVC. Can be templated.
-  # existingClaim:
+  existingClaim: ""
 
   ## If persistence is not enabled, this allows to mount the
   ## local storage in-memory to improve performance


### PR DESCRIPTION
Hi,

https://github.com/grafana/helm-charts/pull/1333 seems to have introduced a templating issue when setting `persistence.enabled` to `true` and not passing an `existingClaim` value. `tpl` expects a string to parse but gets an empty interface. Please find below the error message:

```
Error: template: grafana/templates/deployment.yaml:49:10: executing "grafana/templates/deployment.yaml" at <include "grafana.pod" .>: error calling include: template: grafana/templates/_pod.tpl:659:20: executing "grafana.pod" at <tpl>: wrong number of args for tpl: want 2 got 1

Use --debug flag to render out invalid YAML
```

Defining an empty string as a default value fixes the issue.

Thanks in advance for reviewing