### PR TITLE
Remove confusing mimir-distributed-beta chart from helm repo

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -20255,40 +20255,6 @@ entries:
     urls:
     - https://github.com/grafana/helm-charts/releases/download/mimir-distributed-0.1.1/mimir-distributed-0.1.1.tgz
     version: 0.1.1
-  mimir-distributed-beta:
-  - apiVersion: v2
-    appVersion: 2.0.0
-    created: "2022-06-01T15:10:40.396933728Z"
-    dependencies:
-    - alias: memcached
-      condition: memcached.enabled
-      name: memcached
-      repository: https://charts.bitnami.com/bitnami
-      version: 5.5.2
-    - alias: memcached-queries
-      condition: memcached-queries.enabled
-      name: memcached
-      repository: https://charts.bitnami.com/bitnami
-      version: 5.5.2
-    - alias: memcached-metadata
-      condition: memcached-metadata.enabled
-      name: memcached
-      repository: https://charts.bitnami.com/bitnami
-      version: 5.5.2
-    - alias: minio
-      condition: minio.enabled
-      name: minio
-      repository: https://helm.min.io/
-      version: 8.0.10
-    description: Grafana Mimir
-    digest: 9652e2e3cc7b27353c4231a438b5c1cf659fce5e8817e1e4d2b45bf792d4f23e
-    home: https://grafana.com/docs/mimir/v2.0.x/
-    icon: https://grafana.com/static/img/logos/logo-mimir.svg
-    kubeVersion: ^1.10.0-0
-    name: mimir-distributed-beta
-    urls:
-    - https://github.com/grafana/helm-charts/releases/download/mimir-distributed-beta-2.1.0-beta.1/mimir-distributed-beta-2.1.0-beta.1.tgz
-    version: 2.1.0-beta.1
   mimir-openshift-experimental:
   - apiVersion: v2
     appVersion: 2.0.0


### PR DESCRIPTION
This was never really in use, since we switched to using actual
beta versions instead with mimir-distributed chart.

Signed-off-by: György Krajcsovits <gyorgy.krajcsovits@grafana.com>