### PR TITLE
[grafana] Bump Grafana to v9.0.1

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.30.3
-appVersion: 8.5.3
+version: 7.0.0
+appVersion: 9.0.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net


### PR DESCRIPTION
Bump Grafana app version to v9.0.1 https://github.com/grafana/grafana/releases/tag/v9.0.1
