### PR TITLE
Adjustment of Tempo Helm chart

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 0.15.4
+version: 0.15.5
 appVersion: 1.4.1
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -41,19 +41,18 @@ tempo:
   server:
     # -- HTTP server listen port
     http_listen_port: 3100
-  # tempo storage backend
-  # refer https://github.com/grafana/tempo/tree/master/docs/tempo/website/configuration
-  ## Use s3 for example
-  # backend: s3                                         # store traces in s3
-  #  s3:
-  #    bucket: tempo                                   # store traces in this bucket
-  #    endpoint: s3.dualstack.us-east-2.amazonaws.com  # api endpoint
-  #    access_key: ...                                 # optional. access key when using static credentials.
-  #    secret_key: ...                                 # optional. secret key when using static credentials.
-  #    insecure: false                                 # optional. enable if endpoint is http
-  ## end
   storage:
     trace:
+      # tempo storage backend
+      # refer https://github.com/grafana/tempo/tree/master/docs/tempo/website/configuration
+      ## Use s3 for example
+      # backend: s3                                         # store traces in s3
+      # s3:
+      #   bucket: tempo                                   # store traces in this bucket
+      #   endpoint: s3.dualstack.us-east-2.amazonaws.com  # api endpoint
+      #   access_key: ...                                 # optional. access key when using static credentials.
+      #   secret_key: ...                                 # optional. secret key when using static credentials.
+      #   insecure: false                                 # optional. enable if endpoint is http
       backend: local
       local:
         path: /var/tempo/traces


### PR DESCRIPTION
hello,
The Tempo Helm chart needed some adjustment regarding the plcement of S3 storage. the commented example was in wrong place and alse indentition was wrong s3 object which was set under backend: s3