### PR TITLE
[Grafana] Fix existing volume claim usage issue

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.29.1
+version: 6.29.2
 appVersion: 8.5.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -656,7 +656,7 @@ volumes:
 {{- if and .Values.persistence.enabled (eq .Values.persistence.type "pvc") }}
   - name: storage
     persistentVolumeClaim:
-      claimName: {{ tpl (default .Values.persistence.existingClaim (include "grafana.fullname" .)) . }}
+      claimName: {{ tpl (default (include "grafana.fullname" .) .Values.persistence.existingClaim) . }}
 {{- else if and .Values.persistence.enabled (eq .Values.persistence.type "statefulset") }}
 # nothing
 {{- else }}


### PR DESCRIPTION
The issue is still the order inside 'default' section.

Usage:  default "<default value"> <item>
Source: https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-default-function

The wrong line: 

```
claimName: {{ tpl (default .Values.persistence.existingClaim (include "grafana.fullname" .)) . }}
```

The fixed line based on the guide:

```
claimName: {{ tpl (default (include "grafana.fullname" .) .Values.persistence.existingClaim) . }}
```

Tested the result will be as expected:

Default claim name: grafana 
Existing claim name: grafana-pvc
So look like the expected result provided after the change.

```
volumes:
        - name: config
          configMap:
            name: grafana
        - name: storage
          persistentVolumeClaim:
            claimName: grafana-pvc
```

fixes #1350 #1358
