### PR TITLE
[tempo] allow setting priorityClassName

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 0.15.6
+version: 0.15.7
 appVersion: 1.4.1
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 0.15.6](https://img.shields.io/badge/Version-0.15.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.1](https://img.shields.io/badge/AppVersion-1.4.1-informational?style=flat-square)
+![Version: 0.15.7](https://img.shields.io/badge/Version-0.15.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.1](https://img.shields.io/badge/AppVersion-1.4.1-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 
@@ -23,6 +23,7 @@ Grafana Tempo Single Binary Mode
 | persistence.size | string | `"10Gi"` |  |
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
+| priorityClassName | string | `nil` | The name of the PriorityClass |
 | replicas | int | `1` |  |
 | securityContext | object | `{}` |  |
 | service.annotations | object | `{}` |  |

--- a/charts/tempo/templates/statefulset.yaml
+++ b/charts/tempo/templates/statefulset.yaml
@@ -28,6 +28,9 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "tempo.serviceAccountName" . }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
       - args:
         - -config.file=/conf/tempo.yaml

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -206,3 +206,6 @@ tolerations: []
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ##
 affinity: {}
+
+# -- The name of the PriorityClass
+priorityClassName: null


### PR DESCRIPTION
This extends the tempo chart such that it allows setting the priorityClassName at the pod spec level. I don't know why this is missing, and we actually need it when deploying tempo via this chart. 

I did not figure out how to regenerate the README, maybe somebody can tell me? Also, I didn't know if I was supposed to bump the chart version. I can remove this from this PR if that's something happening on release only.

Let me know if there's something else missing! Hope you can merge and release this soon.