### PR TITLE
Make workflows in this repository reusable from other repositories

### DIFF
--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -1,6 +1,7 @@
 name: Check CODEOWNERS
 
-on: pull_request
+on: workflow_call
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,4 +4,6 @@ on: pull_request
 
 jobs:
   call-lint:
-    uses: grafana/helm-charts/.github/workflows/linter.yml
+    uses: ./.github/workflows/linter.yml
+  call-lint-test:
+    uses: ./.github/workflows/lint-test.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on: pull_request
 
 jobs:
+  call-check-codeowners:
+    uses: ./.github/workflows/check-codeowners.yaml
   call-lint:
     uses: ./.github/workflows/linter.yml
   call-lint-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,7 @@
+name: CI
+
+on: pull_request
+
+jobs:
+  call-lint:
+    uses: grafana/helm-charts/.github/workflows/linter.yml

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,6 +1,16 @@
 name: Lint and Test Charts
 
-on: pull_request
+on:
+  workflow_call:
+    inputs:
+      ct_configfile:
+        description: location of the ct config file
+        default: ct.yaml
+        required: false
+        type: string
+
+env:
+  CT_CONFIGFILE: ${{ inputs.ct_configfile }}
 
 jobs:
   lint-test:
@@ -29,13 +39,13 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --config ct.yaml)
+          changed=$(ct list-changed --config "${CT_CONFIGFILE}")
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --config ct.yaml
+        run: ct lint --config "${CT_CONFIGFILE}"
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
@@ -43,9 +53,9 @@ jobs:
 
       - name: Run chart-testing (install)
         run: |
-          changed=$(ct list-changed --config ct.yaml)
+          changed=$(ct list-changed --config "${CT_CONFIGFILE}")
           if [[ "$changed" == "charts/enterprise-metrics" ]]; then
             # Do not run `ct install` for enterprise-metrics
             exit 0
           fi
-          ct install --config ct.yaml
+          ct install --config "${CT_CONFIGFILE}"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -3,7 +3,14 @@ name: Lint Code Base
 # Documentation:
 # https://help.github.com/en/articles/workflow-syntax-for-github-actions
 
-on: pull_request
+on:
+  workflow_call:
+    inputs:
+      filter_regex_include:
+        description: this sets the scope of the super linter
+        default: ".*"
+        required: false
+        type: string
 
 jobs:
   build:
@@ -25,6 +32,7 @@ jobs:
         uses: docker://github/super-linter:v3.12.0
         env:
           FILTER_REGEX_EXCLUDE: .*(README\.md|Chart\.yaml|NOTES.txt).*
+          FILTER_REGEX_INCLUDE: ${{ inputs.filter_regex_include }}
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_KUBERNETES_KUBEVAL: false
           VALIDATE_YAML: false


### PR DESCRIPTION
This PR enables storing helm charts next to their product (like we do with jsonnet), but still allows to reuse common github actions for linting and testing. Out of scope: release (will be another PR).