### PR TITLE
Allow to skip the version check during linting

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -8,6 +8,11 @@ on:
         default: ct.yaml
         required: false
         type: string
+      ct_check_version_increment:
+        description: whether to check for version bump requirement
+        default: true
+        required: false
+        type: boolean
 
 env:
   CT_CONFIGFILE: ${{ inputs.ct_configfile }}
@@ -45,7 +50,7 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --config "${CT_CONFIGFILE}"
+        run: ct lint --config "${CT_CONFIGFILE}" --check-version-increment=${{ inputs.ct_check_version_increment }}
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0


### PR DESCRIPTION
We'd like to release the Mimir chart periodically, not on every
PR. So version check won't be needed.

Signed-off-by: György Krajcsovits <gyorgy.krajcsovits@grafana.com>