### PR TITLE
[grafana] Upgrade Grafana to 9.0.4 and bump chart

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.32.6
-appVersion: 9.0.3
+version: 6.32.7
+appVersion: 9.0.4
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net


### PR DESCRIPTION
Update Grafana due to the latest release and quick smoke test locally in our setup.