### PR TITLE
[loki-simple-scalable] Match more closely Grafana Labs deployments

### DIFF
--- a/charts/loki-simple-scalable/Chart.yaml
+++ b/charts/loki-simple-scalable/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-simple-scalable
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.5.0
-version: 1.0.0
+version: 1.1.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-simple-scalable/templates/_helpers.tpl
+++ b/charts/loki-simple-scalable/templates/_helpers.tpl
@@ -68,7 +68,7 @@ Create the name of the service account to use
 */}}
 {{- define "loki.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
-    {{ default (include "loki.fullname" .) .Values.serviceAccount.name }}
+    {{ default (include "loki.name" .) .Values.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}

--- a/charts/loki-simple-scalable/templates/configmap.yaml
+++ b/charts/loki-simple-scalable/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "loki.fullname" . }}
+  name: {{ include "loki.name" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 data:

--- a/charts/loki-simple-scalable/templates/gateway/_helpers-gateway.tpl
+++ b/charts/loki-simple-scalable/templates/gateway/_helpers-gateway.tpl
@@ -2,7 +2,7 @@
 gateway fullname
 */}}
 {{- define "loki.gatewayFullname" -}}
-{{ include "loki.fullname" . }}-gateway
+{{ include "loki.name" . }}-gateway
 {{- end }}
 
 {{/*

--- a/charts/loki-simple-scalable/templates/podsecuritypolicy.yaml
+++ b/charts/loki-simple-scalable/templates/podsecuritypolicy.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ include "loki.fullname" . }}
+  name: {{ include "loki.name" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:

--- a/charts/loki-simple-scalable/templates/prometheusrule.yaml
+++ b/charts/loki-simple-scalable/templates/prometheusrule.yaml
@@ -3,7 +3,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ include "loki.fullname" $ }}
+  name: {{ include "loki.name" $ }}
   {{- with .namespace }}
   namespace: {{ . }}
   {{- end }}

--- a/charts/loki-simple-scalable/templates/read/_helpers-read.tpl
+++ b/charts/loki-simple-scalable/templates/read/_helpers-read.tpl
@@ -2,7 +2,7 @@
 read fullname
 */}}
 {{- define "loki.readFullname" -}}
-{{ include "loki.fullname" . }}-read
+{{ include "loki.name" . }}-read
 {{- end }}
 
 {{/*

--- a/charts/loki-simple-scalable/templates/read/service-read-headless.yaml
+++ b/charts/loki-simple-scalable/templates/read/service-read-headless.yaml
@@ -8,9 +8,9 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: http
+    - name: http-metrics
       port: 3100
-      targetPort: http
+      targetPort: http-metrics
       protocol: TCP
     - name: grpc
       port: 9095

--- a/charts/loki-simple-scalable/templates/read/service-read.yaml
+++ b/charts/loki-simple-scalable/templates/read/service-read.yaml
@@ -10,9 +10,9 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: http
+    - name: http-metrics
       port: 3100
-      targetPort: http
+      targetPort: http-metrics
       protocol: TCP
     - name: grpc
       port: 9095

--- a/charts/loki-simple-scalable/templates/read/statefulset-read.yaml
+++ b/charts/loki-simple-scalable/templates/read/statefulset-read.yaml
@@ -28,6 +28,9 @@ spec:
         {{- end }}
       labels:
         {{- include "loki.readSelectorLabels" . | nindent 8 }}
+        {{- with .Values.read.selectorLabels }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
         app.kubernetes.io/part-of: memberlist
     spec:
       serviceAccountName: {{ include "loki.serviceAccountName" . }}
@@ -50,7 +53,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
-            - name: http
+            - name: http-metrics
               containerPort: 3100
               protocol: TCP
             - name: grpc
@@ -108,7 +111,7 @@ spec:
             secretName: {{ .Values.loki.existingSecretForConfig }}
           {{- else }}
           configMap:
-            name: {{ include "loki.fullname" . }}
+            name: {{ include "loki.name" . }}
           {{- end }}
         {{- if .Values.enterprise.enabled }}
         - name: license

--- a/charts/loki-simple-scalable/templates/role.yaml
+++ b/charts/loki-simple-scalable/templates/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "loki.fullname" . }}
+  name: {{ include "loki.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}

--- a/charts/loki-simple-scalable/templates/rolebinding.yaml
+++ b/charts/loki-simple-scalable/templates/rolebinding.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "loki.fullname" . }}
+  name: {{ include "loki.name" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "loki.fullname" . }}
+  name: {{ include "loki.name" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "loki.serviceAccountName" . }}

--- a/charts/loki-simple-scalable/templates/securitycontextconstraints.yaml
+++ b/charts/loki-simple-scalable/templates/securitycontextconstraints.yaml
@@ -2,7 +2,7 @@
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: {{ include "loki.fullname" . }}
+  name: {{ include "loki.name" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 allowHostDirVolumePlugin: false

--- a/charts/loki-simple-scalable/templates/service-memberlist.yaml
+++ b/charts/loki-simple-scalable/templates/service-memberlist.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "loki.fullname" . }}-memberlist
+  name: {{ include "loki.name" . }}-memberlist
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:

--- a/charts/loki-simple-scalable/templates/tokengen/_helpers.yaml
+++ b/charts/loki-simple-scalable/templates/tokengen/_helpers.yaml
@@ -2,7 +2,7 @@
 tokengen fullname
 */}}
 {{- define "enterprise-logs.tokengenFullname" -}}
-{{ include "loki.fullname" . }}-tokengen
+{{ include "loki.name" . }}-tokengen
 {{- end }}
 
 {{/*

--- a/charts/loki-simple-scalable/templates/tokengen/job-tokengen.yaml
+++ b/charts/loki-simple-scalable/templates/tokengen/job-tokengen.yaml
@@ -1,15 +1,15 @@
-{{ if and .Values.tokengen.enable .Values.enterprise.enabled }}
+{{ if and .Values.enterprise.tokengen.enabled .Values.enterprise.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "enterprise-logs.tokengenFullname" . }}
   labels:
     {{- include "enterprise-logs.tokengenLabels" . | nindent 4 }}
-    {{- with .Values.tokengen.labels }}
+    {{- with .Values.enterprise.tokengen.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
-    {{- with .Values.tokengen.annotations }}
+    {{- with .Values.enterprise.tokengen.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
     "helm.sh/hook": post-install
@@ -21,19 +21,19 @@ spec:
     metadata:
       labels:
         {{- include "enterprise-logs.tokengenSelectorLabels" . | nindent 8 }}
-        {{- with .Values.tokengen.labels }}
+        {{- with .Values.enterprise.tokengen.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
-        {{- with .Values.tokengen.annotations }}
+        {{- with .Values.enterprise.tokengen.annotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.tokengen.priorityClassName }}
-      priorityClassName: {{ .Values.tokengen.priorityClassName }}
+      {{- if .Values.enterprise.tokengen.priorityClassName }}
+      priorityClassName: {{ .Values.enterprise.tokengen.priorityClassName }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.tokengen.securityContext | nindent 8 }}
+        {{- toYaml .Values.enterprise.tokengen.securityContext | nindent 8 }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       {{- range .Values.imagePullSecrets }}
@@ -48,12 +48,12 @@ spec:
             - -config.file=/etc/loki/config/config.yaml
             - -target=tokengen
             - -tokengen.token-file=/shared/admin-token
-            {{- with .Values.tokengen.extraArgs }}
+            {{- with .Values.enterprise.tokengen.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           volumeMounts:
-            {{- if .Values.tokengen.extraVolumeMounts }}
-              {{ toYaml .Values.tokengen.extraVolumeMounts | nindent 12 }}
+            {{- if .Values.enterprise.tokengen.extraVolumeMounts }}
+              {{ toYaml .Values.enterprise.tokengen.extraVolumeMounts | nindent 12 }}
             {{- end }}
             - name: shared
               mountPath: /shared
@@ -62,8 +62,8 @@ spec:
             - name: license
               mountPath: /etc/loki/license
           env:
-            {{- if .Values.tokengen.env }}
-              {{ toYaml .Values.tokengen.env | nindent 12 }}
+            {{- if .Values.enterprise.tokengen.env }}
+              {{ toYaml .Values.enterprise.tokengen.env | nindent 12 }}
             {{- end }}
       containers:
         - name: create-secret
@@ -72,10 +72,10 @@ spec:
           command:
             - /bin/bash
             - -euc
-            - kubectl create secret generic {{ .Values.tokengen.adminTokenSecret }} --from-file=token=/shared/admin-token --from-literal=grafana-token="$(base64 <(echo :$(cat /shared/admin-token)))"
+            - kubectl create secret generic {{ .Values.enterprise.tokengen.adminTokenSecret }} --from-file=token=/shared/admin-token --from-literal=grafana-token="$(base64 <(echo :$(cat /shared/admin-token)))"
           volumeMounts:
-            {{- if .Values.tokengen.extraVolumeMounts }}
-              {{ toYaml .Values.tokengen.extraVolumeMounts | nindent 12 }}
+            {{- if .Values.enterprise.tokengen.extraVolumeMounts }}
+              {{ toYaml .Values.enterprise.tokengen.extraVolumeMounts | nindent 12 }}
             {{- end }}
             - name: shared
               mountPath: /shared
@@ -88,23 +88,23 @@ spec:
       serviceAccountName: {{ template "enterprise-logs.tokengenFullname" . }}
       volumes:
         - name: config
-          {{- if .Values.useExternalConfig }}
+          {{- if .Values.enterprise.useExternalConfig }}
           secret:
-            secretName: {{ .Values.externalConfigName }}
+            secretName: {{ .Values.enterprise.externalConfigName }}
           {{- else }}
           configMap:
-            name: {{ include "loki.fullname" . }}
+            name: {{ include "loki.name" . }}
           {{- end }}
         - name: license
           secret:
-          {{- if .Values.useExternalLicense }}
-            secretName: {{ .Values.externalLicenseName }}
+          {{- if .Values.enterprise.useExternalLicense }}
+            secretName: {{ .Values.enterprise.externalLicenseName }}
           {{- else }}
             secretName: enterprise-logs-license
           {{- end }}
         - name: shared
           emptyDir: {}
-        {{- if .Values.tokengen.extraVolumes }}
-        {{ toYaml .Values.tokengen.extraVolumes | nindent 8 }}
+        {{- if .Values.enterprise.tokengen.extraVolumes }}
+        {{ toYaml .Values.enterprise.tokengen.extraVolumes | nindent 8 }}
         {{- end }}
 {{- end }}

--- a/charts/loki-simple-scalable/templates/tokengen/role-tokengen.yaml
+++ b/charts/loki-simple-scalable/templates/tokengen/role-tokengen.yaml
@@ -1,15 +1,15 @@
-{{ if and .Values.tokengen.enable .Values.enterprise.enabled }}
+{{ if and .Values.enterprise.tokengen.enabled .Values.enterprise.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "enterprise-logs.tokengenFullname" . }}
   labels:
     {{- include "enterprise-logs.tokengenLabels" . | nindent 4 }}
-    {{- with .Values.tokengen.labels }}
+    {{- with .Values.enterprise.tokengen.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
-    {{- with .Values.tokengen.annotations }}
+    {{- with .Values.enterprise.tokengen.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
     "helm.sh/hook": post-install

--- a/charts/loki-simple-scalable/templates/tokengen/rolebinding-tokengen.yaml
+++ b/charts/loki-simple-scalable/templates/tokengen/rolebinding-tokengen.yaml
@@ -1,15 +1,15 @@
-{{ if and .Values.tokengen.enable .Values.enterprise.enabled }}
+{{ if and .Values.enterprise.tokengen.enabled .Values.enterprise.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "enterprise-logs.tokengenFullname" . }}
   labels:
     {{- include "enterprise-logs.tokengenLabels" . | nindent 4 }}
-    {{- with .Values.tokengen.labels }}
+    {{- with .Values.enterprise.tokengen.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
-    {{- with .Values.tokengen.annotations }}
+    {{- with .Values.enterprise.tokengen.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
     "helm.sh/hook": post-install

--- a/charts/loki-simple-scalable/templates/tokengen/serviceaccount-tokengen.yaml
+++ b/charts/loki-simple-scalable/templates/tokengen/serviceaccount-tokengen.yaml
@@ -1,15 +1,15 @@
-{{ if and .Values.tokengen.enable .Values.enterprise.enabled }}
+{{ if and .Values.enterprise.tokengen.enabled .Values.enterprise.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "enterprise-logs.tokengenFullname" . }}
   labels:
     {{- include "enterprise-logs.tokengenLabels" . | nindent 4 }}
-    {{- with .Values.tokengen.labels }}
+    {{- with .Values.enterprise.tokengen.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
-    {{- with .Values.tokengen.annotations }}
+    {{- with .Values.enterprise.tokengen.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
     "helm.sh/hook": post-install

--- a/charts/loki-simple-scalable/templates/write/_helpers-write.tpl
+++ b/charts/loki-simple-scalable/templates/write/_helpers-write.tpl
@@ -2,7 +2,7 @@
 write fullname
 */}}
 {{- define "loki.writeFullname" -}}
-{{ include "loki.fullname" . }}-write
+{{ include "loki.name" . }}-write
 {{- end }}
 
 {{/*

--- a/charts/loki-simple-scalable/templates/write/service-write-headless.yaml
+++ b/charts/loki-simple-scalable/templates/write/service-write-headless.yaml
@@ -8,9 +8,9 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: http
+    - name: http-metrics
       port: 3100
-      targetPort: http
+      targetPort: http-metrics
       protocol: TCP
     - name: grpc
       port: 9095

--- a/charts/loki-simple-scalable/templates/write/service-write.yaml
+++ b/charts/loki-simple-scalable/templates/write/service-write.yaml
@@ -10,9 +10,9 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: http
+    - name: http-metrics
       port: 3100
-      targetPort: http
+      targetPort: http-metrics
       protocol: TCP
     - name: grpc
       port: 9095

--- a/charts/loki-simple-scalable/templates/write/statefulset-write.yaml
+++ b/charts/loki-simple-scalable/templates/write/statefulset-write.yaml
@@ -29,6 +29,9 @@ spec:
         {{- end }}
       labels:
         {{- include "loki.writeSelectorLabels" . | nindent 8 }}
+        {{- with .Values.write.selectorLabels }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
         app.kubernetes.io/part-of: memberlist
     spec:
       serviceAccountName: {{ include "loki.serviceAccountName" . }}
@@ -51,7 +54,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
-            - name: http
+            - name: http-metrics
               containerPort: 3100
               protocol: TCP
             - name: grpc
@@ -105,7 +108,7 @@ spec:
             secretName: {{ .Values.loki.existingSecretForConfig }}
           {{- else }}
           configMap:
-            name: {{ include "loki.fullname" . }}
+            name: {{ include "loki.name" . }}
           {{- end }}
         {{- if .Values.enterprise.enabled }}
         - name: license

--- a/charts/loki-simple-scalable/values.yaml
+++ b/charts/loki-simple-scalable/values.yaml
@@ -173,6 +173,8 @@ enterprise:
   # -- Name of external licesne secret to use
   externalLicenseName: null
 
+  # -- If enabled, the correct admin_client storage will be configured. If disabled while running enterprise,
+  # make sure auth is set to `type: trust`, or that `auth_enabled` is set to `false`.
   adminApi:
     enabled: true
 

--- a/charts/loki-simple-scalable/values.yaml
+++ b/charts/loki-simple-scalable/values.yaml
@@ -26,7 +26,7 @@ loki:
   readinessProbe:
     httpGet:
       path: /ready
-      port: http
+      port: http-metrics
     initialDelaySeconds: 30
     timeoutSeconds: 1
   image:
@@ -63,7 +63,7 @@ loki:
     {{- if .Values.enterprise.enabled}}
     {{- tpl .Values.enterprise.config . }}
     {{- else }}
-    auth_enabled: false
+    auth_enabled: {{ .Values.loki.authEnabled }}
     {{- end }}
 
     server:
@@ -72,7 +72,7 @@ loki:
 
     memberlist:
       join_members:
-        - {{ include "loki.fullname" . }}-memberlist
+        - {{ include "loki.name" . }}-memberlist
 
     {{- if .Values.loki.commonConfig}}
     common:
@@ -91,7 +91,23 @@ loki:
     {{- if .Values.loki.schemaConfig}}
     schema_config:
     {{- toYaml .Values.loki.schemaConfig | nindent 2}}
-    {{- end}}
+    {{- else }}
+    schema_config:
+      configs:
+        - from: 2022-01-11
+          store: boltdb-shipper
+          {{- if eq .Values.loki.storage.type "s3" }}
+          object_store: s3
+          {{- else if eq .Values.loki.storage.type "gcs" }}
+          object_store: gcs
+          {{- else }}
+          object_store: filesystem
+          {{- end }}
+          schema: v12
+          index:
+            prefix: loki_index_
+            period: 24h
+    {{- end }}
 
     {{- if or .Values.minio.enabled (eq .Values.loki.storage.type "s3") (eq .Values.loki.storage.type "gcs") }}
     ruler:
@@ -99,6 +115,9 @@ loki:
         s3:
           bucketnames: {{ .Values.loki.storage.bucketNames.ruler }}
     {{- end -}}
+
+  # Should authentication be enabled
+  authEnabled: true
 
   # -- Check https://grafana.com/docs/loki/latest/configuration/#common_config for more info on how to provide a common configuration
   commonConfig:
@@ -127,15 +146,7 @@ loki:
       rules_directory: /var/loki/rules
 
   # -- Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas
-  schemaConfig:
-    configs:
-      - from: 2020-09-07
-        store: boltdb-shipper
-        object_store: filesystem
-        schema: v11
-        index:
-          prefix: loki_index_
-          period: 24h
+  schemaConfig: {}
 
   # -- Structured loki configuration, takes precedence over `loki.config`, `loki.schemaConfig`, `loki.storageConfig`
   structuredConfig: {}
@@ -156,17 +167,28 @@ enterprise:
   license:
     contents: "NOTAVALIDLICENSE"
 
+  # -- Set to true when providing an external license
+  useExternalLicense: false
+
+  # -- Name of external licesne secret to use
+  externalLicenseName: null
+
+  adminApi:
+    enabled: true
+
   # enterprise specific sections of the config.yaml file
   config: |
+    {{- if .Values.enterprise.adminApi.enabled }}
     {{- if or .Values.minio.enabled (eq .Values.loki.storage.type "s3") (eq .Values.loki.storage.type "gcs") }}
     admin_client:
       storage:
         s3:
           bucket_name: {{ .Values.loki.storage.bucketNames.admin }}
     {{- end }}
+    {{- end }}
     auth:
-      type: enterprise
-    auth_enabled: true
+      type: {{ .Values.enterprise.adminApi.enabled | ternary "enterprise" "trust" }}
+    auth_enabled: {{ .Values.loki.authEnabled }}
     cluster_name: {{ .Release.Name }}
     license:
       path: /etc/loki/license/license.jwt
@@ -180,6 +202,31 @@ enterprise:
     tag: v1.4.0
     # -- Docker image pull policy
     pullPolicy: IfNotPresent
+
+  # -- Configuration for `tokengen` target
+  tokengen:
+    # -- Whether the job should be part of the deployment
+    enabled: true
+    # -- Name of the secret to store the admin token in
+    adminTokenSecret: "gel-admin-token"
+    # -- Additional CLI arguments for the `tokengen` target
+    extraArgs: []
+    # -- Additional Kubernetes environment
+    env: []
+    # -- Additional labels for the `tokengen` Job
+    labels: {}
+    # -- Additional annotations for the `tokengen` Job
+    annotations: {}
+    # -- Additional volumes for Pods
+    extraVolumes: []
+    # -- Additional volume mounts for Pods
+    extraVolumeMounts: []
+    # -- Run containers as user `enterprise-logs(uid=10001)`
+    securityContext:
+      runAsNonRoot: true
+      runAsGroup: 10001
+      runAsUser: 10001
+      fsGroup: 10001
 
   nginxConfig:
     file: |
@@ -296,31 +343,6 @@ enterprise:
         }
       }
 
-# -- Configuration for `tokengen` target
-tokengen:
-  # -- Whether the job should be part of the deployment
-  enable: true
-  # -- Name of the secret to store the admin token in
-  adminTokenSecret: "gel-admin-token"
-  # -- Additional CLI arguments for the `tokengen` target
-  extraArgs: []
-  # -- Additional Kubernetes environment
-  env: []
-  # -- Additional labels for the `tokengen` Job
-  labels: {}
-  # -- Additional annotations for the `tokengen` Job
-  annotations: {}
-  # -- Additional volumes for Pods
-  extraVolumes: []
-  # -- Additional volume mounts for Pods
-  extraVolumeMounts: []
-  # -- Run containers as user `enterprise-logs(uid=10001)`
-  securityContext:
-    runAsNonRoot: true
-    runAsGroup: 10001
-    runAsUser: 10001
-    fsGroup: 10001
-
 serviceAccount:
   # -- Specifies whether a ServiceAccount should be created
   create: true
@@ -401,6 +423,8 @@ write:
   priorityClassName: null
   # -- Annotations for write pods
   podAnnotations: {}
+  # -- Additional selector labels for each `write` pod
+  selectorLabels: {}
   # -- Labels for ingestor service
   serviceLabels: {}
   # -- Additional CLI args for the write
@@ -428,13 +452,6 @@ write:
             matchLabels:
               {{- include "loki.writeSelectorLabels" . | nindent 10 }}
           topologyKey: kubernetes.io/hostname
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 100
-          podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                {{- include "loki.writeSelectorLabels" . | nindent 12 }}
-            topologyKey: failure-domain.beta.kubernetes.io/zone
   # -- Node selector for write pods
   nodeSelector: {}
   # -- Tolerations for write pods
@@ -475,6 +492,8 @@ read:
   priorityClassName: null
   # -- Annotations for read pods
   podAnnotations: {}
+  # -- Additional selecto labels for each `read` pod
+  selectorLabels: {}
   # -- Labels for read service
   serviceLabels: {}
   # -- Additional CLI args for the read
@@ -500,13 +519,6 @@ read:
             matchLabels:
               {{- include "loki.readSelectorLabels" . | nindent 10 }}
           topologyKey: kubernetes.io/hostname
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 100
-          podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                {{- include "loki.readSelectorLabels" . | nindent 12 }}
-            topologyKey: failure-domain.beta.kubernetes.io/zone
   # -- Node selector for read pods
   nodeSelector: {}
   # -- Tolerations for read pods
@@ -593,13 +605,6 @@ gateway:
             matchLabels:
               {{- include "loki.gatewaySelectorLabels" . | nindent 10 }}
           topologyKey: kubernetes.io/hostname
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 100
-          podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                {{- include "loki.gatewaySelectorLabels" . | nindent 12 }}
-            topologyKey: failure-domain.beta.kubernetes.io/zone
   # -- Node selector for gateway pods
   nodeSelector: {}
   # -- Tolerations for gateway pods


### PR DESCRIPTION
This PR represent changes made to the helm chart to make it easier to run internally at Grafana Labs.

* In order to better support this helm chart, we are spinning up an
  environment at Grafana Labs that uses it. In order to do so, a few
  changes were necessary.
* Also includes a few ease of use changes like:
  * less verbose names
  * better automatic schema config based on storage type
  * ability to add extra selector labels to pods of stateful sets