### PR TITLE
[loki-distributed] Add optional appProtocol to memberlist svc

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.5.0
-version: 0.49.0
+version: 0.50.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.49.0](https://img.shields.io/badge/Version-0.49.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 0.50.0](https://img.shields.io/badge/Version-0.50.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 
@@ -218,6 +218,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | ingester.terminationGracePeriodSeconds | int | `300` | Grace period to allow the ingester to shutdown before it is killed. Especially for the ingestor, this must be increased. It must be long enough so ingesters can be gracefully shutdown flushing/transferring all data and to successfully leave the member ring on shutdown. |
 | ingester.tolerations | list | `[]` | Tolerations for ingester pods |
 | loki.annotations | object | `{}` | If set, these annotations are added to all of the Kubernetes controllers (Deployments, StatefulSets, etc) that this chart launches. Use this to implement something like the "Wave" controller or another controller that is monitoring top level deployment resources. |
+| loki.appProtocol | string | `""` | Adds the appProtocol field to the memberlist service. This allows memberlist to work with istio protocol selection. Ex: "http" or "tcp" |
 | loki.config | string | See values.yaml | Config file contents for Loki |
 | loki.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The SecurityContext for Loki containers |
 | loki.existingSecretForConfig | string | `""` | Specify an existing secret containing loki configuration. If non-empty, overrides `loki.config` |

--- a/charts/loki-distributed/templates/service-memberlist.yaml
+++ b/charts/loki-distributed/templates/service-memberlist.yaml
@@ -12,6 +12,9 @@ spec:
       port: 7946
       targetPort: http-memberlist
       protocol: TCP
+      {{- if .Values.loki.appProtocol }}
+      appProtocol: {{ .Values.loki.appProtocol }}
+      {{- end }}
   selector:
     {{- include "loki.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -68,6 +68,8 @@ loki:
     allowPrivilegeEscalation: false
   # -- Specify an existing secret containing loki configuration. If non-empty, overrides `loki.config`
   existingSecretForConfig: ""
+  # -- Adds the appProtocol field to the memberlist service. This allows memberlist to work with istio protocol selection. Ex: "http" or "tcp"
+  appProtocol: ""
   # -- Config file contents for Loki
   # @default -- See values.yaml
   config: |


### PR DESCRIPTION
This PR references the same issue as https://github.com/grafana/helm-charts/issues/1099, but for the loki-distributed helm-chart.

Using istio protocol selection, the ports break in the memberlist service and throw the following error:
```
level=warn ts=2021-08-13T10:42:42.205933Z caller=client.go:344 component=client host=api.*.appdomain.cloud msg=“error sending batch, will retry” status=500 error="server returned HTTP status 500 Internal Server Error (500): empty ring"
```

This can be fixed by adding the `appProtocol` field in the memberlist service and setting it to `tcp` for loki-distributed. If appProtocol is left empty, then it will be ignored and not included in the service.