### PR TITLE
[loki] add sidecar to find loki rules in configmaps and secrets

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 2.13.2
+version: 2.14.0
 appVersion: v2.6.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki/templates/clusterrole.yaml
+++ b/charts/loki/templates/clusterrole.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.rbac.create (not .Values.rbac.namespaced) (not .Values.rbac.useExistingRole) }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+{{- with .Values.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  name: {{ template "loki.fullname" . }}-clusterrole
+{{- if .Values.sidecar.rules.enabled }}
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["configmaps", "secrets"]
+  verbs: ["get", "watch", "list"]
+{{- else }}
+rules: []
+{{- end }}
+{{- end }}

--- a/charts/loki/templates/clusterrolebinding.yaml
+++ b/charts/loki/templates/clusterrolebinding.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.rbac.create (not .Values.rbac.namespaced) }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "loki.fullname" . }}-clusterrolebinding
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+{{- with .Values.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "loki.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+{{- if (not .Values.rbac.useExistingRole) }}
+  name: {{ template "loki.fullname" . }}-clusterrole
+{{- else }}
+  name: {{ .Values.rbac.useExistingRole }}
+{{- end }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/charts/loki/templates/role.yaml
+++ b/charts/loki/templates/role.yaml
@@ -13,5 +13,9 @@ rules:
   verbs:          ['use']
   resourceNames:  [{{ template "loki.fullname" . }}]
 {{- end }}
+{{- if and .Values.rbac.namespaced .Values.sidecar.rules.enabled }}
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["configmaps", "secrets"]
+  verbs: ["get", "watch", "list"]
 {{- end }}
-
+{{- end }}

--- a/charts/loki/templates/statefulset.yaml
+++ b/charts/loki/templates/statefulset.yaml
@@ -72,6 +72,10 @@ spec:
             - name: rules
               mountPath: /rules/fake
             {{- end }}
+            {{- if .Values.sidecar.rules.enabled }}
+            - name: sc-rules-volume
+              mountPath: {{ .Values.sidecar.rules.folder | quote }}
+            {{- end}}
           ports:
             - name: http-metrics
               containerPort: {{ .Values.config.server.http_listen_port | default 3100 }}
@@ -104,6 +108,73 @@ spec:
           envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- if .Values.sidecar.rules.enabled }}
+        - name: {{ template "loki.name" . }}-sc-rules
+          {{- if .Values.sidecar.image.sha }}
+          image: "{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
+          {{- else }}
+          image: "{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+          env:
+            - name: METHOD
+              value: {{ .Values.sidecar.rules.watchMethod }}
+            - name: LABEL
+              value: "{{ .Values.sidecar.rules.label }}"
+            {{- if .Values.sidecar.rules.labelValue }}
+            - name: LABEL_VALUE
+              value: {{ quote .Values.sidecar.rules.labelValue }}
+            {{- end }}
+            - name: FOLDER
+              value: "{{ .Values.sidecar.rules.folder }}"
+            - name: RESOURCE
+              value: {{ quote .Values.sidecar.rules.resource }}
+            {{- if .Values.sidecar.enableUniqueFilenames }}
+            - name: UNIQUE_FILENAMES
+              value: "{{ .Values.sidecar.enableUniqueFilenames }}"
+            {{- end }}
+            {{- if .Values.sidecar.rules.searchNamespace }}
+            - name: NAMESPACE
+              value: "{{ .Values.sidecar.rules.searchNamespace | join "," }}"
+            {{- end }}
+            {{- if .Values.sidecar.skipTlsVerify }}
+            - name: SKIP_TLS_VERIFY
+              value: "{{ .Values.sidecar.skipTlsVerify }}"
+            {{- end }}
+            {{- if .Values.sidecar.rules.script }}
+            - name: SCRIPT
+              value: "{{ .Values.sidecar.rules.script }}"
+            {{- end }}
+            {{- if .Values.sidecar.rules.watchServerTimeout }}
+            - name: WATCH_SERVER_TIMEOUT
+              value: "{{ .Values.sidecar.rules.watchServerTimeout }}"
+            {{- end }}
+            {{- if .Values.sidecar.rules.watchClientTimeout }}
+            - name: WATCH_CLIENT_TIMEOUT
+              value: "{{ .Values.sidecar.rules.watchClientTimeout }}"
+            {{- end }}
+            {{- if .Values.sidecar.rules.logLevel }}
+            - name: LOG_LEVEL
+              value: "{{ .Values.sidecar.rules.logLevel }}"
+            {{- end }}
+          {{- if .Values.sidecar.livenessProbe }}
+          livenessProbe:
+          {{ toYaml .Values.livenessProbe | indent 6 }}
+          {{- end }}
+          {{- if .Values.sidecar.readinessProbe }}
+          readinessProbe:
+          {{ toYaml .Values.readinessProbe | indent 6 }}
+          {{- end }}
+          resources:
+          {{ toYaml .Values.sidecar.resources | indent 6 }}
+          {{- if .Values.sidecar.securityContext }}
+          securityContext:
+          {{- toYaml .Values.sidecar.securityContext | nindent 6 }}
+          {{- end }}
+          volumeMounts:
+            - name: sc-rules-volume
+              mountPath: {{ .Values.sidecar.rules.folder | quote }}
+        {{- end}}
 {{- if .Values.extraContainers }}
 {{ toYaml .Values.extraContainers | indent 8}}
 {{- end }}
@@ -133,6 +204,15 @@ spec:
           {{- else }}
             secretName: {{ template "loki.fullname" . }}
           {{- end }}
+        {{- if .Values.sidecar.rules.enabled }}
+        - name: sc-rules-volume
+        {{- if .Values.sidecar.rules.sizeLimit }}
+          emptyDir:
+            sizeLimit: {{ .Values.sidecar.rules.sizeLimit }}
+        {{- else }}
+          emptyDir: {}
+        {{- end -}}
+        {{- end -}}
 {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 8}}
 {{- end }}

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -179,6 +179,56 @@ podManagementPolicy: OrderedReady
 rbac:
   create: true
   pspEnabled: true
+  namespaced: false
+  useExistingRole: false
+
+sidecar:
+  image:
+    repository: kiwigrid/k8s-sidecar
+    tag: 1.19.2
+    sha: ""
+  imagePullPolicy: IfNotPresent
+  resources: {}
+#   limits:
+#     cpu: 100m
+#     memory: 100Mi
+#   requests:
+#     cpu: 50m
+#     memory: 50Mi
+  securityContext: {}
+  # skipTlsVerify Set to true to skip tls verification for kube api calls
+  # skipTlsVerify: true
+  enableUniqueFilenames: false
+  readinessProbe: {}
+  livenessProbe: {}
+  rules:
+    enabled: true
+    # label that the configmaps/secrets with rules are marked with
+    label: loki_rule
+    # value of label that the configmaps/secrets with rules are set to
+    labelValue: ""
+    # folder in which the rules will be placed in
+    folder: /rules
+    # Namespaces list. If specified, the sidecar will search for config-maps/secrets inside these namespaces.
+    # Otherwise the namespace in which the sidecar is running will be used.
+    # It's also possible to specify ALL to search in all namespaces.
+    searchNamespace: null
+    # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
+    watchMethod: WATCH
+    # search in configmap, secret or both
+    resource: both
+    # Absolute path to shell script to execute after a configmap got reloaded
+    script: null
+    # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+    # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+    # watchServerTimeout: 3600
+    #
+    # watchClientTimeout: is a client-side timeout, configuring your local socket.
+    # If you have a network outage dropping all packets with no RST/FIN,
+    # this is how long your client waits before realizing & dropping the connection.
+    # defaults to 66sec (sic!)
+    # watchClientTimeout: 60
+    # logLevel: DEBUG
 
 readinessProbe:
   httpGet:


### PR DESCRIPTION
This PR adds a sidecar to the `loki` chart that queries the Kubernetes API to find `Configmaps` and/or `Secrets` that contain `loki` rules, similar to the way the `grafana` chart does it for dashboards, plugins, ....

I'm not quite sure how to handle the combination of this feature with the `useExistingAlertingGroup` and `alertingGroups` features.
All of these have to be mounted to a single folder in the loki container and then the config has to point to that folder.
Do you think documenting this would be sufficient or should a new top-level value like `rulePath` be added (which would probably be a breaking change :disappointed: )?
Any input would be appreciated.

This might also fix https://github.com/grafana/helm-charts/issues/1375.