### PR TITLE
[mimir-distributed] WIP: add support for ruler remote evaluation

### DIFF
--- a/charts/mimir-distributed/Chart.yaml
+++ b/charts/mimir-distributed/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.0.14
+version: 2.1.0
 appVersion: 2.0.0
 description: "Grafana Mimir"
 engine: gotpl

--- a/charts/mimir-distributed/capped-large.yaml
+++ b/charts/mimir-distributed/capped-large.yaml
@@ -105,7 +105,27 @@ querier:
       cpu: 1
       memory: 12Gi
 
+ruler_querier:
+  replicas: 6
+  resources:
+    requests:
+      cpu: 1
+      memory: 12Gi
+    limits:
+      cpu: 1
+      memory: 12Gi
+
 query_frontend:
+  replicas: 2
+  resources:
+    requests:
+      cpu: 2
+      memory: 6Gi
+    limits:
+      cpu: 2
+      memory: 6Gi
+
+ruler_query_frontend:
   replicas: 2
   resources:
     requests:

--- a/charts/mimir-distributed/capped-small.yaml
+++ b/charts/mimir-distributed/capped-small.yaml
@@ -105,7 +105,27 @@ querier:
       cpu: 1
       memory: 12Gi
 
+ruler_querier:
+  replicas: 2
+  resources:
+    requests:
+      cpu: 1
+      memory: 12Gi
+    limits:
+      cpu: 1
+      memory: 12Gi
+
 query_frontend:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 2
+      memory: 6Gi
+    limits:
+      cpu: 2
+      memory: 6Gi
+
+ruler_query_frontend:
   replicas: 1
   resources:
     requests:

--- a/charts/mimir-distributed/large.yaml
+++ b/charts/mimir-distributed/large.yaml
@@ -101,7 +101,25 @@ querier:
       cpu: 1
       memory: 12Gi
 
+ruler_querier:
+  replicas: 6
+  resources:
+    limits:
+      memory: 24Gi
+    requests:
+      cpu: 1
+      memory: 12Gi
+
 query_frontend:
+  replicas: 2
+  resources:
+    limits:
+      memory: 6Gi
+    requests:
+      cpu: 2
+      memory: 2Gi
+
+ruler_query_frontend:
   replicas: 2
   resources:
     limits:

--- a/charts/mimir-distributed/small.yaml
+++ b/charts/mimir-distributed/small.yaml
@@ -101,7 +101,25 @@ querier:
       cpu: 1
       memory: 12Gi
 
+ruler_querier:
+  replicas: 2
+  resources:
+    limits:
+      memory: 24Gi
+    requests:
+      cpu: 1
+      memory: 12Gi
+
 query_frontend:
+  replicas: 1
+  resources:
+    limits:
+      memory: 6Gi
+    requests:
+      cpu: 2
+      memory: 2Gi
+
+ruler_query_frontend:
   replicas: 1
   resources:
     limits:

--- a/charts/mimir-distributed/templates/ruler-querier/ruler-querier-dep.yaml
+++ b/charts/mimir-distributed/templates/ruler-querier/ruler-querier-dep.yaml
@@ -1,0 +1,123 @@
+{{- if .Values.ruler.remoteEvaluationEnabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ruler-querier") }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" . "component" "ruler-querier" "memberlist" true) | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.ruler_querier.annotations | nindent 4 }}
+spec:
+  replicas: {{ .Values.ruler_querier.replicas }}
+  selector:
+    matchLabels:
+      {{- include "mimir.selectorLabels" (dict "ctx" . "component" "ruler-querier" "memberlist" true) | nindent 6 }}
+  strategy:
+    {{- toYaml .Values.ruler_querier.strategy | nindent 4 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mimir.podLabels" (dict "ctx" . "component" "ruler-querier" "memberlist" true) | nindent 8 }}
+        {{- with .Values.ruler_querier.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+{{- if .Values.useExternalConfig }}
+        checksum/config: {{ .Values.externalConfigVersion }}
+{{- else }}
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+{{- end}}
+        {{- with .Values.ruler_querier.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "mimir.serviceAccountName" . }}
+    {{- if .Values.ruler_querier.priorityClassName }}
+      priorityClassName: {{ .Values.ruler_querier.priorityClassName }}
+    {{- end }}
+      securityContext:
+        {{- toYaml .Values.ruler_querier.securityContext | nindent 8 }}
+      initContainers:
+        {{- toYaml .Values.ruler_querier.initContainers | nindent 8 }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end}}
+      {{- end }}
+      containers:
+        - name: ruler-querier
+          image: "{{ include "mimir.imageReference" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "-target=querier"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-querier.frontend-address={{ template "mimir.fullname" . }}-ruler-query-frontend-headless.{{ .Release.Namespace }}.svc:{{ include "mimir.serverGrpcListenPort" . }}"
+          {{- range $key, $value := .Values.ruler_querier.extraArgs }}
+            - "-{{ $key }}={{ $value }}"
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.ruler_querier.extraVolumeMounts }}
+              {{ toYaml .Values.ruler_querier.extraVolumeMounts | nindent 12}}
+            {{- end }}
+            - name: config
+              mountPath: /etc/mimir
+            {{- if .Values.enterprise.enabled }}
+            - name: license
+              mountPath: /license
+            {{- end }}
+            - name: runtime-config
+              mountPath: /var/{{ include "mimir.name" . }}
+            - name: storage
+              mountPath: "/data"
+              subPath: {{ .Values.ruler_querier.persistence.subPath }}
+          ports:
+            - name: http-metrics
+              containerPort: {{ include "mimir.serverHttpListenPort" . }}
+              protocol: TCP
+            - name: grpc
+              containerPort: {{ include "mimir.serverGrpcListenPort" . }}
+              protocol: TCP
+            - name: memberlist
+              containerPort: {{ include "mimir.memberlistBindPort" . }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.ruler_querier.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.ruler_querier.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.ruler_querier.resources | nindent 12 }}
+          securityContext:
+            readOnlyRootFilesystem: true
+          env:
+            {{- if .Values.ruler_querier.env }}
+              {{- toYaml .Values.ruler_querier.env | nindent 12 }}
+            {{- end }}
+{{- if .Values.ruler_querier.extraContainers }}
+{{ toYaml .Values.ruler_querier.extraContainers | indent 8}}
+{{- end }}
+      nodeSelector:
+        {{- toYaml .Values.ruler_querier.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.ruler_querier.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.ruler_querier.tolerations | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.querier.terminationGracePeriodSeconds }}
+      volumes:
+        - name: config
+          secret:
+            secretName: {{ tpl .Values.externalConfigSecretName . }}
+        {{- if .Values.enterprise.enabled }}
+        - name: license
+          secret:
+            secretName: {{ tpl .Values.license.secretName . }}
+        {{- end }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "mimir.fullname" . }}-runtime
+{{- if .Values.ruler_querier.extraVolumes }}
+{{ toYaml .Values.ruler_querier.extraVolumes | indent 8}}
+{{- end }}
+        - name: storage
+          emptyDir: {}
+{{- end -}}

--- a/charts/mimir-distributed/templates/ruler-querier/ruler-querier-pdb.yaml
+++ b/charts/mimir-distributed/templates/ruler-querier/ruler-querier-pdb.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.ruler.remoteEvaluationEnabled -}}
+{{- if .Values.ruler_querier.podDisruptionBudget -}}
+apiVersion: {{ include "mimir.podDisruptionBudget.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ruler-querier") }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" . "component" "ruler-querier" "memberlist" true) | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "mimir.selectorLabels" (dict "ctx" . "component" "ruler-querier" "memberlist" true) | nindent 6 }}
+{{ toYaml .Values.ruler_querier.podDisruptionBudget | indent 2 }}
+{{- end -}}
+{{- end -}}

--- a/charts/mimir-distributed/templates/ruler-querier/ruler-querier-servmon.yaml
+++ b/charts/mimir-distributed/templates/ruler-querier/ruler-querier-servmon.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.ruler.remoteEvaluationEnabled -}}
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "ruler-querier") }}
+  {{- with .namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" $ "component" "ruler-querier" "memberlist" true) | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .namespaceSelector }}
+  namespaceSelector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "mimir.selectorLabels" (dict "ctx" $ "component" "ruler-querier" "memberlist" true) | nindent 6 }}
+  endpoints:
+    - port: http-metrics
+      {{- with .interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      relabelings:
+        - sourceLabels: [job]
+          replacement: "{{ $.Release.Namespace }}/ruler-querier"
+          targetLabel: job
+        - replacement: "{{ include "mimir.clusterName" $ }}"
+          targetLabel: cluster
+        {{- with .relabelings }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/mimir-distributed/templates/ruler-querier/ruler-querier-svc.yaml
+++ b/charts/mimir-distributed/templates/ruler-querier/ruler-querier-svc.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.ruler.remoteEvaluationEnabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ruler-querier") }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" . "component" "ruler-querier" "memberlist" true) | nindent 4 }}
+    {{- with .Values.ruler_querier.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- toYaml .Values.ruler_querier.service.annotations | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ include "mimir.serverHttpListenPort" .}}
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: {{ include "mimir.serverGrpcListenPort" . }}
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    {{- include "mimir.selectorLabels" (dict "ctx" . "component" "ruler-querier" "memberlist" true) | nindent 4 }}
+{{- end -}}

--- a/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-dep.yaml
+++ b/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-dep.yaml
@@ -1,0 +1,121 @@
+{{- if .Values.ruler.remoteEvaluationEnabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ruler-query-frontend") }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" . "component" "ruler-query-frontend") | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.ruler_query_frontend.annotations | nindent 4 }}
+spec:
+  replicas: {{ .Values.ruler_query_frontend.replicas }}
+  selector:
+    matchLabels:
+      {{- include "mimir.selectorLabels" (dict "ctx" . "component" "ruler-query-frontend") | nindent 6 }}
+  strategy:
+    {{- toYaml .Values.ruler_query_frontend.strategy | nindent 4 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mimir.podLabels" (dict "ctx" . "component" "ruler-query-frontend") | nindent 8 }}
+        {{- with .Values.ruler_query_frontend.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+{{- if .Values.useExternalConfig }}
+        checksum/config: {{ .Values.externalConfigVersion }}
+{{- else }}
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+{{- end}}
+        {{- with .Values.ruler_query_frontend.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "mimir.serviceAccountName" . }}
+    {{- if .Values.ruler_query_frontend.priorityClassName }}
+      priorityClassName: {{ .Values.ruler_query_frontend.priorityClassName }}
+    {{- end }}
+      securityContext:
+        {{- toYaml .Values.ruler_query_frontend.securityContext | nindent 8 }}
+      initContainers:
+        {{- toYaml .Values.ruler_query_frontend.initContainers | nindent 8 }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end}}
+      {{- end }}
+      containers:
+        - name: ruler-query-frontend
+          image: "{{ include "mimir.imageReference" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "-target=query-frontend"
+            - "-config.file=/etc/mimir/mimir.yaml"
+          {{- range $key, $value := .Values.ruler_query_frontend.extraArgs }}
+            - "-{{ $key }}={{ $value }}"
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.ruler_query_frontend.extraVolumeMounts }}
+              {{ toYaml .Values.ruler_query_frontend.extraVolumeMounts | nindent 12}}
+            {{- end }}
+            - name: runtime-config
+              mountPath: /var/{{ include "mimir.name" . }}
+            {{- if .Values.enterprise.enabled }}
+            - name: license
+              mountPath: /license
+            {{- end }}
+            - name: config
+              mountPath: /etc/mimir
+            - name: storage
+              mountPath: /data
+              {{- if .Values.ruler_query_frontend.persistence.subPath }}
+              subPath: {{ .Values.ruler_query_frontend.persistence.subPath }}
+              {{- end }}
+          ports:
+            - name: http-metrics
+              containerPort: {{ include "mimir.serverHttpListenPort" . }}
+              protocol: TCP
+            - name: grpc
+              containerPort: {{ include "mimir.serverGrpcListenPort" . }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.ruler_query_frontend.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.ruler_query_frontend.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.ruler_query_frontend.resources | nindent 12 }}
+          securityContext:
+            readOnlyRootFilesystem: true
+          env:
+            {{- if .Values.ruler_query_frontend.env }}
+              {{- toYaml .Values.ruler_query_frontend.env | nindent 12 }}
+            {{- end }}
+{{- if .Values.ruler_query_frontend.extraContainers }}
+{{ toYaml .Values.ruler_query_frontend.extraContainers | indent 8}}
+{{- end }}
+      nodeSelector:
+        {{- toYaml .Values.ruler_query_frontend.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.ruler_query_frontend.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.ruler_query_frontend.tolerations | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.ruler_query_frontend.terminationGracePeriodSeconds }}
+      volumes:
+        - name: config
+          secret:
+            secretName: {{ tpl .Values.externalConfigSecretName . }}
+        {{- if .Values.enterprise.enabled }}
+        - name: license
+          secret:
+            secretName: {{ tpl .Values.license.secretName . }}
+        {{- end }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "mimir.fullname" . }}-runtime
+{{- if .Values.ruler_query_frontend.extraVolumes }}
+{{ toYaml .Values.ruler_query_frontend.extraVolumes | indent 8}}
+{{- end }}
+        - name: storage
+          emptyDir: {}
+{{- end -}}

--- a/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-pdb.yaml
+++ b/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-pdb.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.ruler.remoteEvaluationEnabled -}}
+{{- if .Values.ruler_query_frontend.podDisruptionBudget -}}
+apiVersion: {{ include "mimir.podDisruptionBudget.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ruler-query-frontend") }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" . "component" "ruler-query-frontend") | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "mimir.selectorLabels" (dict "ctx" . "component" "ruler-query-frontend") | nindent 6 }}
+{{ toYaml .Values.ruler_query_frontend.podDisruptionBudget | indent 2 }}
+{{- end -}}
+{{- end -}}

--- a/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-servmon.yaml
+++ b/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-servmon.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.ruler.remoteEvaluationEnabled -}}
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "ruler-query-frontend") }}
+  {{- with .namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" $ "component" "ruler-query-frontend") | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .namespaceSelector }}
+  namespaceSelector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "mimir.selectorLabels" (dict "ctx" $ "component" "ruler-query-frontend") | nindent 6 }}
+    matchExpressions:
+      - key: prometheus.io/service-monitor
+        operator: NotIn
+        values:
+          - "false"
+  endpoints:
+    - port: http-metrics
+      {{- with .interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      relabelings:
+        - sourceLabels: [job]
+          replacement: "{{ $.Release.Namespace }}/ruler-query-frontend"
+          targetLabel: job
+        - replacement: "{{ include "mimir.clusterName" $ }}"
+          targetLabel: cluster
+        {{- with .relabelings }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-svc-headless.yaml
+++ b/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-svc-headless.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.ruler.remoteEvaluationEnabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ruler-query-frontend") }}-headless
+  labels:
+    {{- include "mimir.labels" (dict "ctx" . "component" "ruler-query-frontend") | nindent 4 }}
+    prometheus.io/service-monitor: "false"
+    {{- with .Values.ruler_query_frontend.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- toYaml .Values.ruler_query_frontend.service.annotations | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - port: {{ include "mimir.serverHttpListenPort" .}}
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: {{ include "mimir.serverGrpcListenPort" . }}
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    {{- include "mimir.selectorLabels" (dict "ctx" . "component" "ruler-query-frontend") | nindent 4 }}
+{{- end -}}

--- a/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-svc.yaml
+++ b/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-svc.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.ruler.remoteEvaluationEnabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ruler-query-frontend") }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" . "component" "ruler-query-frontend") | nindent 4 }}
+    {{- with .Values.query_frontend.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- toYaml .Values.ruler_query_frontend.service.annotations | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ include "mimir.serverHttpListenPort" .}}
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: {{ include "mimir.serverGrpcListenPort" . }}
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    {{- include "mimir.selectorLabels" (dict "ctx" . "component" "ruler-query-frontend") | nindent 4 }}
+{{- end -}}

--- a/charts/mimir-distributed/values.yaml
+++ b/charts/mimir-distributed/values.yaml
@@ -79,6 +79,11 @@ mimir:
       enable_api: true
       rule_path: '/data'
       alertmanager_url: dnssrvnoa+http://_http-metrics._tcp.{{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}/alertmanager
+      {{- if .Values.ruler.remoteEvaluationEnabled }}
+      # TODO(ortuman): Remote evaluation not yet supported. Waiting for grafana/mimir:2.1.0 
+      # query_frontend:
+      #  address: 'dns:///{{ template "mimir.fullname" . }}-ruler-query-frontend.{{ .Release.Namespace }}.svc:{{ include "mimir.serverGrpcListenPort" . }}'
+      {{- end }}
 
     server:
       grpc_server_max_recv_msg_size: 104857600
@@ -592,6 +597,9 @@ ruler:
   enabled: true
   replicas: 1
 
+  # Use a dedicated set of query components (ruler-query-frontend + ruler-querier) to perform rule evaluation.
+  remoteEvaluationEnabled: true
+
   service:
     annotations: {}
     labels: {}
@@ -616,6 +624,136 @@ ruler:
 
   nodeSelector: {}
   affinity: {}
+  annotations: {}
+  persistence:
+    subPath:
+
+  readinessProbe:
+    httpGet:
+      path: /ready
+      port: http-metrics
+    initialDelaySeconds: 45
+
+  securityContext: {}
+
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+
+  terminationGracePeriodSeconds: 180
+
+  tolerations: []
+  initContainers: []
+  extraContainers: []
+  extraVolumes: []
+  extraVolumeMounts: []
+  env: []
+
+ruler_querier:
+  replicas: 1
+
+  service:
+    annotations: {}
+    labels: {}
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  # Additional ruler-querier container arguments, e.g. log level (debug, info, warn, error)
+  extraArgs: {}
+
+  # Pod Labels
+  podLabels: {}
+
+  # Pod Annotations
+  podAnnotations: {}
+
+  # Pod Disruption Budget
+  podDisruptionBudget: {}
+
+  nodeSelector: {}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: target
+                  operator: In
+                  values:
+                    - querier
+            topologyKey: 'kubernetes.io/hostname'
+
+  annotations: {}
+  persistence:
+    subPath:
+
+  readinessProbe:
+    httpGet:
+      path: /ready
+      port: http-metrics
+    initialDelaySeconds: 45
+
+  securityContext: {}
+
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+
+  terminationGracePeriodSeconds: 180
+
+  tolerations: []
+  initContainers: []
+  extraContainers: []
+  extraVolumes: []
+  extraVolumeMounts: []
+  env: []
+
+ruler_query_frontend:
+  replicas: 1
+
+  service:
+    annotations: {}
+    labels: {}
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  # Additional ruler-query-frontend container arguments, e.g. log level (debug, info, warn, error)
+  extraArgs: {}
+
+  # Pod Labels
+  podLabels: {}
+
+  # Pod Annotations
+  podAnnotations: {}
+
+  # Pod Disruption Budget
+  podDisruptionBudget: {}
+
+  nodeSelector: {}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: target
+                  operator: In
+                  values:
+                    - query-frontend
+            topologyKey: 'kubernetes.io/hostname'
+
   annotations: {}
   persistence:
     subPath:


### PR DESCRIPTION
This PR is intended to be the basis to support remote rule evaluation in helm. **Still a WIP**.

Most remarkable changes are listed below:

* New `remoteEvaluationEnabled` option has been added to the default `values.yaml` file to enable/disable ruler remote operational mode. 
* Two new components have been added, `ruler-querier` and `ruler-query-frontend`.
* For these new componets most configuration is being shared with common `querier/query-frontend`, except for `ruler-querier`, where the frontend address option is being overridden via CLI arg.