### PR TITLE
[loki-simple-scalable] updated loki release version to 2.6.1 and bumped version of the chart

### DIFF
--- a/charts/loki-simple-scalable/Chart.yaml
+++ b/charts/loki-simple-scalable/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: loki-simple-scalable
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
-appVersion: 2.6.0
-version: 1.7.5
+appVersion: 2.6.1
+version: 1.7.6
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-simple-scalable/README.md
+++ b/charts/loki-simple-scalable/README.md
@@ -1,6 +1,6 @@
 # loki-simple-scalable
 
-![Version: 1.7.5](https://img.shields.io/badge/Version-1.7.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.0](https://img.shields.io/badge/AppVersion-2.6.0-informational?style=flat-square)
+![Version: 1.7.6](https://img.shields.io/badge/Version-1.7.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 


### PR DESCRIPTION
updated loki release version to 2.6.1 and bumped version of the chart
Signed-off-by: Vladyslav Diachenko <vlad.diachenko@grafana.com>