### PR TITLE
[loki-simple-scalable] Ssd ruler config

### DIFF
--- a/charts/loki-simple-scalable/CHANGELOG.md
+++ b/charts/loki-simple-scalable/CHANGELOG.md
@@ -11,6 +11,14 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## 1.7.3
+
+- [BUGFIX] Fix a bug in how object storage client was defined for the ruler
+
+## 1.7.2
+
+- [ENHANCEMENT] Memcache can now easily be configured as an external caching option.
+
 ## 1.6.0
 
 - [FEATURE] Added self-monitoring option, with dashboards and Grafana Agent Operator custom resources to allow Loki to scrape it's own logs.

--- a/charts/loki-simple-scalable/Chart.yaml
+++ b/charts/loki-simple-scalable/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-simple-scalable
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.6.0
-version: 1.7.2
+version: 1.7.3
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-simple-scalable/README.md
+++ b/charts/loki-simple-scalable/README.md
@@ -1,6 +1,6 @@
 # loki-simple-scalable
 
-![Version: 1.7.2](https://img.shields.io/badge/Version-1.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.0](https://img.shields.io/badge/AppVersion-2.6.0-informational?style=flat-square)
+![Version: 1.7.3](https://img.shields.io/badge/Version-1.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.0](https://img.shields.io/badge/AppVersion-2.6.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/charts/loki-simple-scalable/templates/_helpers.tpl
+++ b/charts/loki-simple-scalable/templates/_helpers.tpl
@@ -150,6 +150,19 @@ filesystem:
 {{- end -}}
 
 {{/*
+Storage config for ruler
+*/}}
+{{- define "loki.rulerStorageConfig" -}}
+{{- if or .Values.minio.enabled (eq .Values.loki.storage.type "s3") -}}
+s3:
+  bucketnames: {{ $.Values.loki.storage.bucketNames.ruler }}
+{{- else if eq .Values.loki.storage.type "gcs" -}}
+gcs:
+  bucket_name: {{ $.Values.loki.storage.bucketNames.ruler }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Memcached Docker image
 */}}
 {{- define "loki.memcachedImage" -}}

--- a/charts/loki-simple-scalable/values.yaml
+++ b/charts/loki-simple-scalable/values.yaml
@@ -125,8 +125,7 @@ loki:
     {{- if or .Values.minio.enabled (eq .Values.loki.storage.type "s3") (eq .Values.loki.storage.type "gcs") }}
     ruler:
       storage:
-        s3:
-          bucketnames: {{ .Values.loki.storage.bucketNames.ruler }}
+      {{- include "loki.rulerStorageConfig" . | nindent 4}}
     {{- end -}}
 
     {{- with .Values.loki.memcached.results_cache }}


### PR DESCRIPTION
This is needed to fix a bug in the generated config that always assumed S3 for ruler storage. Fixes #1552.