### PR TITLE
[tempo-distributed] Add grpclb port to tempo-distributed query-frontend-discovery service

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.17.2
+version: 0.17.3
 appVersion: 1.4.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/templates/query-frontend/service-query-frontend-discovery.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/service-query-frontend-discovery.yaml
@@ -20,6 +20,10 @@ spec:
       port: 9095
       protocol: TCP
       targetPort: 9095
+    - name: grpclb
+      port: 9096
+      protocol: TCP
+      targetPort: grpc
     - name: tempo-query-jaeger-ui
       port: 16686
       targetPort: 16686


### PR DESCRIPTION
Adds grpclb port to tempo-distributed query-frontend-discovery service

PR #1122 seems to be stale, so this is a new PR with all of the requirements met. 