### PR TITLE
[promtail] Change `/run/promtail` mount to configurable with `values.yaml`

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.5.0
-version: 5.1.0
+version: 6.0.0
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 5.1.0](https://img.shields.io/badge/Version-5.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 6.0.0](https://img.shields.io/badge/Version-6.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/templates/daemonset.yaml
+++ b/charts/promtail/templates/daemonset.yaml
@@ -62,8 +62,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/promtail
-            - name: run
-              mountPath: /run/promtail
             {{- with .Values.defaultVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -121,9 +119,6 @@ spec:
         - name: config
           secret:
             secretName: {{ include "promtail.fullname" . }}
-        - name: run
-          hostPath:
-            path: /run/promtail
         {{- with .Values.defaultVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -122,6 +122,9 @@ tolerations:
 # Use `extraVolumes`/`extraVolumeMounts` for additional custom volumes.
 # @default -- See `values.yaml`
 defaultVolumes:
+  - name: run
+    hostPath:
+      path: /run/promtail
   - name: containers
     hostPath:
       path: /var/lib/docker/containers
@@ -132,6 +135,8 @@ defaultVolumes:
 # -- Default volume mounts. Corresponds to `volumes`.
 # @default -- See `values.yaml`
 defaultVolumeMounts:
+  - name: run
+    mountPath: /run/promtail
   - name: containers
     mountPath: /var/lib/docker/containers
     readOnly: true


### PR DESCRIPTION
⚠ **BREAKING CHANGE** ⚠

By making `/run/promtail` mount configurable, platforms with limited `hostPath` specification (e.g. GKE Autopilot) will be able to use Helm Chart of Promtail.

Close #447
Close #644