### PR TITLE
[grafana] image-renderer: fix namespace selector issue

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.32.7
+version: 6.32.8
 appVersion: 9.0.4
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/image-renderer-network-policy.yaml
+++ b/charts/grafana/templates/image-renderer-network-policy.yaml
@@ -64,10 +64,7 @@ spec:
         - port: {{ .Values.service.port }}
           protocol: TCP
       to:
-        - namespaceSelector:
-            matchLabels:
-              name: {{ template "grafana.namespace" . }}
-          podSelector:
+        - podSelector:
             matchLabels:
               {{- include "grafana.selectorLabels" . | nindent 14 }}
               {{- if .Values.podLabels }}


### PR DESCRIPTION
fixes https://github.com/grafana/helm-charts/issues/795
removing the `namespaceSelector` from the network policy
effectively only allows pods from the same namespace to access 
the image renderer. there is no need to manually specify the
namespace, and the label previously used to match on a namespace
isn't the default K8s namespace label (that would be 
kubernetes.io/metadata.name )