### PR TITLE
Enable push to gh-pages automatically from chart releaser

### DIFF
--- a/.github/workflows/update-helm-repo.yaml
+++ b/.github/workflows/update-helm-repo.yaml
@@ -182,4 +182,4 @@ jobs:
       - name: Update helm repo index.yaml
         run: |
           cd helm-charts
-          "${CR_TOOL_PATH}/cr" index --config "${CR_CONFIGFILE}" --token "${{ secrets.helm_repo_token }}" --index-path "${CR_INDEX_PATH}" --package-path "${CR_PACKAGE_PATH}" --pr
+          "${CR_TOOL_PATH}/cr" index --config "${CR_CONFIGFILE}" --token "${{ secrets.helm_repo_token }}" --index-path "${CR_INDEX_PATH}" --package-path "${CR_PACKAGE_PATH}" --push


### PR DESCRIPTION
Testing of the update via pull request is finished. Enable push to
the branch so no manual action is needed.

Signed-off-by: György Krajcsovits <gyorgy.krajcsovits@grafana.com>