### PR TITLE
[grafana] Set LOG_LEVEL in the sidecar container.

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.32.4
+version: 6.32.5
 appVersion: 9.0.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.32.3
+version: 6.32.4
 appVersion: 9.0.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -198,6 +198,10 @@ containers:
       - name: LABEL_VALUE
         value: {{ quote .Values.sidecar.dashboards.labelValue }}
       {{- end }}
+      {{- if .Values.sidecar.logLevel }}
+      - name: LOG_LEVEL
+        value: {{ quote .Values.sidecar.dashboards.logLevel }}
+      {{- end }}
       - name: FOLDER
         value: "{{ .Values.sidecar.dashboards.folder }}{{- with .Values.sidecar.dashboards.defaultFolderName }}/{{ . }}{{- end }}"
       - name: RESOURCE

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -664,6 +664,8 @@ sidecar:
   enableUniqueFilenames: false
   readinessProbe: {}
   livenessProbe: {}
+  # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+  logLevel: INFO
   dashboards:
     enabled: false
     SCProvider: true


### PR DESCRIPTION
By default, sidecar image is very noisy. Recently they've added the functionality to set LOG_LEVEL in the upstream
(https://github.com/kiwigrid/k8s-sidecar/pull/190), let's have it available in Grafana's chart.

Signed-off-by: Bartek Stalewski <ftpd@insomniac.pl>