### PR TITLE
[tempo] add securityContext & enable removing tempoQuery container 

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 0.15.3
+version: 0.15.4
 appVersion: 1.4.1
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 0.15.3](https://img.shields.io/badge/Version-0.15.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.1](https://img.shields.io/badge/AppVersion-1.4.1-informational?style=flat-square)
+![Version: 0.15.4](https://img.shields.io/badge/Version-0.15.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.1](https://img.shields.io/badge/AppVersion-1.4.1-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 
@@ -56,20 +56,20 @@ Grafana Tempo Single Binary Mode
 | tempo.resources | object | `{}` |  |
 | tempo.retention | string | `"24h"` |  |
 | tempo.searchEnabled | bool | `false` | If true, enables Tempo's native search |
-| tempo.securityContext | object | `{}` | |
+| tempo.securityContext | object | `{}` |  |
 | tempo.server.http_listen_port | int | `3100` | HTTP server listen port |
 | tempo.storage.trace.backend | string | `"local"` |  |
 | tempo.storage.trace.local.path | string | `"/var/tempo/traces"` |  |
 | tempo.storage.trace.wal.path | string | `"/var/tempo/wal"` |  |
 | tempo.tag | string | `"1.4.1"` |  |
 | tempo.updateStrategy | string | `"RollingUpdate"` |  |
-| tempoQuery.enabled | bool | `true` | if False and tempo.searchEnabled = True, disables tempo-query container|
+| tempoQuery.enabled | bool | `true` | if False and tempo.searchEnabled = True, disables tempo-query container |
 | tempoQuery.extraArgs | object | `{}` |  |
 | tempoQuery.extraEnv | list | `[]` | Environment variables to add |
 | tempoQuery.extraVolumeMounts | list | `[]` | Volume mounts to add |
 | tempoQuery.pullPolicy | string | `"IfNotPresent"` |  |
 | tempoQuery.repository | string | `"grafana/tempo-query"` |  |
-| tempoQuery.securityContext | object | `{}` | |
+| tempoQuery.securityContext | object | `{}` |  |
 | tempoQuery.tag | string | `"1.4.1"` |  |
 | tolerations | list | `[]` |  |
 

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -24,6 +24,7 @@ Grafana Tempo Single Binary Mode
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
 | replicas | int | `1` |  |
+| securityContext | object | `{}` |  |
 | service.annotations | object | `{}` |  |
 | service.labels | object | `{}` |  |
 | service.type | string | `"ClusterIP"` |  |
@@ -55,17 +56,20 @@ Grafana Tempo Single Binary Mode
 | tempo.resources | object | `{}` |  |
 | tempo.retention | string | `"24h"` |  |
 | tempo.searchEnabled | bool | `false` | If true, enables Tempo's native search |
+| tempo.securityContext | object | `{}` | |
 | tempo.server.http_listen_port | int | `3100` | HTTP server listen port |
 | tempo.storage.trace.backend | string | `"local"` |  |
 | tempo.storage.trace.local.path | string | `"/var/tempo/traces"` |  |
 | tempo.storage.trace.wal.path | string | `"/var/tempo/wal"` |  |
 | tempo.tag | string | `"1.4.1"` |  |
 | tempo.updateStrategy | string | `"RollingUpdate"` |  |
+| tempoQuery.enabled | bool | `true` | if False and tempo.searchEnabled = True, disables tempo-query container|
 | tempoQuery.extraArgs | object | `{}` |  |
 | tempoQuery.extraEnv | list | `[]` | Environment variables to add |
 | tempoQuery.extraVolumeMounts | list | `[]` | Volume mounts to add |
 | tempoQuery.pullPolicy | string | `"IfNotPresent"` |  |
 | tempoQuery.repository | string | `"grafana/tempo-query"` |  |
+| tempoQuery.securityContext | object | `{}` | |
 | tempoQuery.tag | string | `"1.4.1"` |  |
 | tolerations | list | `[]` |  |
 

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -63,7 +63,7 @@ Grafana Tempo Single Binary Mode
 | tempo.storage.trace.wal.path | string | `"/var/tempo/wal"` |  |
 | tempo.tag | string | `"1.4.1"` |  |
 | tempo.updateStrategy | string | `"RollingUpdate"` |  |
-| tempoQuery.enabled | bool | `true` | if False and tempo.searchEnabled = True, disables tempo-query container |
+| tempoQuery.enabled | bool | `true` | if False the tempo-query container is not deployed |
 | tempoQuery.extraArgs | object | `{}` |  |
 | tempoQuery.extraEnv | list | `[]` | Environment variables to add |
 | tempoQuery.extraVolumeMounts | list | `[]` | Volume mounts to add |

--- a/charts/tempo/templates/configmap-tempo-query.yaml
+++ b/charts/tempo/templates/configmap-tempo-query.yaml
@@ -1,3 +1,4 @@
+{{- if or (not .Values.tempo.searchEnabled) .Values.tempoQuery.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,3 +9,4 @@ metadata:
 data:
   tempo-query.yaml: |
     backend: {{ template "tempo.fullname" . }}:{{ .Values.tempo.server.http_listen_port }}
+{{- end }}

--- a/charts/tempo/templates/configmap-tempo-query.yaml
+++ b/charts/tempo/templates/configmap-tempo-query.yaml
@@ -1,4 +1,4 @@
-{{- if or (not .Values.tempo.searchEnabled) .Values.tempoQuery.enabled }}
+{{- if .Values.tempoQuery.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/tempo/templates/service.yaml
+++ b/charts/tempo/templates/service.yaml
@@ -35,7 +35,7 @@ spec:
   - name: tempo-prom-metrics
     port: 3100
     targetPort: 3100
-  {{- if or (not .Values.tempo.searchEnabled) .Values.tempoQuery.enabled }}
+  {{- if .Values.tempoQuery.enabled }}
   - name: jaeger-metrics
     port: 16687
     targetPort: 16687

--- a/charts/tempo/templates/service.yaml
+++ b/charts/tempo/templates/service.yaml
@@ -35,12 +35,14 @@ spec:
   - name: tempo-prom-metrics
     port: 3100
     targetPort: 3100
+  {{- if or (not .Values.tempo.searchEnabled) .Values.tempoQuery.enabled }}
   - name: jaeger-metrics
     port: 16687
     targetPort: 16687
   - name: tempo-query-jaeger-ui
     port: 16686
     targetPort: 16686
+  {{- end }}
   - name: tempo-jaeger-thrift-compact
     port: 6831
     protocol: UDP

--- a/charts/tempo/templates/statefulset.yaml
+++ b/charts/tempo/templates/statefulset.yaml
@@ -81,7 +81,7 @@ spec:
         - mountPath: /var/tempo
           name: storage
         {{- end }}
-      {{- if or (not .Values.tempo.searchEnabled) .Values.tempoQuery.enabled }}
+      {{- if .Values.tempoQuery.enabled }}
       - args:
         - --query.base-path=/
         - --grpc-storage-plugin.configuration-file=/conf/tempo-query.yaml

--- a/charts/tempo/templates/statefulset.yaml
+++ b/charts/tempo/templates/statefulset.yaml
@@ -63,6 +63,10 @@ spec:
           name: opencensus
         resources:
           {{- toYaml .Values.tempo.resources | nindent 10 }}
+        {{- with .Values.tempo.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
           {{- if .Values.tempo.extraEnv }}
             {{- toYaml .Values.tempo.extraEnv | nindent 12 }}
@@ -77,6 +81,7 @@ spec:
         - mountPath: /var/tempo
           name: storage
         {{- end }}
+      {{- if or (not .Values.tempo.searchEnabled) .Values.tempoQuery.enabled }}
       - args:
         - --query.base-path=/
         - --grpc-storage-plugin.configuration-file=/conf/tempo-query.yaml
@@ -97,18 +102,27 @@ spec:
           {{- end }}
         resources:
           {{- toYaml .Values.tempoQuery.resources | nindent 10 }}
+        {{- with .Values.tempoQuery.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         {{- if .Values.tempoQuery.extraVolumeMounts -}}
           {{ toYaml .Values.tempoQuery.extraVolumeMounts | nindent 8 }}
         {{- end }}
         - mountPath: /conf
           name: tempo-query-conf
+      {{- end }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.securityContext }}
+      securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -127,7 +127,7 @@ tempoQuery:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
-  ## remove tempo-query container if tempo.searchEnabled = true and tempoQuery.enabled = false
+  # -- if False and tempo.searchEnabled = True, disables tempo-query container
   enabled: true
   ## Additional container arguments
   extraArgs: {}

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -80,6 +80,12 @@ tempo:
           endpoint: "0.0.0.0:4317"
         http:
           endpoint: "0.0.0.0:4318"
+  securityContext: {}
+    # allowPrivilegeEscalation: false
+    #  capabilities:
+    #    drop:
+    #    - ALL
+    # readOnlyRootFilesystem: true
   ## Additional container arguments
   extraArgs: {}
   # -- Environment variables to add
@@ -120,6 +126,9 @@ tempoQuery:
   ##
   # pullSecrets:
   #   - myRegistryKeySecretName
+
+  ## remove tempo-query container if tempo.searchEnabled = true and tempoQuery.enabled = false
+  enabled: true
   ## Additional container arguments
   extraArgs: {}
   # -- Environment variables to add
@@ -130,6 +139,19 @@ tempoQuery:
   #   mountPath: /mnt/volume
   #   readOnly: true
   #   existingClaim: volume-claim
+  securityContext: {}
+    # allowPrivilegeEscalation: false
+    #  capabilities:
+    #    drop:
+    #    - ALL
+    # # readOnlyRootFilesystem: true # fails, do not enable
+
+# Add container securityContext
+securityContext: {}
+  # runAsUser: 65532
+  # runAsGroup: 65532
+  # fsGroup: 65532
+  # runAsNonRoot: true
 
 serviceAccount:
   # -- Specifies whether a ServiceAccount should be created

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -127,7 +127,7 @@ tempoQuery:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
-  # -- if False and tempo.searchEnabled = True, disables tempo-query container
+  # -- if False the tempo-query container is not deployed
   enabled: true
   ## Additional container arguments
   extraArgs: {}

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -144,7 +144,7 @@ tempoQuery:
     #  capabilities:
     #    drop:
     #    - ALL
-    # # readOnlyRootFilesystem: true # fails, do not enable
+    # readOnlyRootFilesystem: false # fails if true, do not enable
 
 # Add container securityContext
 securityContext: {}


### PR DESCRIPTION
This PR
- allows adding `securityContext` to
  - pod `tempo`
  - container `tempo`
  - container `tempo-query`
- allows for removing the container `tempo-query` for two reasons
  - not needed for Grafana 7.5+ as [Grafana 7.5.x and higher can query Tempo directly](https://grafana.com/docs/tempo/latest/configuration/querying/#grafana-75x-and-higher-easy-mode)
  - container `tempo-query` fails with `securityContext.readOnlyRootFilesystem: true`

Maintainers: feel free to modify, reword comments/readme.md or remove parts. 

#### Technical Requirements 
- [x] Signed-off-by: smartbit <smartbit@users.noreply.github.com>
- [x] follows [Chart Best Practices Guide](https://helm.sh/docs/chart_best_practices/)
- [x] chart linted & installed successfully using ct
- [x] bumped version to `0.15.4`