### PR TITLE
[grafana] add non object grafana.ini configs

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.29.6
+version: 6.29.7
 appVersion: 8.5.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/configmap.yaml
+++ b/charts/grafana/templates/configmap.yaml
@@ -14,7 +14,19 @@ data:
   plugins: {{ join "," .Values.plugins }}
 {{- end }}
   grafana.ini: |
+{{- range $elem, $elemVal := index .Values "grafana.ini" }}
+    {{- if not (kindIs "map" $elemVal) }}
+    {{- if kindIs "invalid" $elemVal }}
+    {{ $elem }} =
+    {{- else if kindIs "string" $elemVal }}
+    {{ $elem }} = {{ tpl $elemVal $ }}
+    {{- else }}
+    {{ $elem }} = {{ $elemVal }}
+    {{- end }}
+    {{- end }}
+{{- end }}
 {{- range $key, $value := index .Values "grafana.ini" }}
+    {{- if kindIs "map" $value }}
     [{{ $key }}]
     {{- range $elem, $elemVal := $value }}
     {{- if kindIs "invalid" $elemVal }}
@@ -23,6 +35,7 @@ data:
     {{ $elem }} = {{ tpl $elemVal $ }}
     {{- else }}
     {{ $elem }} = {{ $elemVal }}
+    {{- end }}
     {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
There are configs that are not an object within grafana.ini e.g. force_migration=<bool>
This commit adds these configs. With this change this will be possible in values.yml: 
grafana.ini:
  force_migration: true