### PR TITLE
[grafana] Update servicemonitor.yaml

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.29.11
+version: 6.29.12
 appVersion: 8.5.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/servicemonitor.yaml
+++ b/charts/grafana/templates/servicemonitor.yaml
@@ -40,5 +40,5 @@ spec:
       {{- include "grafana.selectorLabels" . | nindent 8 }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ template "grafana.namespace" . }}
 {{- end }}


### PR DESCRIPTION
When namespaceOverride is set, the serviceMonitor does not work anymore without this fix.

Signed-off-by: Maurice Faber <morriz@idiotz.nl>