### PR TITLE
Skip chart release if tag already exists

### DIFF
--- a/.github/workflows/update-helm-repo.yaml
+++ b/.github/workflows/update-helm-repo.yaml
@@ -66,9 +66,19 @@ jobs:
             exit 1
           fi
           if [[ -n "${changed}" ]]; then
-            echo "::set-output name=changed::true"
-            echo "::set-output name=chartpath::${changed}"
+            name=$(yq ".name" < ${changed}/Chart.yaml)
+            version=$(yq ".version" < ${changed}/Chart.yaml)
+
+            if [ $(git tag -l "${name}-${version}") ]; then
+              echo "Tag ${tagname} already exists, skipping release"
+              echo "::set-output name=changed::false"
+            else
+              echo "Releasing ${changed}"
+              echo "::set-output name=changed::true"
+              echo "::set-output name=chartpath::${changed}"
+            fi
           else
+            echo "No charts have changed, skipping release"
             echo "::set-output name=changed::false"
           fi
 


### PR DESCRIPTION
Also added some informational logging to aid debugging in the future

This is necessary for Mimir since we are moving to a weekly release instead of releasing every commit. There are potentially many commits with "changed" charts despite the version in `Chart.yaml` being unchanged. For example, this run failed when I merged some changes to main: https://github.com/grafana/mimir/actions/runs/2450081153

Signed-off-by: Patrick Oyarzun <patrick.oyarzun@grafana.com>