### PR TITLE
[grafana] Fix LOG_LEVEL in the sidecar container.

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.32.6
+version: 6.32.7
 appVersion: 9.0.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.32.5
+version: 6.32.6
 appVersion: 9.0.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -200,7 +200,7 @@ containers:
       {{- end }}
       {{- if .Values.sidecar.logLevel }}
       - name: LOG_LEVEL
-        value: {{ quote .Values.sidecar.dashboards.logLevel }}
+        value: {{ quote .Values.sidecar.logLevel }}
       {{- end }}
       - name: FOLDER
         value: "{{ .Values.sidecar.dashboards.folder }}{{- with .Values.sidecar.dashboards.defaultFolderName }}/{{ . }}{{- end }}"


### PR DESCRIPTION
Fix the helm template value.
This bug was introduced in #1624 resulting in the following error:
```
Traceback (most recent call last):
  File "/app/sidecar.py", line 11, in <module>
    from helpers import REQ_RETRY_TOTAL, REQ_RETRY_CONNECT, REQ_RETRY_READ, REQ_RETRY_BACKOFF_FACTOR
  File "/app/helpers.py", line 8, in <module>
    from logger import get_logger
  File "/app/logger.py", line 69, in <module>
    root_logger.setLevel(level.upper() if isinstance(level, str) else level)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 1452, in setLevel
    self.level = _checkLevel(level)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 198, in _checkLevel
    raise ValueError("Unknown level: %r" % level)
ValueError: Unknown level: ''
```

Signed-off-by: Siavash Safi <git@hosted.run>