### PR TITLE
[grafana] feat: Defaults image.tag to chart appVersion

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.29.4
+version: 6.29.5
 appVersion: 8.5.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -59,8 +59,8 @@ This version requires Helm >= 3.1.0.
 | `securityContext`                         | Deployment securityContext                    | `{"runAsUser": 472, "runAsGroup": 472, "fsGroup": 472}`  |
 | `priorityClassName`                       | Name of Priority Class to assign pods         | `nil`                                                   |
 | `image.repository`                        | Image repository                              | `grafana/grafana`                                       |
-| `image.tag`                               | Image tag (`Must be >= 5.0.0`)                | `8.2.5`                                                 |
-| `image.sha`                               | Image sha (optional)                          | `2acf04c016c77ca2e89af3536367ce847ee326effb933121881c7c89781051d3` |
+| `image.tag`                               | Overrides the Grafana image tag whose default is the chart appVersion (`Must be >= 5.0.0`) | ``                                                      |
+| `image.sha`                               | Image sha (optional)                          | ``                                                      |
 | `image.pullPolicy`                        | Image pull policy                             | `IfNotPresent`                                          |
 | `image.pullSecrets`                       | Image pull secrets (can be templated)         | `[]`                                                    |
 | `service.enabled`                         | Enable grafana service                        | `true`                                                  |

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -395,9 +395,9 @@ containers:
 {{- end}}
   - name: {{ .Chart.Name }}
     {{- if .Values.image.sha }}
-    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}@sha256:{{ .Values.image.sha }}"
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}@sha256:{{ .Values.image.sha }}"
     {{- else }}
-    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
     {{- end }}
     imagePullPolicy: {{ .Values.image.pullPolicy }}
   {{- if .Values.command }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -74,7 +74,8 @@ livenessProbe:
 
 image:
   repository: grafana/grafana
-  tag: 8.5.3
+  # Overrides the Grafana image tag whose default is the chart appVersion
+  tag: ""
   sha: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
There are many cases that PR or chart release only changed `appVersion` and left `image.tag` value (may not be the whole):

* chart 6.26.6 #1289
  * fixed in chart 6.26.7 #1294
* (by me) chart 6.21.7 #1051
  * fixed in chart 6.21.8 #1052
* chart 6.20.3 #907
  * fixed in chart 6.20.6 #975
* chart 6.16.7 #692, chart 6.16.8 #694
  * fixed in chart 6.16.9 #698

It seems first-comers can make mistakes easily, so I've changed the tag used by pod image definition defaults to chart `appVersion`.

Description based on: https://github.com/argoproj/argo-helm/blob/1492575ee07aebdbdc22ff4d16da7455fe3e1b1e/charts/argo-cd/values.yaml#L16