### PR TITLE
[loki-canary] Adding flexibility to add pod labels to loki-canary daemon set

### DIFF
--- a/charts/loki-canary/Chart.yaml
+++ b/charts/loki-canary/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-canary
 description: Helm chart for Grafana Loki Canary
 type: application
 appVersion: 2.5.0
-version: 0.8.0
+version: 0.8.1
 home: https://github.com/grafana/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-canary/README.md
+++ b/charts/loki-canary/README.md
@@ -1,6 +1,6 @@
 # loki-canary
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki Canary
 

--- a/charts/loki-canary/README.md
+++ b/charts/loki-canary/README.md
@@ -38,6 +38,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | nameOverride | string | `""` | Overrides the chart's name |
 | nodeSelector | object | `{}` | Node selector for canary pods |
 | podAnnotations | object | `{}` | Common annotations for all pods |
+| podLabels | object | `{}` | Common labels for all pods |
 | priorityClassName | string | `nil` | The name of the PriorityClass for pods |
 | resources | object | `{}` | Resource requests and limits for the canary |
 | revisionHistoryLimit | int | `10` | The number of old ReplicaSets to retain to allow rollback |

--- a/charts/loki-canary/templates/daemonset.yaml
+++ b/charts/loki-canary/templates/daemonset.yaml
@@ -17,6 +17,9 @@ spec:
         {{- end }}
       labels:
         {{- include "loki-canary.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "loki-canary.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}

--- a/charts/loki-canary/values.yaml
+++ b/charts/loki-canary/values.yaml
@@ -21,6 +21,9 @@ priorityClassName: null
 # -- Common annotations for all pods
 podAnnotations: {}
 
+# -- Common labels for all pods
+podLabels: {}
+
 # -- The number of old ReplicaSets to retain to allow rollback
 revisionHistoryLimit: 10
 


### PR DESCRIPTION
We are using loki-canary charts and wanted to manage pods using some custom labels on pods. Loki-Canary doesn't provide fexibility yet to use custom podLabels on Daemonset loki-canary. Added .Values.podLabels that can be applied to loki-canary daemonset.