### PR TITLE
Update servicemonitor.yaml

### DIFF
--- a/charts/grafana/templates/servicemonitor.yaml
+++ b/charts/grafana/templates/servicemonitor.yaml
@@ -40,5 +40,5 @@ spec:
       {{- include "grafana.selectorLabels" . | nindent 8 }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ template "grafana.namespace" . }}
 {{- end }}


### PR DESCRIPTION
When `namespaceOverride` is set, the serviceMonitor does not work anymore without this fix.

Signed-off-by: Maurice Faber <maurice.faber@redkubes.com>