### PR TITLE
[tempo-distributed] Add pdb if resource has > 1 replicas

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.17.2
+version: 0.17.3
 appVersion: 1.4.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/templates/compactor/poddisruptionbudget-compactor.yaml
+++ b/charts/tempo-distributed/templates/compactor/poddisruptionbudget-compactor.yaml
@@ -1,0 +1,13 @@
+{{- if gt (int .Values.compactor.replicas) 1 }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "tempo.compactorFullname" . }}
+  labels:
+    {{- include "tempo.compactorLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "tempo.compactorSelectorLabels" . | nindent 6 }}
+  maxUnavailable: 1
+{{- end }}

--- a/charts/tempo-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
@@ -1,0 +1,13 @@
+{{- if gt (int .Values.distributor.replicas) 1 }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "tempo.distributorFullname" . }}
+  labels:
+    {{- include "tempo.distributorLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "tempo.distributorSelectorLabels" . | nindent 6 }}
+  maxUnavailable: 1
+{{- end }}

--- a/charts/tempo-distributed/templates/gateway/poddisruptionbudget-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/poddisruptionbudget-gateway.yaml
@@ -1,0 +1,13 @@
+{{- if gt (int .Values.gateway.replicas) 1 }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "tempo.gatewayFullname" . }}
+  labels:
+    {{- include "tempo.gatewayLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "tempo.gatewaySelectorLabels" . | nindent 6 }}
+  maxUnavailable: 1
+{{- end }}

--- a/charts/tempo-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
@@ -1,0 +1,13 @@
+{{- if gt (int .Values.ingester.replicas) 1 }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "tempo.ingesterFullname" . }}
+  labels:
+    {{- include "tempo.ingesterLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "tempo.ingesterSelectorLabels" . | nindent 6 }}
+  maxUnavailable: 1
+{{- end }}

--- a/charts/tempo-distributed/templates/memcached/_helpers-memcached.tpl
+++ b/charts/tempo-distributed/templates/memcached/_helpers-memcached.tpl
@@ -1,4 +1,11 @@
 {{/*
+memcached fullname
+*/}}
+{{- define "tempo.memcachedFullname" -}}
+{{ include "tempo.fullname" . }}-memcached
+{{- end }}
+
+{{/*
 memcached common labels
 */}}
 {{- define "tempo.memcachedLabels" -}}

--- a/charts/tempo-distributed/templates/memcached/poddisruptionbudget-memcached.yaml
+++ b/charts/tempo-distributed/templates/memcached/poddisruptionbudget-memcached.yaml
@@ -1,0 +1,13 @@
+{{- if gt (int .Values.memcached.replicas) 1 }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "tempo.memcachedFullname" . }}
+  labels:
+    {{- include "tempo.memcachedLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "tempo.memcachedSelectorLabels" . | nindent 6 }}
+  maxUnavailable: 1
+{{- end }}

--- a/charts/tempo-distributed/templates/memcached/service-memcached.yaml
+++ b/charts/tempo-distributed/templates/memcached/service-memcached.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "tempo.fullname" . }}-memcached
+  name: {{ include "tempo.memcachedFullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.memcachedLabels" . | nindent 4 }}

--- a/charts/tempo-distributed/templates/memcached/servicemonitor-memcached.yaml
+++ b/charts/tempo-distributed/templates/memcached/servicemonitor-memcached.yaml
@@ -4,7 +4,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "tempo.fullname" $ }}-memcached
+  name: {{ template "tempo.memcachedFullname" $ }}
   {{- with .namespace }}
   namespace: {{ . }}
   {{- end }}

--- a/charts/tempo-distributed/templates/memcached/statefulset-memcached.yaml
+++ b/charts/tempo-distributed/templates/memcached/statefulset-memcached.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "tempo.fullname" . }}-memcached
+  name: {{ include "tempo.memcachedFullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.memcachedLabels" . | nindent 4 }}

--- a/charts/tempo-distributed/templates/querier/poddisruptionbudget-querier.yaml
+++ b/charts/tempo-distributed/templates/querier/poddisruptionbudget-querier.yaml
@@ -1,0 +1,13 @@
+{{- if gt (int .Values.querier.replicas) 1 }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "tempo.querierFullname" . }}
+  labels:
+    {{- include "tempo.querierLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "tempo.querierSelectorLabels" . | nindent 6 }}
+  maxUnavailable: 1
+{{- end }}

--- a/charts/tempo-distributed/templates/query-frontend/poddisruptionbudget-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/poddisruptionbudget-query-frontend.yaml
@@ -1,0 +1,13 @@
+{{- if gt (int .Values.queryFrontend.replicas) 1 }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "tempo.queryFrontendFullname" . }}
+  labels:
+    {{- include "tempo.queryFrontendLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "tempo.queryFrontendSelectorLabels" . | nindent 6 }}
+  maxUnavailable: 1
+{{- end }}


### PR DESCRIPTION
This adds pdbs in the same manner that the loki-distributed chart does.

I've added a pdb for each resource but some could be considered up for debate - i.e. to my knowledge having 0 replicas available of memcached or queryFrontend would not cause downtime, but 0 of ingester or distributor would cause big issues.

This addresses https://github.com/grafana/helm-charts/issues/1364

Signed-off-by: AlexDHoffer <alexdchoffer@gmail.com>