### PR TITLE
[loki-distributed] Fix ignoring KubeVersion containing a platform version

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.5.0
-version: 0.48.5
+version: 0.48.6
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.48.5](https://img.shields.io/badge/Version-0.48.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 0.48.6](https://img.shields.io/badge/Version-0.48.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/templates/_helpers.tpl
+++ b/charts/loki-distributed/templates/_helpers.tpl
@@ -134,7 +134,7 @@ Return if ingress supports pathType.
 Return the appropriate apiVersion for PodDisruptionBudget.
 */}}
 {{- define "loki.pdb.apiVersion" -}}
-  {{- if and (.Capabilities.APIVersions.Has "policy/v1") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) -}}
+  {{- if and (.Capabilities.APIVersions.Has "policy/v1") (semverCompare ">=1.21-0" .Capabilities.KubeVersion.Version) -}}
     {{- print "policy/v1" -}}
   {{- else -}}
     {{- print "policy/v1beta1" -}}


### PR DESCRIPTION
Hi,

This PR is to handle KubeVersion containing a platform version like `1.22.9-eks-1` appropriately.

### Background

We run loki-distributed on EKS, and tried to upgrade loki-distributed to 0.48.5 to use `policy/v1` API for PodDisruptionBudgets. But `policy/v1` api doesn't appeared in the manifest.
According to [the docs](https://helm.sh/docs/chart_template_guide/function_list/#working-with-prerelease-versions) , semverCompare function skips a such KubeVersion if the version in the condition doesn't contain the suffix `-0`. This works on my environment.

Thanks.