### PR TITLE
[grafana] bump version to 8.5.2

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.29.2
-appVersion: 8.5.0
+version: 6.29.3
+appVersion: 8.5.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -74,7 +74,7 @@ livenessProbe:
 
 image:
   repository: grafana/grafana
-  tag: 8.5.0
+  tag: 8.5.2
   sha: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Small update to default to latest grafana version in a helm chart.