### PR TITLE
[tempo] Updated default version of tempo-query image to work with Apple M1 

### DIFF
--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -91,7 +91,7 @@ tempo:
 
 tempoQuery:
   repository: grafana/tempo-query
-  tag: 1.0.1
+  tag: 1.4.1
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Base image for tempo-query needs to support arm64 tag is updated to 1.4.1