### PR TITLE
[loki-distributed] Add service annotations to loki and memcached

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.5.0
-version: 0.50.0
+version: 0.51.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.50.0](https://img.shields.io/badge/Version-0.50.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 0.51.0](https://img.shields.io/badge/Version-0.51.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 
@@ -239,6 +239,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | loki.readinessProbe.timeoutSeconds | int | `1` |  |
 | loki.revisionHistoryLimit | int | `10` | The number of old ReplicaSets to retain to allow rollback |
 | loki.schemaConfig | object | `{"configs":[{"from":"2020-09-07","index":{"period":"24h","prefix":"loki_index_"},"object_store":"filesystem","schema":"v11","store":"boltdb-shipper"}]}` | Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas |
+| loki.serviceAnnotations | object | `{}` | Common annotations for all loki services |
 | loki.storageConfig | object | `{"boltdb_shipper":{"active_index_directory":"/var/loki/index","cache_location":"/var/loki/cache","cache_ttl":"168h","shared_store":"filesystem"},"filesystem":{"directory":"/var/loki/chunks"}}` | Check https://grafana.com/docs/loki/latest/configuration/#storage_config for more info on how to configure storages |
 | loki.structuredConfig | object | `{}` | Structured loki configuration, takes precedence over `loki.config`, `loki.schemaConfig`, `loki.storageConfig` |
 | memcached.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The SecurityContext for memcached containers |
@@ -253,6 +254,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | memcached.readinessProbe.initialDelaySeconds | int | `5` |  |
 | memcached.readinessProbe.tcpSocket.port | string | `"http"` |  |
 | memcached.readinessProbe.timeoutSeconds | int | `1` |  |
+| memcached.serviceAnnotations | object | `{}` | Common annotations for all memcached services |
 | memcachedChunks.affinity | string | Hard node and soft zone anti-affinity | Affinity for memcached-chunks pods. Passed through `tpl` and, thus, to be configured as string |
 | memcachedChunks.enabled | bool | `false` | Specifies whether the Memcached chunks cache should be enabled |
 | memcachedChunks.extraArgs | list | `["-I 32m"]` | Additional CLI args for memcached-chunks |

--- a/charts/loki-distributed/templates/compactor/service-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/service-compactor.yaml
@@ -9,6 +9,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     app.kubernetes.io/component: compactor
+  {{- with .Values.loki.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/loki-distributed/templates/distributor/service-distributor.yaml
+++ b/charts/loki-distributed/templates/distributor/service-distributor.yaml
@@ -7,6 +7,10 @@ metadata:
     {{- with .Values.distributor.serviceLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- with .Values.loki.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/loki-distributed/templates/index-gateway/service-index-gateway.yaml
+++ b/charts/loki-distributed/templates/index-gateway/service-index-gateway.yaml
@@ -8,6 +8,10 @@ metadata:
     {{- with .Values.indexGateway.serviceLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- with .Values.loki.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/loki-distributed/templates/ingester/service-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/service-ingester.yaml
@@ -7,6 +7,10 @@ metadata:
     {{- with .Values.ingester.serviceLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- with .Values.loki.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/loki-distributed/templates/memcached-chunks/service-memcached-chunks.yaml
+++ b/charts/loki-distributed/templates/memcached-chunks/service-memcached-chunks.yaml
@@ -8,6 +8,10 @@ metadata:
     {{- with .Values.memcachedChunks.serviceLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- with .Values.memcached.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/charts/loki-distributed/templates/memcached-frontend/service-memcached-frontend.yaml
+++ b/charts/loki-distributed/templates/memcached-frontend/service-memcached-frontend.yaml
@@ -8,6 +8,10 @@ metadata:
     {{- with .Values.memcachedFrontend.serviceLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- with .Values.memcached.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/charts/loki-distributed/templates/memcached-index-queries/service-memcached-index-queries.yaml
+++ b/charts/loki-distributed/templates/memcached-index-queries/service-memcached-index-queries.yaml
@@ -8,6 +8,10 @@ metadata:
     {{- with .Values.memcachedIndexQueries.serviceLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- with .Values.memcached.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/charts/loki-distributed/templates/memcached-index-writes/service-memcached-index-writes.yaml
+++ b/charts/loki-distributed/templates/memcached-index-writes/service-memcached-index-writes.yaml
@@ -8,6 +8,10 @@ metadata:
     {{- with .Values.memcachedIndexWrites.serviceLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- with .Values.memcached.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/charts/loki-distributed/templates/querier/service-querier.yaml
+++ b/charts/loki-distributed/templates/querier/service-querier.yaml
@@ -7,6 +7,10 @@ metadata:
     {{- with .Values.querier.serviceLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- with .Values.loki.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/loki-distributed/templates/query-frontend/service-query-frontend.yaml
+++ b/charts/loki-distributed/templates/query-frontend/service-query-frontend.yaml
@@ -7,6 +7,10 @@ metadata:
     {{- with .Values.queryFrontend.serviceLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- with .Values.loki.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/charts/loki-distributed/templates/ruler/service-ruler.yaml
+++ b/charts/loki-distributed/templates/ruler/service-ruler.yaml
@@ -8,6 +8,10 @@ metadata:
     {{- with .Values.ruler.serviceLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- with .Values.loki.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/charts/loki-distributed/templates/table-manager/service-table-manager.yaml
+++ b/charts/loki-distributed/templates/table-manager/service-table-manager.yaml
@@ -9,6 +9,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     app.kubernetes.io/component: table-manager
+  {{- with .Values.loki.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -70,6 +70,8 @@ loki:
   existingSecretForConfig: ""
   # -- Adds the appProtocol field to the memberlist service. This allows memberlist to work with istio protocol selection. Ex: "http" or "tcp"
   appProtocol: ""
+  # -- Common annotations for all loki services
+  serviceAnnotations: {}
   # -- Config file contents for Loki
   # @default -- See values.yaml
   config: |
@@ -1170,6 +1172,8 @@ memcached:
       drop:
         - ALL
     allowPrivilegeEscalation: false
+  # -- Common annotations for all memcached services
+  serviceAnnotations: {}
 
 memcachedExporter:
   # -- Specifies whether the Memcached Exporter should be enabled


### PR DESCRIPTION
Adding optional service annotations to all loki services and memcached services. This is required if a user wants to use service annotations for prometheus scraping.

Example values.yaml:
```yaml
loki:
  serviceAnnotations:
    prometheus.io/scrape: 'true'
```

Example service:
```yaml
apiVersion: v1
kind: Service
metadata:
  name: loki-distributed-query-frontend
  labels:
    app.kubernetes.io/name: loki-distributed
  annotations:
    prometheus.io/scrape: "true
```

This references https://github.com/grafana/helm-charts/issues/534
