### PR TITLE
[enterprise-logs] Support configuring `containerSecurityContext` for compactor and gateway targets in the enterprise-logs chart

### DIFF
--- a/charts/enterprise-logs/CHANGELOG.md
+++ b/charts/enterprise-logs/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## 2.3.1
+
+- [CHANGE] Support configuring `containerSecurityContext` for compactor and gateway targets. #1656
+
 ## 2.3.0
 
 - [CHANGE] Bump GEL version to v1.5.0

--- a/charts/enterprise-logs/Chart.yaml
+++ b/charts/enterprise-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v2"
 name: "enterprise-logs"
 type: application
-version: "2.3.0"
+version: "2.3.1"
 appVersion: "v1.5.0"
 kubeVersion: "^1.10.0-0"
 description: "Grafana Enterprise Logs"

--- a/charts/enterprise-logs/templates/compactor/statefulset-compactor.yaml
+++ b/charts/enterprise-logs/templates/compactor/statefulset-compactor.yaml
@@ -153,7 +153,7 @@ spec:
           resources:
             {{- toYaml .Values.compactor.resources | nindent 12 }}
           securityContext:
-            readOnlyRootFilesystem: true
+            {{- toYaml .Values.compactor.containerSecurityContext | nindent 12 }}
           env:
             {{- if .Values.compactor.env }}
             {{- toYaml .Values.compactor.env | nindent 12 }}

--- a/charts/enterprise-logs/templates/gateway/deployment-gateway.yaml
+++ b/charts/enterprise-logs/templates/gateway/deployment-gateway.yaml
@@ -97,7 +97,7 @@ spec:
           resources:
             {{- toYaml .Values.gateway.resources | nindent 12 }}
           securityContext:
-            readOnlyRootFilesystem: true
+            {{- toYaml .Values.gateway.containerSecurityContext | nindent 12 }}
           env:
             {{- if .Values.gateway.env }}
             {{ toYaml .Values.gateway.env | nindent 12 }}

--- a/charts/enterprise-logs/values.yaml
+++ b/charts/enterprise-logs/values.yaml
@@ -274,6 +274,12 @@ gateway:
     runAsGroup: 10001
     runAsUser: 10001
     fsGroup: 10001
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    allowPrivilegeEscalation: false
 
   # If you want to use your own proxy URLs, set this to false.
   useDefaultProxyURLs: true
@@ -340,6 +346,12 @@ compactor:
     runAsGroup: 10001
     runAsUser: 10001
     fsGroup: 10001
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    allowPrivilegeEscalation: false
 
   strategy:
     type: RollingUpdate


### PR DESCRIPTION
Signed-off-by: JordanRushing <rushing.jordan@gmail.com>