### PR TITLE
[loki]  Support .Values.extraEnvFrom

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 2.12.1
+version: 2.12.2
 appVersion: v2.5.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki/templates/statefulset.yaml
+++ b/charts/loki/templates/statefulset.yaml
@@ -100,6 +100,10 @@ spec:
             - name: JAEGER_AGENT_HOST
               value: "{{ .Values.tracing.jaegerAgentHost }}"
             {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
 {{- if .Values.extraContainers }}
 {{ toYaml .Values.extraContainers | indent 8}}
 {{- end }}

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -126,6 +126,8 @@ config:
 extraArgs: {}
   # log.level: debug
 
+extraEnvFrom: []
+
 livenessProbe:
   httpGet:
     path: /ready


### PR DESCRIPTION
This brings `loki` into line with some of the other charts, e.g. for providing credentials to object storage