### PR TITLE
[mimir-distributed] Add support for the query-frontend results cache

### DIFF
--- a/charts/mimir-distributed/CHANGELOG.md
+++ b/charts/mimir-distributed/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the Pull Request that introduced the change.
 
+## 2.0.15
+
+* [ENHANCEMENT] Add support for the results cache used by the query frontend
+
 ## 2.0.14
 
 * [BUGFIX] exclude headless services from ServiceMonitors to prevent duplication of prometheus scrape targets #1308

--- a/charts/mimir-distributed/CHANGELOG.md
+++ b/charts/mimir-distributed/CHANGELOG.md
@@ -13,7 +13,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## 2.0.15
 
-* [ENHANCEMENT] Add support for the results cache used by the query frontend
+* [ENHANCEMENT] Add support for the results cache used by the query frontend #1411
 
 ## 2.0.14
 

--- a/charts/mimir-distributed/CHANGELOG.md
+++ b/charts/mimir-distributed/CHANGELOG.md
@@ -14,6 +14,10 @@ Entries should include a reference to the Pull Request that introduced the chang
 ## 2.0.15
 
 * [ENHANCEMENT] Add support for the results cache used by the query frontend #1411
+  - This will result in additional resource usage due to the addition of one or
+    more memcached replicas. This applies when using small.yaml, large.yaml,
+    capped-large.yaml, capped-small.yaml, or when setting
+    `memcached-results.enabled=true`
 
 ## 2.0.14
 

--- a/charts/mimir-distributed/Chart.lock
+++ b/charts/mimir-distributed/Chart.lock
@@ -8,8 +8,11 @@ dependencies:
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
   version: 5.5.2
+- name: memcached
+  repository: https://charts.bitnami.com/bitnami
+  version: 5.5.2
 - name: minio
   repository: https://helm.min.io/
   version: 8.0.10
-digest: sha256:8a8861e8a68eae8dacbba0be65dbfcee5574629ebe4fd5bfd7ffee11e58f889d
-generated: "2022-03-30T17:30:35.654777032+01:00"
+digest: sha256:721e88dc6ab63573059b45b7d0d0c680c0702d34f9bdf396bcfbad121f830c9e
+generated: "2022-05-24T12:43:43.108071-05:00"

--- a/charts/mimir-distributed/Chart.yaml
+++ b/charts/mimir-distributed/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.0.14
+version: 2.0.15
 appVersion: 2.0.0
 description: "Grafana Mimir"
 engine: gotpl
@@ -23,6 +23,11 @@ dependencies:
     version: 5.5.2
     repository: https://charts.bitnami.com/bitnami
     condition: memcached-metadata.enabled
+  - name: memcached
+    alias: memcached-results
+    version: 5.5.2
+    repository: https://charts.bitnami.com/bitnami
+    condition: memcached-results.enabled
   - name: minio
     alias: minio
     version: 8.0.10

--- a/charts/mimir-distributed/README.md
+++ b/charts/mimir-distributed/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/v2.0.x/)
 
 # mimir-distributed
 
-![Version: 2.0.14](https://img.shields.io/badge/Version-2.0.14-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.0.15](https://img.shields.io/badge/Version-2.0.15-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Mimir
 
@@ -17,6 +17,7 @@ Kubernetes: `^1.10.0-0`
 | https://charts.bitnami.com/bitnami | memcached(memcached) | 5.5.2 |
 | https://charts.bitnami.com/bitnami | memcached-queries(memcached) | 5.5.2 |
 | https://charts.bitnami.com/bitnami | memcached-metadata(memcached) | 5.5.2 |
+| https://charts.bitnami.com/bitnami | memcached-results(memcached) | 5.5.2 |
 | https://helm.min.io/ | minio(minio) | 8.0.10 |
 
 ## Dependencies

--- a/charts/mimir-distributed/capped-large.yaml
+++ b/charts/mimir-distributed/capped-large.yaml
@@ -82,6 +82,10 @@ memcached-queries:
 memcached-metadata:
   enabled: true
 
+memcached-results:
+  enabled: true
+  replicaCount: 4
+
 minio:
   enabled: false
 

--- a/charts/mimir-distributed/capped-small.yaml
+++ b/charts/mimir-distributed/capped-small.yaml
@@ -82,6 +82,9 @@ memcached-queries:
 memcached-metadata:
   enabled: true
 
+memcached-results:
+  enabled: true
+
 minio:
   enabled: false
 

--- a/charts/mimir-distributed/large.yaml
+++ b/charts/mimir-distributed/large.yaml
@@ -80,6 +80,10 @@ memcached-queries:
 memcached-metadata:
   enabled: true
 
+memcached-results:
+  enabled: true
+  replicaCount: 4
+
 minio:
   enabled: false
 

--- a/charts/mimir-distributed/small.yaml
+++ b/charts/mimir-distributed/small.yaml
@@ -80,6 +80,9 @@ memcached-queries:
 memcached-metadata:
   enabled: true
 
+memcached-results:
+  enabled: true
+
 minio:
   enabled: false
 

--- a/charts/mimir-distributed/values.yaml
+++ b/charts/mimir-distributed/values.yaml
@@ -88,6 +88,14 @@ mimir:
     frontend:
       log_queries_longer_than: 10s
       align_queries_with_step: true
+      {{- if index .Values "memcached-results" "enabled" }}
+      results_cache:
+        backend: memcached
+        memcached:
+          addresses: dns+{{ .Release.Name }}-memcached-results.{{ .Release.Namespace }}.svc:11211
+          max_item_size: {{ (index .Values "memcached-results").maxItemMemory }}
+      cache_results: true
+      {{- end }}
 
     compactor:
       data_dir: "/data"
@@ -1029,6 +1037,38 @@ memcached-queries:
       memory: 2457Mi  # (floor (* 1.2 2048))
 
 memcached-metadata:
+  enabled: false
+  architecture: high-availability
+  arguments:
+    - -m 512
+    - -o
+    - modern
+    - -v
+    - -I 1m
+    - -c 1024
+  image:
+    repository: memcached
+    tag: 1.6.9
+  # maxItemMemory is in bytes. Should match memcached -I flag (which is in MB)
+  # It is a string to avoid https://github.com/helm/helm/issues/1707.
+  maxItemMemory: '1048576'  # (* 1 (* 1024 1024))
+  metrics:
+    enabled: true
+    image:
+      registry: quay.io
+      repository: prometheus/memcached-exporter
+      tag: v0.9.0
+  replicaCount: 1
+  resources:
+    limits:
+      # memory limits should match requests
+      memory: 614Mi
+    requests:
+      cpu: 500m
+      # memory requests should be exceed memcached -m flag
+      memory: 614Mi  # (floor (* 1.2 512))
+
+memcached-results:
   enabled: false
   architecture: high-availability
   arguments:


### PR DESCRIPTION
Fixes https://github.com/grafana/helm-charts/issues/1403

Tested locally that the results cache is used for subsequent requests for the same data.

Note `fetched_chunk_bytes`, etc are `0`, and response_time is sub 10ms.

```
level=info ts=2022-05-24T17:33:25.8620796Z caller=handler.go:223 org_id=anonymous msg="query stats" component=query-frontend method=POST path=/prometheus/api/v1/query_range response_time=123.8518ms query_wall_time_seconds=0.116888 fetched_series_count=1000 fetched_chunk_bytes=3394000 fetched_chunks_count=3000 sharded_queries=0 param_end=1653411855 param_query=sum(cortex_load_generator_sine_wave) param_start=1653409470 param_step=15                                                                                          
level=info ts=2022-05-24T17:33:31.9627418Z caller=handler.go:223 org_id=anonymous msg="query stats" component=query-frontend method=POST path=/prometheus/api/v1/query_range response_time=2.3415ms query_wall_time_seconds=0 fetched_series_count=0 fetched_chunk_bytes=0 fetched_chunks_count=0 sharded_queries=0 param_start=1653409470 param_step=15 param_end=1653411855 param_query=sum(cortex_load_generator_sine_wave)                                                                                                               
```

Also tested upgrade from previous chart and enabling / disabling the results cache.

Signed-off-by: Patrick Oyarzun <patrick.oyarzun@grafana.com>