### PR TITLE
[loki] Allowed to add labels to service-headless and PVC

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 2.13.0
+version: 2.13.1
 appVersion: v2.6.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 2.12.2
+version: 2.13.0
 appVersion: v2.5.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki/README.md
+++ b/charts/loki/README.md
@@ -28,12 +28,20 @@ Major version upgrades listed here indicate that there is an incompatible breaki
 
 ### From 2.11.x to 2.12.0
 
-In version 2.12.0, we enabled memberlist by default and added additional kubernetes service used for members communication. 
+In version 2.12.0, we enabled memberlist by default and added additional kubernetes service used for members communication.
 
 If you already use `memberlist`, just review the config (`.Values.config.memberlist`) to make sure new `memberlist` config matches with your current configuration.
 
 If you use another implementation(`etcd`, `consul`, `inmemory`) for the ring, you can disable `memberlist` with setting `.Values.config.memberlist` to `null`. 
 It prevents from enabling `memberlist` and creating additional kubernetes service.
+
+### From 2.12.x to 2.13.0
+
+In version 2.13.0, we added custom labels to the `volumeClaimTemplates` in the `loki` Statefulset.
+
+If you want to add labels to PersistentVolumeClaim (PVC) via `persistence.labels` values, you must delete the old `loki` Statefulset in the existing release prior upgrading. Without it, the upgrade fails with the following error:
+
+> Error: UPGRADE FAILED: cannot patch "loki" with kind StatefulSet: StatefulSet.apps "loki" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden
 
 ## Run Loki behind https ingress
 

--- a/charts/loki/templates/service-headless.yaml
+++ b/charts/loki/templates/service-headless.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     variant: headless
 spec:
   clusterIP: None

--- a/charts/loki/templates/statefulset.yaml
+++ b/charts/loki/templates/statefulset.yaml
@@ -147,6 +147,8 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: storage
+      labels:
+        {{- toYaml .Values.persistence.labels | nindent 8 }}
       annotations:
         {{- toYaml .Values.persistence.annotations | nindent 8 }}
     spec:

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -154,6 +154,7 @@ persistence:
   accessModes:
   - ReadWriteOnce
   size: 10Gi
+  labels: {}
   annotations: {}
   # selector:
   #   matchLabels:


### PR DESCRIPTION
Hi team,

The admission controller in our multi-tenant K8s cluster requests all services and PVCs must have compliant labels. Loki service has custom labels, but not Loki service-headless and PVC created by the statefulset.

This PR allows to add extra labels to the `volumeClaimTemplates` section in the Statefulset and the Loki service-headless.

Signed-off-by: Canh Ngo <canhnt@gmail.com>