### PR TITLE
[loki-stack] Update loki to 2.12.2

### DIFF
--- a/charts/loki-stack/Chart.yaml
+++ b/charts/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 2.6.5
+version: 2.6.6
 appVersion: v2.4.2
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki-stack/requirements.yaml
+++ b/charts/loki-stack/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - name: "loki"
   condition: loki.enabled
   repository: "https://grafana.github.io/helm-charts"
-  version: "^2.10.1"
+  version: "^2.12.2"
 - name: "promtail"
   condition: promtail.enabled
   repository: "https://grafana.github.io/helm-charts"


### PR DESCRIPTION
As a follow-up to #1513, this updates `loki-stack`'s `loki` requirement to a version that includes the change