### PR TITLE
[enterprise-logs-simple] - gateway: Set the HTTP version for proxying to HTTP/1.1 

### DIFF
--- a/charts/enterprise-logs-simple/Chart.yaml
+++ b/charts/enterprise-logs-simple/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v2"
 name: "enterprise-logs-simple"
 type: application
-version: "1.2.0"
+version: "1.2.1"
 appVersion: "v1.4.0"
 kubeVersion: "^1.10.0-0"
 description: "DEPRECATED Grafana Enterprise Logs (Simple Scalable)"

--- a/charts/enterprise-logs-simple/values.yaml
+++ b/charts/enterprise-logs-simple/values.yaml
@@ -232,6 +232,8 @@ loki-simple-scalable:
           uwsgi_temp_path       /tmp/uwsgi_temp;
           scgi_temp_path        /tmp/scgi_temp;
 
+          proxy_http_version    1.1;
+
           default_type application/octet-stream;
           log_format   {{ .Values.gateway.nginxConfig.logFormat }}
 


### PR DESCRIPTION
Related to: https://github.com/grafana/helm-charts/pull/1339

By default nginx uses HTTP/1.0 for proxied requests : https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_http_version

This is suboptimal since promtail uses HTTP/1.1 and can cause issues with Istio which , by default, will reject anything lower than HTTP/1.1

Signed-off-by: Francesco Ciocchetti <primeroznl@gmail.com>
