### PR TITLE
[grafana] Upgrade PodDisruptionBudget apiVersion

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.29.5
+version: 6.29.6
 appVersion: 8.5.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_helpers.tpl
+++ b/charts/grafana/templates/_helpers.tpl
@@ -142,6 +142,17 @@ Return the appropriate apiVersion for ingress.
 {{- end -}}
 
 {{/*
+Return the appropriate apiVersion for podsecuritypolicy and PodDisruptionBudget.
+*/}}
+{{- define "grafana.policy.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "policy/v1") (semverCompare ">= 1.21-1" .Capabilities.KubeVersion.Version) -}}
+    {{- print "policy/v1" -}}
+  {{- else -}}
+    {{- print "policy/v1beta1 -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Return if ingress is stable.
 */}}
 {{- define "grafana.ingress.isStable" -}}

--- a/charts/grafana/templates/_helpers.tpl
+++ b/charts/grafana/templates/_helpers.tpl
@@ -148,7 +148,7 @@ Return the appropriate apiVersion for podsecuritypolicy and PodDisruptionBudget.
   {{- if and (.Capabilities.APIVersions.Has "policy/v1") (semverCompare ">= 1.21-1" .Capabilities.KubeVersion.Version) -}}
     {{- print "policy/v1" -}}
   {{- else -}}
-    {{- print "policy/v1beta1 -}}
+    {{- print "policy/v1beta1" -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/grafana/templates/poddisruptionbudget.yaml
+++ b/charts/grafana/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "grafana.fullname" . }}

--- a/charts/grafana/templates/poddisruptionbudget.yaml
+++ b/charts/grafana/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget }}
-apiVersion: policy/v1
+apiVersion: {{ include "grafana.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "grafana.fullname" . }}

--- a/charts/grafana/templates/podsecuritypolicy.yaml
+++ b/charts/grafana/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "grafana.fullname" . }}

--- a/charts/grafana/templates/podsecuritypolicy.yaml
+++ b/charts/grafana/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: {{ include "grafana.policy.apiVersion" . }}
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "grafana.fullname" . }}

--- a/charts/grafana/templates/podsecuritypolicy.yaml
+++ b/charts/grafana/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: policy/v1
+apiVersion: {{ include "grafana.policy.apiVersion" . }}
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "grafana.fullname" . }}


### PR DESCRIPTION
PodDisruptionBudget apiVersion policy/v1beta1 is deprecated in v1.21+. and will be unavailable in the next Kubernetes version. Nothing else needs to be changed in the yaml specs
