### PR TITLE
[tempo-distributed] gateway: Set the HTTP version for proxying to HTTP/1.1

### DIFF
--- a/charts/loki-simple-scalable/Chart.yaml
+++ b/charts/loki-simple-scalable/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-simple-scalable
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.6.0
-version: 1.7.1
+version: 1.7.2
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-simple-scalable/values.yaml
+++ b/charts/loki-simple-scalable/values.yaml
@@ -249,6 +249,8 @@ enterprise:
         uwsgi_temp_path       /tmp/uwsgi_temp;
         scgi_temp_path        /tmp/scgi_temp;
 
+        proxy_http_version    1.1;
+
         default_type application/octet-stream;
         log_format   {{ .Values.gateway.nginxConfig.logFormat }}
 
@@ -760,6 +762,8 @@ gateway:
         fastcgi_temp_path     /tmp/fastcgi_temp;
         uwsgi_temp_path       /tmp/uwsgi_temp;
         scgi_temp_path        /tmp/scgi_temp;
+
+        proxy_http_version    1.1;
 
         default_type application/octet-stream;
         log_format   {{ .Values.gateway.nginxConfig.logFormat }}

--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.21.5
+version: 0.21.6
 appVersion: 1.4.1
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -1025,6 +1025,8 @@ gateway:
         uwsgi_temp_path       /tmp/uwsgi_temp;
         scgi_temp_path        /tmp/scgi_temp;
 
+        proxy_http_version    1.1;
+
         default_type application/octet-stream;
         log_format   {{ .Values.gateway.nginxConfig.logFormat }}
 


### PR DESCRIPTION
related to https://github.com/grafana/helm-charts/pull/1339

By default nginx uses HTTP/1.0 for proxied requests : https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_http_version

This is suboptimal since promtail uses HTTP/1.1 and can cause issues with Istio which , by default, will reject anything lower than HTTP/1.1

Slack conversation for reference: https://grafana.slack.com/archives/CEPJRLQNL/p1651595415595109

Signed-off-by: Francesco Ciocchetti <primeroznl@gmail.com>
