### PR TITLE
[loki-simple-scalable] Service Memberlist tcp prefix fix

### DIFF
--- a/charts/loki-simple-scalable/Chart.yaml
+++ b/charts/loki-simple-scalable/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-simple-scalable
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.6.1
-version: 1.8.3
+version: 1.8.4
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-simple-scalable/README.md
+++ b/charts/loki-simple-scalable/README.md
@@ -1,6 +1,6 @@
 # loki-simple-scalable
 
-![Version: 1.8.3](https://img.shields.io/badge/Version-1.8.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 1.8.4](https://img.shields.io/badge/Version-1.8.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/charts/loki-simple-scalable/templates/service-memberlist.yaml
+++ b/charts/loki-simple-scalable/templates/service-memberlist.yaml
@@ -10,7 +10,7 @@ spec:
   ports:
     - name: tcp
       port: 7946
-      targetPort: tcp-memberlist
+      targetPort: http-memberlist
       protocol: TCP
   selector:
     {{- include "loki.selectorLabels" . | nindent 4 }}

--- a/charts/loki-simple-scalable/templates/service-memberlist.yaml
+++ b/charts/loki-simple-scalable/templates/service-memberlist.yaml
@@ -8,9 +8,9 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: http
+    - name: tcp
       port: 7946
-      targetPort: http-memberlist
+      targetPort: tcp-memberlist
       protocol: TCP
   selector:
     {{- include "loki.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
We had made this change to our helm-charts we re-host a while ago and upon upgrade to latest version we left the port name as `http` and encountered nothing but issues, think a PR is necessary since this breaks istio injected loki-simple-scalable deployments.

For issue https://github.com/grafana/helm-charts/issues/1099