### PR TITLE
Add pod permission to agent operator

### DIFF
--- a/charts/agent-operator/Chart.yaml
+++ b/charts/agent-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: grafana-agent-operator
 description: A Helm chart for Grafana Agent Operator
 type: application
 version: 0.2.0
-appVersion: "0.24.2"
+appVersion: "0.24.3"
 home: https://grafana.com/docs/agent/latest/
 icon: https://raw.githubusercontent.com/grafana/agent/v0.24.2/docs/assets/logo_and_name.png
 sources:

--- a/charts/agent-operator/templates/operator-clusterrole.yaml
+++ b/charts/agent-operator/templates/operator-clusterrole.yaml
@@ -36,6 +36,7 @@ rules:
   resources:
   - namespaces
   - nodes
+  - pods
   verbs: [get, list, watch]
 - apiGroups: [""]
   resources:


### PR DESCRIPTION
Without this permission, the agent did not seem able to get logs. Maybe there's another way around this, but adding this permission fixed the problem for me.

Signed-off-by: Trevor Whitney <trevorjwhitney@gmail.com>