### PR TITLE
Reusable workflow to release a chart from a different repository

### DIFF
--- a/.github/workflows/update-helm-repo.yaml
+++ b/.github/workflows/update-helm-repo.yaml
@@ -1,0 +1,185 @@
+name: Release a chart
+
+on:
+  workflow_call:
+    inputs:
+      charts_dir:
+        description: path to the helm charts
+        default: charts
+        required: false
+        type: string
+      cr_configfile:
+        description: location of the chart releaser (cr) config file
+        default: cr.yaml
+        required: false
+        type: string
+      ct_configfile:
+        description: location of the chart tester (ct) config file
+        default: ct.yaml
+        required: false
+        type: string
+    secrets:
+      helm_repo_token:
+        description: GitHub api token to use against the helm-charts repository
+        required: true
+      gpg_key_base64:
+        description: GPG key in base64 for signing helm package with
+        required: true
+
+env:
+  CR_CONFIGFILE: "${{ github.workspace }}/source/${{ inputs.cr_configfile }}"
+  CT_CONFIGFILE: "${{ github.workspace }}/source/${{ inputs.ct_configfile }}"
+  CR_INDEX_PATH: "${{ github.workspace }}/.cr-index"
+  CR_KEYRING: "${{ github.workspace }}/.cr-gpg/secring.gpg"
+  CR_PACKAGE_PATH: "${{ github.workspace }}/.cr-release-packages"
+  CR_TOOL_PATH: "${{ github.workspace }}/.cr-tool"
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.list-changed.outputs.changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          path: source
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.1.0
+
+      - name: List changed charts
+        id: list-changed
+        run: |
+          cd source
+          changed=$(ct list-changed --config "${CT_CONFIGFILE}")
+          echo "${changed}"
+          num_changed=$(wc -l <<< ${changed})
+          if [[ "${num_changed}" -gt "1" ]] ; then
+            echo "More than one chart changed, exiting"
+            exit 1
+          fi
+          if [[ -n "${changed}" ]]; then
+            echo "::set-output name=changed::true"
+          else
+            echo "::set-output name=changed::false"
+          fi
+
+  release:
+    needs: [ setup ]
+    runs-on: ubuntu-latest
+    if: needs.setup.outputs.changed == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          path: source
+
+      - name: Configure Git
+        run: |
+          cd source
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Checkout helm-charts
+        # The cr tool only works if the target repository is already checked out
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          repository: grafana/helm-charts
+          path: helm-charts
+          token: ${{ secrets.helm_repo_token }}
+
+      - name: Configure Git for helm-charts
+        run: |
+          cd helm-charts
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.5.2
+
+      - name: Prepare GPG key
+        run: |
+          keyring_dir=$(dirname "${CR_KEYRING}")
+          mkdir "${keyring_dir}"
+          base64 -d <<< "$GPG_KEY_BASE64" > "${CR_KEYRING}"
+        env:
+          GPG_KEY_BASE64: "${{ secrets.gpg_key_base64 }}"
+
+      - name: Add dependency chart repos
+        run: |
+          helm repo add elastic https://helm.elastic.co
+          helm repo add grafana https://grafana.github.io/helm-charts
+          helm repo add prometheus https://prometheus-community.github.io/helm-charts
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add hashicorp https://helm.releases.hashicorp.com
+          helm repo add minio https://helm.min.io
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.1.0
+
+      - name: Parse Chart.yaml
+        id: parse-chart
+        run: |
+          cd source
+          changed=$(ct list-changed --config "${CT_CONFIGFILE}")
+          description=$(yq ".description" < ${changed}/Chart.yaml)
+          name=$(yq ".name" < ${changed}/Chart.yaml)
+          version=$(yq ".version" < ${changed}/Chart.yaml)
+          echo "::set-output name=chartpath::${changed}"
+          echo "::set-output name=desc::${description}"
+          echo "::set-output name=tagname::${name}-${version}"
+
+      - name: Install CR tool
+        run: |
+          mkdir "${CR_TOOL_PATH}"
+          mkdir "${CR_PACKAGE_PATH}"
+          mkdir "${CR_INDEX_PATH}"
+          curl -sSLo cr.tar.gz "https://github.com/helm/chart-releaser/releases/download/v1.4.0/chart-releaser_1.4.0_linux_amd64.tar.gz"
+          tar -xzf cr.tar.gz -C "${CR_TOOL_PATH}"
+          rm -f cr.tar.gz
+
+      - name: Create helm package
+        run: |
+          cd source
+          "${CR_TOOL_PATH}/cr" package "${{ steps.parse-chart.outputs.chartpath }}" --config "${CR_CONFIGFILE}" --package-path "${CR_PACKAGE_PATH}"
+          echo "Result of chart package:"
+          ls -l "${CR_PACKAGE_PATH}"
+
+      - name: Create tag and check if exists on origin
+        run: |
+          cd source
+          echo "Making tag ${{ steps.parse-chart.outputs.tagname }}"
+          git tag "${{ steps.parse-chart.outputs.tagname }}"
+
+      - name: Make github release
+        uses: softprops/action-gh-release@v1
+        with:
+          body: |
+            ${{ steps.parse-chart.outputs.desc }}
+
+            Source commit: https://github.com/${{ github.repository }}/commit/${{ github.sha }}
+
+            Tag on source: https://github.com/${{ github.repository }}/releases/tag/${{ steps.parse-chart.outputs.tagname }}
+          files: |
+            ${{ env.CR_PACKAGE_PATH }}/${{ steps.parse-chart.outputs.tagname }}.tgz
+            ${{ env.CR_PACKAGE_PATH }}/${{ steps.parse-chart.outputs.tagname }}.tgz.prov
+          repository: grafana/helm-charts
+          tag_name: ${{ steps.parse-chart.outputs.tagname }}
+          token: ${{ secrets.helm_repo_token }}
+
+      - name: Push release tag on origin
+        run: |
+          cd source
+          echo "Pushing tag ${{ steps.parse-chart.outputs.tagname }}"
+          git push origin "${{ steps.parse-chart.outputs.tagname }}"
+
+      - name: Update helm repo index.yaml
+        run: |
+          cd helm-charts
+          "${CR_TOOL_PATH}/cr" index --config "${CR_CONFIGFILE}" --token "${{ secrets.helm_repo_token }}" --index-path "${CR_INDEX_PATH}" --package-path "${CR_PACKAGE_PATH}" --pr


### PR DESCRIPTION
This workflow builds a chart in a source repository and releases it
to the helm-charts repository. It tags the source repository. It creates
a PR to update the helm repo index.yaml in the helm-charts repository.

Eventually we'd want the workflow to just commit the change to the index.yaml for helm without a PR - but let's test things e2e first.

**Note** this workflow is only triggered by other workflows, not by itself.

Signed-off-by: György Krajcsovits <gyorgy.krajcsovits@grafana.com>