### PR TITLE
[agent-operator] Add: Kubernetes recommended labels, custom labels and extra args

### DIFF
--- a/charts/agent-operator/Chart.yaml
+++ b/charts/agent-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: grafana-agent-operator
 description: A Helm chart for Grafana Agent Operator
 type: application
-version: 0.1.14
+version: 0.2.0
 appVersion: "0.24.2"
 home: https://grafana.com/docs/agent/latest/
 icon: https://raw.githubusercontent.com/grafana/agent/v0.24.2/docs/assets/logo_and_name.png

--- a/charts/agent-operator/Chart.yaml
+++ b/charts/agent-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: grafana-agent-operator
 description: A Helm chart for Grafana Agent Operator
 type: application
-version: 0.1.12
+version: 0.2.0
 appVersion: "0.24.2"
 home: https://grafana.com/docs/agent/latest/
 icon: https://raw.githubusercontent.com/grafana/agent/v0.24.2/docs/assets/logo_and_name.png

--- a/charts/agent-operator/README.md
+++ b/charts/agent-operator/README.md
@@ -1,6 +1,6 @@
 # grafana-agent-operator
 
-![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.2](https://img.shields.io/badge/AppVersion-0.24.2-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.2](https://img.shields.io/badge/AppVersion-0.24.2-informational?style=flat-square)
 
 A Helm chart for Grafana Agent Operator
 
@@ -55,6 +55,8 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Pod affinity configuration |
 | annotations | object | `{}` | Annotations for the Deployment |
+| customLabels | object | `{}` | Additional labels to add to all resources |
+| extraArgs | list | `[]` | List of additional cli arguments to configure agent-operator (example: `--log.level`) |
 | fullnameOverride | string | `""` | Overrides the chart's computed fullname |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.pullSecrets | list | `[]` | Image pull secrets |

--- a/charts/agent-operator/templates/_helpers.tpl
+++ b/charts/agent-operator/templates/_helpers.tpl
@@ -36,9 +36,14 @@ Common labels
 {{- define "ga-operator.labels" -}}
 {{ include "ga-operator.selectorLabels" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: operator
+app.kubernetes.io/part-of: {{ template "ga-operator.name" . }}
 helm.sh/chart: {{ include "ga-operator.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels }}
 {{- end }}
 {{- end }}
 

--- a/charts/agent-operator/templates/_helpers.tpl
+++ b/charts/agent-operator/templates/_helpers.tpl
@@ -37,7 +37,6 @@ Common labels
 {{ include "ga-operator.selectorLabels" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/component: operator
-app.kubernetes.io/part-of: {{ template "ga-operator.name" . }}
 helm.sh/chart: {{ include "ga-operator.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}

--- a/charts/agent-operator/templates/operator-clusterrole.yaml
+++ b/charts/agent-operator/templates/operator-clusterrole.yaml
@@ -4,8 +4,7 @@ kind: ClusterRole
 metadata:
   name: {{ include "ga-operator.fullname" . }}
   labels:
-    app.kubernetes.io/component: operator
-{{ include "ga-operator.labels" . | indent 4 }}
+    {{ include "ga-operator.labels" . | indent 4 }}
 rules:
 - apiGroups: [monitoring.grafana.com]
   resources:

--- a/charts/agent-operator/templates/operator-clusterrole.yaml
+++ b/charts/agent-operator/templates/operator-clusterrole.yaml
@@ -4,7 +4,7 @@ kind: ClusterRole
 metadata:
   name: {{ include "ga-operator.fullname" . }}
   labels:
-    {{ include "ga-operator.labels" . | indent 4 }}
+{{ include "ga-operator.labels" . | indent 4 }}
 rules:
 - apiGroups: [monitoring.grafana.com]
   resources:

--- a/charts/agent-operator/templates/operator-clusterrolebinding.yaml
+++ b/charts/agent-operator/templates/operator-clusterrolebinding.yaml
@@ -4,8 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "ga-operator.fullname" . }}
   labels:
-    app.kubernetes.io/component: operator
-{{ include "ga-operator.labels" . | indent 4 }}
+    {{ include "ga-operator.labels" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/agent-operator/templates/operator-clusterrolebinding.yaml
+++ b/charts/agent-operator/templates/operator-clusterrolebinding.yaml
@@ -4,7 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "ga-operator.fullname" . }}
   labels:
-    {{ include "ga-operator.labels" . | indent 4 }}
+{{ include "ga-operator.labels" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/agent-operator/templates/operator-deployment.yaml
+++ b/charts/agent-operator/templates/operator-deployment.yaml
@@ -35,21 +35,16 @@ spec:
         resources:
         {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- if and .Values.kubeletService.namespace .Values.kubeletService.serviceName }}
+        {{- if or (and .Values.kubeletService.namespace .Values.kubeletService.serviceName) (.Values.extraArgs) }}
         args:
+          {{- if and .Values.kubeletService.namespace .Values.kubeletService.serviceName }}
           - --kubelet-service={{ .Values.kubeletService.namespace }}/{{ .Values.kubeletService.serviceName }}
-          {{-  if .Values.extraArgs  }}
+          {{- end }}
+          {{- if .Values.extraArgs  }}
           {{- range .Values.extraArgs  }}
           - {{ . }}
           {{- end }}
           {{- end }}
-        {{- else}}
-        {{-  if .Values.extraArgs  }}
-        args:
-          {{- range .Values.extraArgs  }}
-          - {{ . }}
-          {{- end }}
-        {{- end }}
         {{- end }}
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/charts/agent-operator/templates/operator-deployment.yaml
+++ b/charts/agent-operator/templates/operator-deployment.yaml
@@ -3,8 +3,7 @@ kind: Deployment
 metadata:
   name: {{ include "ga-operator.fullname" . }}
   labels:
-    app.kubernetes.io/component: operator
-    {{- include "ga-operator.labels" . | nindent 4 }}
+    {{ include "ga-operator.labels" . | indent 4 }}
   {{- with .Values.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
@@ -13,11 +12,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-{{ include "ga-operator.selectorLabels" . | indent 6 }}
+      {{ include "ga-operator.selectorLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-{{ include "ga-operator.selectorLabels" . | indent 8 }}
+        {{ include "ga-operator.labels" . | indent 8 }}
 {{- with .Values.podAnnotations }}
       annotations:
 {{ toYaml . | indent 8 }}

--- a/charts/agent-operator/templates/operator-deployment.yaml
+++ b/charts/agent-operator/templates/operator-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ include "ga-operator.fullname" . }}
   labels:
-    {{ include "ga-operator.labels" . | indent 4 }}
+{{ include "ga-operator.labels" . | indent 4 }}
   {{- with .Values.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
@@ -12,11 +12,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{ include "ga-operator.selectorLabels" . | indent 6 }}
+{{ include "ga-operator.selectorLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        {{ include "ga-operator.labels" . | indent 8 }}
+{{ include "ga-operator.labels" . | indent 8 }}
 {{- with .Values.podAnnotations }}
       annotations:
 {{ toYaml . | indent 8 }}

--- a/charts/agent-operator/templates/operator-deployment.yaml
+++ b/charts/agent-operator/templates/operator-deployment.yaml
@@ -38,6 +38,18 @@ spec:
         {{- if and .Values.kubeletService.namespace .Values.kubeletService.serviceName }}
         args:
           - --kubelet-service={{ .Values.kubeletService.namespace }}/{{ .Values.kubeletService.serviceName }}
+          {{-  if .Values.extraArgs  }}
+          {{- range .Values.extraArgs  }}
+          - {{ . }}
+          {{- end }}
+          {{- end }}
+        {{- else}}
+        {{-  if .Values.extraArgs  }}
+        args:
+          {{- range .Values.extraArgs  }}
+          - {{ . }}
+          {{- end }}
+        {{- end }}
         {{- end }}
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/charts/agent-operator/templates/operator-serviceaccount.yaml
+++ b/charts/agent-operator/templates/operator-serviceaccount.yaml
@@ -4,6 +4,6 @@ kind: ServiceAccount
 metadata:
   name: {{ template "ga-operator.serviceAccountName" . }}
   labels:
-    {{ include "ga-operator.labels" . | indent 4 }}
+{{ include "ga-operator.labels" . | indent 4 }}
 {{- end -}}
 

--- a/charts/agent-operator/templates/operator-serviceaccount.yaml
+++ b/charts/agent-operator/templates/operator-serviceaccount.yaml
@@ -4,7 +4,6 @@ kind: ServiceAccount
 metadata:
   name: {{ template "ga-operator.serviceAccountName" . }}
   labels:
-    app.kubernetes.io/component: operator
-{{ include "ga-operator.labels" . | indent 4 }}
+    {{ include "ga-operator.labels" . | indent 4 }}
 {{- end -}}
 

--- a/charts/agent-operator/values.yaml
+++ b/charts/agent-operator/values.yaml
@@ -10,6 +10,10 @@ annotations: {}
 # -- Annotations for the Deployment Pods
 podAnnotations: {}
 
+# -- Additional labels to add to all resources
+customLabels: {}
+  # app: grafana-agent-operator
+
 # -- Pod security context (runAsUser, etc.)
 podSecurityContext: {}
 

--- a/charts/agent-operator/values.yaml
+++ b/charts/agent-operator/values.yaml
@@ -45,8 +45,7 @@ kubeletService:
   namespace: default
   serviceName: kubelet
 
-# List of additional cli arguments to configure grafana-agent-operator
-# for example: --log.level, etc.
+# -- List of additional cli arguments to configure agent-operator (example: `--log.level`)
 extraArgs: []
 
 # -- Resource limits and requests config

--- a/charts/agent-operator/values.yaml
+++ b/charts/agent-operator/values.yaml
@@ -45,6 +45,10 @@ kubeletService:
   namespace: default
   serviceName: kubelet
 
+# List of additional cli arguments to configure grafana-agent-operator
+# for example: --log.level, etc.
+extraArgs: []
+
 # -- Resource limits and requests config
 resources: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

**ENHANCEMENT**
In favour of using Kubernetes [recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) to `agent-operator`:

- Label `app.kubernetes.io/component` has been moved from resources to common label template;

**BUG-FIX**
Manifest `operator-deployment.yaml` contained a bug where deployment template metadata labels, were using `ga-operator.selectorLabels` instead of `ga-operator.labels`.

**FEATURE**
In addition, **optional** custom user labels can now be added to `agent-operator` resources:

```yaml
...
# -- Additional labels to add to all resources
customLabels: {}
  # app: grafana-agent-operator
...
```

**FEATURE**
Chart now supports adding extra arguments for the cli using `extraArgs`:

```yaml
...
# List of additional cli arguments to configure grafana-agent-operator
# for example: --log.level, etc.
extraArgs: []
...
```

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - none

#### Special notes for your reviewer:
Minor has been bumped, since there is some new features.
There is no breaking change (selector labels remain the same) and upgrade is performed normally (i.e. `helm upgrade --install`).

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/grafana/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[agent-operator]`)