### PR TITLE
[enterprise-logs] Mount read/write /tmp directory in Compactor

### DIFF
--- a/charts/enterprise-logs/CHANGELOG.md
+++ b/charts/enterprise-logs/CHANGELOG.md
@@ -11,9 +11,23 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## 2.2.3
+
+- [BUGFIX] Mount rw /tmp directory in Compactor to fix error about read-only filesystem. #1548
+
+## 2.2.2
+
+## 2.2.1
+
+## 2.2.0
+
+## 2.1.0
+
 ## 2.0.4
 
 - [FEATURE] Added OpenShift support. #1085
+
+## 2.0.3
 
 ## 2.0.2
 

--- a/charts/enterprise-logs/Chart.yaml
+++ b/charts/enterprise-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v2"
 name: "enterprise-logs"
 type: application
-version: "2.2.2"
+version: "2.2.3"
 appVersion: "v1.4.1"
 kubeVersion: "^1.10.0-0"
 description: "Grafana Enterprise Logs"

--- a/charts/enterprise-logs/templates/compactor/statefulset-compactor.yaml
+++ b/charts/enterprise-logs/templates/compactor/statefulset-compactor.yaml
@@ -98,6 +98,8 @@ spec:
           {{- end }}
         - name: storage
           emptyDir: {}
+        - name: tmp
+          emptyDir: {}
         {{- if .Values.compactor.extraVolumes }}
         {{ toYaml .Values.compactor.extraVolumes | nindent 8 }}
         {{- end }}
@@ -129,6 +131,8 @@ spec:
               mountPath: /etc/enterprise-logs/license
             - name: storage
               mountPath: /var/loki
+            - name: tmp
+              mountPath: /tmp
             {{- if .Values.compactor.extraVolumeMounts }}
             {{ toYaml .Values.compactor.extraVolumeMounts | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
The /tmp directory is used to write temporary marker files and if it's not mounted, Loki will log errors about read-only file system.

This issue has already been addressed in the `loki` chart with #967, in the `loki-distributed` chart with #717, and in the `loki-simple-scalable` chart with #1146.

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>