### PR TITLE
[loki-simple-scalable] Change s3 defaults to null

### DIFF
--- a/charts/loki-simple-scalable/Chart.yaml
+++ b/charts/loki-simple-scalable/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-simple-scalable
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.6.0
-version: 1.7.1
+version: 1.7.2
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-simple-scalable/README.md
+++ b/charts/loki-simple-scalable/README.md
@@ -1,6 +1,6 @@
 # loki-simple-scalable
 
-![Version: 1.7.1](https://img.shields.io/badge/Version-1.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.0](https://img.shields.io/badge/AppVersion-2.6.0-informational?style=flat-square)
+![Version: 1.7.2](https://img.shields.io/badge/Version-1.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.0](https://img.shields.io/badge/AppVersion-2.6.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 
@@ -134,13 +134,13 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | loki.storage.gcs.requestTimeout | string | `"0s"` |  |
 | loki.storage.local.chunks_directory | string | `"/var/loki/chunks"` |  |
 | loki.storage.local.rules_directory | string | `"/var/loki/rules"` |  |
-| loki.storage.s3.accessKeyId | string | `"accesskey"` |  |
-| loki.storage.s3.endpoint | string | `"https://amazonaws.com"` |  |
+| loki.storage.s3.accessKeyId | string | `nil` |  |
+| loki.storage.s3.endpoint | string | `nil` |  |
 | loki.storage.s3.insecure | bool | `false` |  |
 | loki.storage.s3.region | string | `nil` |  |
 | loki.storage.s3.s3 | string | `nil` |  |
 | loki.storage.s3.s3ForcePathStyle | bool | `false` |  |
-| loki.storage.s3.secretAccessKey | string | `"supersecret"` |  |
+| loki.storage.s3.secretAccessKey | string | `nil` |  |
 | loki.storage.type | string | `"s3"` |  |
 | loki.structuredConfig | object | `{}` | Structured loki configuration, takes precedence over `loki.config`, `loki.schemaConfig`, `loki.storageConfig` |
 | minio | object | `{"accessKey":"enterprise-logs","buckets":[{"name":"chunks","policy":"none","purge":false},{"name":"ruler","policy":"none","purge":false},{"name":"admin","policy":"none","purge":false}],"enabled":false,"persistence":{"size":"5Gi"},"resources":{"requests":{"cpu":"100m","memory":"128Mi"}},"secretKey":"supersecret"}` | ----------------------------------- |

--- a/charts/loki-simple-scalable/templates/_helpers.tpl
+++ b/charts/loki-simple-scalable/templates/_helpers.tpl
@@ -123,12 +123,22 @@ s3:
 {{- else if eq .Values.loki.storage.type "s3" -}}
 {{- with .Values.loki.storage.s3 }}
 s3:
-  s3: {{ .s3 }}
-  endpoint: {{ .endpoint }}
-  region: {{ .region }}
+  {{- with .s3 }}
+  s3: {{ . }}
+  {{- end }}
+  {{- with .endpoint }}
+  endpoint: {{ . }}
+  {{- end }}
+  {{- with .region }}
+  region: {{ . }}
+  {{- end}}
   bucketnames: {{ $.Values.loki.storage.bucketNames.chunks }}
-  secret_access_key: {{ .secretAccessKey }}
-  access_key_id: {{ .accessKeyId }}
+  {{- with .secretAccessKey }}
+  secret_access_key: {{ . }}
+  {{- end }}
+  {{- with .accessKeyId }}
+  access_key_id: {{ . }}
+  {{- end }}
   s3forcepathstyle: {{ .s3ForcePathStyle }}
   insecure: {{ .insecure }}
 {{- end -}}

--- a/charts/loki-simple-scalable/values.yaml
+++ b/charts/loki-simple-scalable/values.yaml
@@ -132,10 +132,10 @@ loki:
     type: s3
     s3:
       s3: null
-      endpoint: https://amazonaws.com
+      endpoint: null
       region: null
-      secretAccessKey: supersecret
-      accessKeyId: accesskey
+      secretAccessKey: null
+      accessKeyId: null
       s3ForcePathStyle: false
       insecure: false
     gcs:


### PR DESCRIPTION
Fixes https://github.com/grafana/helm-charts/issues/1550

Those values can be overriden if need be, but at the same make the chart working for users with IRSA authentication.

I know it kind of duplicates @trevorwhitney PR https://github.com/grafana/helm-charts/pull/1575, but we really need this fix and I completely understand maintainers may have other priorities with the amount of work a project like this one requires, so I proposed mine.

Signed-off-by: cebidhem <cebidhem@pm.me>