### PR TITLE
[promtail] improve documentation for syslog and journal scraping

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.5.0
-version: 6.0.0
+version: 6.0.2
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 6.0.0](https://img.shields.io/badge/Version-6.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 6.0.2](https://img.shields.io/badge/Version-6.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -169,8 +169,22 @@ config:
         relabel_configs:
           - source_labels:
               - __syslog_message_hostname
-            target_label: host
+            target_label: hostname
+
+          # example label values: kernel, CRON, kubelet
+          - source_labels:
+              - __syslog_message_app_name
+            target_label: app
+
+          # example label values: debug, notice, informational, warning, error
+          - source_labels:
+              - __syslog_message_severity
+            target_label: level
 ```
+
+Find additional source labels in the Promtail's docs:
+
+https://grafana.com/docs/loki/latest/clients/promtail/configuration/#syslog
 
 ### Journald Support
 
@@ -187,27 +201,52 @@ config:
             job: systemd-journal
         relabel_configs:
           - source_labels:
-              - '__journal__systemd_unit'
-            target_label: 'unit'
-          - source_labels:
-              - '__journal__hostname'
-            target_label: 'hostname'
+              - __journal__hostname
+            target_label: hostname
 
-# Mount journal directory into promtail pods
+          # example label values: kubelet.service, containerd.service
+          - source_labels:
+              - __journal__systemd_unit
+            target_label: unit
+
+          # example label values: debug, notice, info, warning, error
+          - source_labels:
+              - __journal_priority_keyword
+            target_label: level
+
+# Mount journal directory and machine-id file into promtail pods
 extraVolumes:
   - name: journal
     hostPath:
       path: /var/log/journal
+  - name: machine-id
+    hostPath:
+      path: /etc/machine-id
 
 extraVolumeMounts:
   - name: journal
     mountPath: /var/log/journal
     readOnly: true
+  - name: machine-id
+    mountPath: /etc/machine-id
+    readOnly: true
 ```
+
+Find additional configuration options in Promtail's docs:
+
+https://grafana.com/docs/loki/latest/clients/promtail/configuration/#journal
+
+More journal source labels can be found here https://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html.
+> Note that each message from the journal may have a different set of fields and software may write an arbitrary set of custom fields for their logged messages. [(related issue)](https://github.com/grafana/loki/issues/2048#issuecomment-626234611)
+
+The machine-id needs to be available in the container as it is required for scraping.
+This is described in Promtail's scraping docs:
+
+https://grafana.com/docs/loki/latest/clients/promtail/scraping/#journal-scraping-linux-only
 
 ### Push API Support
 
-```
+```yaml
 extraPorts:
   httpPush:
     name: http-push

--- a/charts/promtail/README.md.gotmpl
+++ b/charts/promtail/README.md.gotmpl
@@ -99,8 +99,22 @@ config:
         relabel_configs:
           - source_labels:
               - __syslog_message_hostname
-            target_label: host
+            target_label: hostname
+
+          # example label values: kernel, CRON, kubelet
+          - source_labels:
+              - __syslog_message_app_name
+            target_label: app
+
+          # example label values: debug, notice, informational, warning, error
+          - source_labels:
+              - __syslog_message_severity
+            target_label: level
 ```
+
+Find additional source labels in the Promtail's docs:
+
+https://grafana.com/docs/loki/latest/clients/promtail/configuration/#syslog
 
 ### Journald Support
 
@@ -117,27 +131,52 @@ config:
             job: systemd-journal
         relabel_configs:
           - source_labels:
-              - '__journal__systemd_unit'
-            target_label: 'unit'
-          - source_labels:
-              - '__journal__hostname'
-            target_label: 'hostname'
+              - __journal__hostname
+            target_label: hostname
 
-# Mount journal directory into promtail pods
+          # example label values: kubelet.service, containerd.service
+          - source_labels:
+              - __journal__systemd_unit
+            target_label: unit
+
+          # example label values: debug, notice, info, warning, error
+          - source_labels:
+              - __journal_priority_keyword
+            target_label: level
+
+# Mount journal directory and machine-id file into promtail pods
 extraVolumes:
   - name: journal
     hostPath:
       path: /var/log/journal
+  - name: machine-id
+    hostPath:
+      path: /etc/machine-id
 
 extraVolumeMounts:
   - name: journal
     mountPath: /var/log/journal
     readOnly: true
+  - name: machine-id
+    mountPath: /etc/machine-id
+    readOnly: true
 ```
+
+Find additional configuration options in Promtail's docs:
+
+https://grafana.com/docs/loki/latest/clients/promtail/configuration/#journal
+
+More journal source labels can be found here https://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html.
+> Note that each message from the journal may have a different set of fields and software may write an arbitrary set of custom fields for their logged messages. [(related issue)](https://github.com/grafana/loki/issues/2048#issuecomment-626234611)
+
+The machine-id needs to be available in the container as it is required for scraping.
+This is described in Promtail's scraping docs:
+
+https://grafana.com/docs/loki/latest/clients/promtail/scraping/#journal-scraping-linux-only
 
 ### Push API Support
 
-```
+```yaml
 extraPorts:
   httpPush:
     name: http-push


### PR DESCRIPTION
This PR improves the docs for promtail syslog and journal scraping configs:
- add some useful source labels
- add some additional links to docs
- fix the journal example to mount `/etc/machine-id`  as described in the docs