### PR TITLE
[loki-canary] add SecurityContext

### DIFF
--- a/charts/loki-canary/Chart.yaml
+++ b/charts/loki-canary/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-canary
 description: Helm chart for Grafana Loki Canary
 type: application
 appVersion: 2.6.0
-version: 0.9.0
+version: 0.9.1
 home: https://github.com/grafana/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-canary/README.md
+++ b/charts/loki-canary/README.md
@@ -1,6 +1,6 @@
 # loki-canary
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.0](https://img.shields.io/badge/AppVersion-2.6.0-informational?style=flat-square)
+![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.0](https://img.shields.io/badge/AppVersion-2.6.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki Canary
 
@@ -26,6 +26,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | basicAuth.existingSecret | string | `nil` | Existing basic auth secret to use. Must contain '.htpasswd' and, if canary is enabled, 'username' and 'password' |
 | basicAuth.password | string | `nil` | The basic auth password for the gateway |
 | basicAuth.username | string | `nil` | The basic auth username for the gateway |
+| containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The SecurityContext for Loki containers |
 | extraArgs | list | `["-labelname=pod","-labelvalue=$(POD_NAME)"]` | Additional CLI args for the canary |
 | extraEnv | list | `[]` | Environment variables to add to the canary pods |
 | extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the canary pods |
@@ -39,6 +40,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | nodeSelector | object | `{}` | Node selector for canary pods |
 | podAnnotations | object | `{}` | Common annotations for all pods |
 | podLabels | object | `{}` | Common labels for all pods |
+| podSecurityContext | object | `{"fsGroup":10001,"runAsGroup":10001,"runAsNonRoot":true,"runAsUser":10001}` | The SecurityContext for Loki pods |
 | priorityClassName | string | `nil` | The name of the PriorityClass for pods |
 | resources | object | `{}` | Resource requests and limits for the canary |
 | revisionHistoryLimit | int | `10` | The number of old ReplicaSets to retain to allow rollback |

--- a/charts/loki-canary/templates/daemonset.yaml
+++ b/charts/loki-canary/templates/daemonset.yaml
@@ -29,6 +29,8 @@ spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: loki
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -42,6 +44,8 @@ spec:
             {{- if .Values.extraArgs }}
             {{- toYaml .Values.extraArgs | nindent 12 }}
             {{- end }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           ports:
             - name: http
               containerPort: 3500

--- a/charts/loki-canary/values.yaml
+++ b/charts/loki-canary/values.yaml
@@ -15,6 +15,20 @@ image:
   # -- Docker image pull policy
   pullPolicy: IfNotPresent
 
+# -- The SecurityContext for Loki pods
+podSecurityContext:
+  fsGroup: 10001
+  runAsGroup: 10001
+  runAsNonRoot: true
+  runAsUser: 10001
+# -- The SecurityContext for Loki containers
+containerSecurityContext:
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+  allowPrivilegeEscalation: false
+
 # -- The name of the PriorityClass for pods
 priorityClassName: null
 


### PR DESCRIPTION
Added podSecurityContext and containerSecurityContext as a helm chart configurable value to loki-canary helm chart.