### PR TITLE
[loki-simple-scalable] Fix: Simple Scalable Model Helm Chart README examples

### DIFF
--- a/charts/loki-simple-scalable/Chart.yaml
+++ b/charts/loki-simple-scalable/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-simple-scalable
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.5.0
-version: 1.4.2
+version: 1.4.3
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-simple-scalable/README.md
+++ b/charts/loki-simple-scalable/README.md
@@ -219,7 +219,7 @@ For exmaple, to use MinIO (deployed separately) as your backend, provide the fol
 
 ```yaml
 loki:
-  config:
+  config: |
     common:
       storage:
         filesystem: null
@@ -262,7 +262,7 @@ values, you must provide an entire `loki.config` value.
 
 ```yaml
 loki:
-  config:
+  config: |
     common:
       storage:
         s3:

--- a/charts/loki-simple-scalable/README.md
+++ b/charts/loki-simple-scalable/README.md
@@ -1,6 +1,6 @@
 # loki-simple-scalable
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 1.4.3](https://img.shields.io/badge/Version-1.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 


### PR DESCRIPTION
**Scope**: Simple Scalable Model Helm Chart Documentation

**Description**
[This commit ](https://github.com/grafana/helm-charts/commit/cab9e61ebdda23129bd59b4a813f5dd4749fc36b) updated the simple scalable model charts' loki.config value to be a string. However the examples were broken within the README. This PR fixes those examples.