### PR TITLE
[grafana] - HA Alerting: Allow StatefulSet to be used instead of Deployment

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.29.11
+version: 6.29.12
 appVersion: 8.5.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/deployment.yaml
+++ b/charts/grafana/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{ if (or (not .Values.persistence.enabled) (eq .Values.persistence.type "pvc")) }}
+{{ if (and (not .Values.useStatefulSet) (or (not .Values.persistence.enabled) (eq .Values.persistence.type "pvc"))) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/grafana/templates/statefulset.yaml
+++ b/charts/grafana/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-{{- if (or (.Values.useStatefulSet) (and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.persistence.type "statefulset"))}}
+{{- if (or (.Values.useStatefulSet) (and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.persistence.type "statefulset")))}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/grafana/templates/statefulset.yaml
+++ b/charts/grafana/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.persistence.type "statefulset")}}
+{{- if (or (.Values.useStatefulSet) (and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.persistence.type "statefulset"))}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -35,6 +35,7 @@ spec:
 {{- end }}
     spec:
       {{- include "grafana.pod" . | nindent 6 }}
+  {{- if .Values.persistence.enabled}}
   volumeClaimTemplates:
   - metadata:
       name: storage
@@ -49,4 +50,5 @@ spec:
         matchLabels:
 {{ toYaml . | indent 10 }}
       {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -882,7 +882,7 @@ networkPolicy:
 
 # Enable backward compatibility of kubernetes where version below 1.13 doesn't have the enableServiceLinks option
 enableKubeBackwardCompatibility: false
-
+useStatefulSet: false
 # Create a dynamic manifests via values:
 extraObjects: []
   # - apiVersion: "kubernetes-client.io/v1"


### PR DESCRIPTION
For HA Alerting:
Would like the ability to use a StatefulSet instead of a deployment. That way I can dynamically populate the ha-peers using predetermined host names.

Example:
```
ha_peers=grafana-0:9094,grafana-1:9094,grafana-2:9094
```