### PR TITLE
[tempo-distributed] Include PodDisruptionBudget for the Ingester

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.21.8
+version: 0.21.9
 appVersion: 1.4.1
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.21.8](https://img.shields.io/badge/Version-0.21.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.1](https://img.shields.io/badge/AppVersion-1.4.1-informational?style=flat-square)
+![Version: 0.21.9](https://img.shields.io/badge/Version-0.21.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.1](https://img.shields.io/badge/AppVersion-1.4.1-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/ingester/pdb.yaml
+++ b/charts/tempo-distributed/templates/ingester/pdb.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.podDisruptionBudget -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "tempo.ingesterFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tempo.ingesterLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "tempo.ingesterFullname" . }}
+{{ toYaml .Values.podDisruptionBudget | indent 2 }}
+{{- end }}

--- a/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
@@ -17,6 +17,7 @@ spec:
     matchLabels:
       {{- include "tempo.ingesterSelectorLabels" . | nindent 6}}
   serviceName: ingester
+  podManagementPolicy: Parallel
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
@@ -17,7 +17,6 @@ spec:
     matchLabels:
       {{- include "tempo.ingesterSelectorLabels" . | nindent 6}}
   serviceName: ingester
-  podManagementPolicy: Parallel
   updateStrategy:
     rollingUpdate:
       partition: 0


### PR DESCRIPTION
This change amends the podManagementPolicy that was introduced in #1057 to include a PodDisruptionBudget.  This will help ensure that the Ingesters won't take an outage during a deployment.