### PR TITLE
[loki] updated loki release version to 2.6.1 and bumped version of the chart

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v1"
 name: loki
-version: 2.13.1
-appVersion: v2.6.0
+version: 2.13.2
+appVersion: v2.6.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."
 home: https://grafana.com/loki

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: grafana/loki
-  tag: 2.6.0
+  tag: 2.6.1
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
updated loki release version to 2.6.1 and bumped version of the chart

Signed-off-by: Vladyslav Diachenko <vlad.diachenko@grafana.com>