### PR TITLE
[loki] add service per replica capability

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 2.11.1
+version: 2.12.0
 appVersion: v2.5.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki/templates/serviceperreplica.yaml
+++ b/charts/loki/templates/serviceperreplica.yaml
@@ -1,0 +1,51 @@
+{{- if and .Values.servicePerReplica.enabled }}
+{{- $count := .Values.replicas | int -}}
+{{- $serviceValues := .Values.servicePerReplica -}}
+{{- range $i, $e := until $count }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "loki.fullname" $ }}-{{ $i }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: {{ template "loki.name" $ }}
+    chart: {{ template "loki.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+    {{- with $serviceValues.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- toYaml $serviceValues.annotations | nindent 4 }}
+spec:
+  type: {{ $serviceValues.type }}
+{{- if (and (eq $serviceValues.type "ClusterIP") (not (empty $serviceValues.clusterIP))) }}
+  clusterIP: {{ $serviceValues.clusterIP }}
+{{- end }}
+{{- if (and (eq $serviceValues.type "LoadBalancer") (not (empty $serviceValues.loadBalancerIP))) }}
+  loadBalancerIP: {{ $serviceValues.loadBalancerIP }}
+{{- end }}
+{{- if $serviceValues.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range $cidr := $serviceValues.loadBalancerSourceRanges }}
+    - {{ $cidr }}
+  {{- end }}
+{{- end }}
+  ports:
+    - port: {{ $serviceValues.port }}
+      protocol: TCP
+      name: http-metrics
+      targetPort: {{ $serviceValues.targetPort }}
+{{- if (and (eq $serviceValues.type "NodePort") (not (empty $serviceValues.nodePort))) }}
+      nodePort: {{ $serviceValues.nodePort }}
+{{- end }}
+{{- if $.Values.extraPorts }}
+{{ toYaml $.Values.extraPorts | indent 4}}
+{{- end }}
+  selector:
+    app: {{ template "loki.name" $ }}
+    release: {{ $.Release.Name }}
+    statefulset.kubernetes.io/pod-name: {{ template "loki.fullname" $ }}-{{ $i }}
+{{- end }}
+{{- end }}

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -201,6 +201,15 @@ service:
   labels: {}
   targetPort: http-metrics
 
+servicePerReplica:
+  enabled: false
+  type: ClusterIP
+  nodePort:
+  port: 3100
+  annotations: {}
+  labels: {}
+  targetPort: http-metrics
+
 serviceAccount:
   create: true
   name:


### PR DESCRIPTION
Add ability to create a dedicated service for each replica of loki

We have a setup with multiple instances of loki for high availability in case a problem occurs on a node running one instance of loki. In that regard we need the ability when investigating a problem to target a specific instance of loki that was not impacted by a problem