### PR TITLE
[grafana] Add egress to network policy

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.29.11
+version: 6.29.12
 appVersion: 8.5.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.29.12
+version: 6.30.0
 appVersion: 8.5.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -246,6 +246,9 @@ This version requires Helm >= 3.1.0.
 | `networkPolicy.enabled`                    | Enable creation of NetworkPolicy resources.                                                                              | `false`             |
 | `networkPolicy.allowExternal`              | Don't require client label for connections                                                                               | `true`              |
 | `networkPolicy.explicitNamespacesSelector` | A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed                           | `{}`                |
+| `networkPolicy.ingress`                    | Enable the creation of an ingress network policy             | `true`    |
+| `networkPolicy.egress.enabled`             | Enable the creation of an egress network policy              | `false`   |
+| `networkPolicy.egress.ports`               | An array of ports to allow for the egress                    | `[]`    |
 | `enableKubeBackwardCompatibility`          | Enable backward compatibility of kubernetes where pod's defintion version below 1.13 doesn't have the enableServiceLinks option  | `false`     |
 
 

--- a/charts/grafana/templates/networkpolicy.yaml
+++ b/charts/grafana/templates/networkpolicy.yaml
@@ -30,7 +30,6 @@ spec:
     - ports:
         {{ .Values.networkPolicy.egress.ports | toJson }}
   {{- end }}
-
   {{- if .Values.networkPolicy.ingress }}
   ingress:
     - ports:
@@ -49,7 +48,5 @@ spec:
               {{- include "grafana.labels" . | nindent 14 }}
               role: read
       {{- end }}
-
   {{- end }}
-
 {{- end }}

--- a/charts/grafana/templates/networkpolicy.yaml
+++ b/charts/grafana/templates/networkpolicy.yaml
@@ -14,9 +14,24 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+  policyTypes:
+    {{- if .Values.networkPolicy.ingress }}
+    - Ingress
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.enabled }}
+    - Egress
+    {{- end }}
   podSelector:
     matchLabels:
     {{- include "grafana.selectorLabels" . | nindent 6 }}
+
+  {{- if .Values.networkPolicy.egress.enabled }}
+  egress:
+    - ports:
+        {{ .Values.networkPolicy.egress.ports | toJson }}
+  {{- end }}
+
+  {{- if .Values.networkPolicy.ingress }}
   ingress:
     - ports:
       - port: {{ .Values.service.targetPort }}
@@ -34,4 +49,7 @@ spec:
               {{- include "grafana.labels" . | nindent 14 }}
               role: read
       {{- end }}
+
+  {{- end }}
+
 {{- end }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -895,7 +895,7 @@ networkPolicy:
     enabled: false
     ##
     ## @param networkPolicy.egress.ports Add individual ports to be allowed by the egress
-    ports:
+    ports: []
     ## Add ports to the egress by specifying - port: <port number>
     ## E.X.
     ## ports:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -864,6 +864,10 @@ networkPolicy:
   ## When true, grafana will accept connections from any source
   ## (with the correct destination port).
   ##
+  ingress: true
+  ## @param networkPolicy.ingress When true enables the creation
+  ## an ingress network policy
+  ##
   allowExternal: true
   ## @param networkPolicy.explicitNamespacesSelector A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed
   ## If explicitNamespacesSelector is missing or set to {}, only client Pods that are in the networkPolicy's namespace
@@ -879,6 +883,30 @@ networkPolicy:
   ##    - {key: role, operator: In, values: [frontend]}
   ##
   explicitNamespacesSelector: {}
+  ##
+  ##
+  ##
+  ##
+  ##
+  ##
+  egress:
+    ## @param networkPolicy.egress.enabled When enabled, an egress network policy will be
+    ## created allowing grafana to connect to external data sources from kubernetes cluster.
+    enabled: false
+    ##
+    ## @param networkPolicy.egress.ports Add individual ports to be allowed by the egress
+    ports:
+    ## Add ports to the egress by specifying - port: <port number>
+    ## E.X.
+    ## ports:
+      ## - port: 80
+      ## - port: 443
+  ##
+  ##
+  ##
+  ##
+  ##
+  ##
 
 # Enable backward compatibility of kubernetes where version below 1.13 doesn't have the enableServiceLinks option
 enableKubeBackwardCompatibility: false


### PR DESCRIPTION
Found a need for egress to be added to the Grafana network policy. In some cases, datasources outside the cluster or namespace will need an egress to be able to connect.

Adding egress to the network policy with the ability to specify ports addresses this issue.

Signed-off-by: Wilson, Jason M <jason.wilson2@marist.edu>