### PR TITLE
[enterprise-logs] Harmonize securityContext for all pods

### DIFF
--- a/charts/enterprise-logs/CHANGELOG.md
+++ b/charts/enterprise-logs/CHANGELOG.md
@@ -11,6 +11,17 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## 2.4.0
+
+- [CHANGE] Update loki-distributed to 0.55.0
+- [CHANGE] Harmonized `securityContext` configs with loki-distributed:
+  - Rename `adminApi.securityContext` option to `adminApi.podSecurityContext`
+  - Add `adminApi.securityContext` option
+  - Rename `tokengen.securityContext` option to `tokengen.podSecurityContext`
+  - Add `tokengen.securityContext` option
+  - Rename `compactor.securityContext` to `compactor.podSecurityContext`
+  - Rename `gateway.securityContext` to `gateway.podSecurityContext`
+
 ## 2.3.1
 
 - [CHANGE] Support configuring `containerSecurityContext` for compactor and gateway targets. #1656

--- a/charts/enterprise-logs/Chart.lock
+++ b/charts/enterprise-logs/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: loki-distributed
   repository: https://grafana.github.io/helm-charts
-  version: 0.48.4
+  version: 0.55.0
 - name: minio
   repository: https://helm.min.io/
   version: 8.0.9
-digest: sha256:b82b12683701b32dd4f7400a516a074d9b976b1ba6f07bc47dfdd27ccf222419
-generated: "2022-05-20T12:53:34.610205992+01:00"
+digest: sha256:83984c68937151d956fb7c87378cad06ef06596e2831e0fd017ef170d1c8adb4
+generated: "2022-08-04T13:22:54.203124165Z"

--- a/charts/enterprise-logs/Chart.yaml
+++ b/charts/enterprise-logs/Chart.yaml
@@ -8,7 +8,7 @@ description: "Grafana Enterprise Logs"
 home: "https://grafana.com/products/enterprise/logs/"
 dependencies:
 - name: loki-distributed
-  version: ^0.48.4
+  version: ^0.55.0
   repository: https://grafana.github.io/helm-charts
 - name: minio
   alias: minio

--- a/charts/enterprise-logs/Chart.yaml
+++ b/charts/enterprise-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v2"
 name: "enterprise-logs"
 type: application
-version: "2.3.1"
+version: "2.4.0"
 appVersion: "v1.5.0"
 kubeVersion: "^1.10.0-0"
 description: "Grafana Enterprise Logs"

--- a/charts/enterprise-logs/templates/admin-api/deployment-admin-api.yaml
+++ b/charts/enterprise-logs/templates/admin-api/deployment-admin-api.yaml
@@ -41,10 +41,8 @@ spec:
       {{- if .Values.adminApi.priorityClassName }}
       priorityClassName: {{ .Values.adminApi.priorityClassName }}
       {{- end }}
-      {{- if .Values.adminApi.securityContext.runAsGroup }}
       securityContext:
-        fsGroup: {{ .Values.adminApi.securityContext.runAsGroup | int }}
-      {{- end}}
+        {{- toYaml .Values.adminApi.podSecurityContext | nindent 8 }}
       initContainers:
       # Taken from
       # https://github.com/minio/charts/blob/a5c84bcbad884728bff5c9c23541f936d57a13b3/minio/templates/post-install-create-bucket-job.yaml
@@ -118,8 +116,7 @@ spec:
           resources:
             {{- toYaml .Values.adminApi.resources | nindent 12 }}
           securityContext:
-            readOnlyRootFilesystem: true
-            {{- toYaml .Values.adminApi.securityContext | nindent 12 }}
+            {{- toYaml .Values.adminApi.containerSecurityContext | nindent 12 }}
           env:
             {{- if .Values.adminApi.env }}
             {{ toYaml .Values.adminApi.env | nindent 12 }}

--- a/charts/enterprise-logs/templates/compactor/statefulset-compactor.yaml
+++ b/charts/enterprise-logs/templates/compactor/statefulset-compactor.yaml
@@ -65,7 +65,7 @@ spec:
       priorityClassName: {{ .Values.compactor.priorityClassName }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.compactor.securityContext | nindent 8 }}
+        {{- toYaml .Values.compactor.podSecurityContext | nindent 8 }}
       initContainers:
         {{- toYaml .Values.compactor.initContainers | nindent 8 }}
       {{- if .Values.image.pullSecrets }}

--- a/charts/enterprise-logs/templates/gateway/deployment-gateway.yaml
+++ b/charts/enterprise-logs/templates/gateway/deployment-gateway.yaml
@@ -40,7 +40,7 @@ spec:
       priorityClassName: {{ .Values.gateway.priorityClassName }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.gateway.securityContext | nindent 8 }}
+        {{- toYaml .Values.gateway.podSecurityContext | nindent 8 }}
       initContainers:
         {{- toYaml .Values.gateway.initContainers | nindent 8 }}
       {{- if .Values.image.pullSecrets }}

--- a/charts/enterprise-logs/templates/tokengen/job-tokengen.yaml
+++ b/charts/enterprise-logs/templates/tokengen/job-tokengen.yaml
@@ -33,7 +33,7 @@ spec:
       priorityClassName: {{ .Values.tokengen.priorityClassName }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.tokengen.securityContext | nindent 8 }}
+        {{- toYaml .Values.tokengen.podSecurityContext | nindent 8 }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}
@@ -73,6 +73,8 @@ spec:
             {{- if .Values.tokengen.env }}
               {{ toYaml .Values.tokengen.env | nindent 12 }}
             {{- end }}
+          securityContext:
+            {{- toYaml .Values.tokengen.containerSecurityContext | nindent 12 }}
       containers:
         - name: create-secret
           image: bitnami/kubectl
@@ -91,6 +93,8 @@ spec:
               mountPath: /etc/loki/config
             - name: license
               mountPath: /etc/enterprise-logs/license
+          securityContext:
+            {{- toYaml .Values.tokengen.containerSecurityContext | nindent 12 }}
       restartPolicy: OnFailure
       serviceAccount: {{ include "loki.serviceAccountName" . }}
       serviceAccountName: {{ include "loki.serviceAccountName" .  }}

--- a/charts/enterprise-logs/values.yaml
+++ b/charts/enterprise-logs/values.yaml
@@ -185,11 +185,17 @@ tokengen:
   # -- Additional volume mounts for Pods
   extraVolumeMounts: []
   # -- Run containers as user `enterprise-logs(uid=10001)`
-  securityContext:
+  podSecurityContext:
     runAsNonRoot: true
     runAsGroup: 10001
     runAsUser: 10001
     fsGroup: 10001
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    allowPrivilegeEscalation: false
 
 # -- Configuration for the `admin-api` target
 adminApi:
@@ -208,10 +214,16 @@ adminApi:
   # -- Run container as user `enterprise-logs(uid=10001)`
   # `fsGroup` must not be specified, because these security options are applied
   # on container level not on Pod level.
-  securityContext:
+  podSecurityContext:
     runAsNonRoot: true
     runAsGroup: 10001
     runAsUser: 10001
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    allowPrivilegeEscalation: false
 
   strategy:
     type: RollingUpdate
@@ -269,7 +281,7 @@ gateway:
     labels: {}
     annotations: {}
   # -- Run container as user `enterprise-logs(uid=10001)`
-  securityContext:
+  podSecurityContext:
     runAsNonRoot: true
     runAsGroup: 10001
     runAsUser: 10001
@@ -341,7 +353,7 @@ compactor:
     labels: {}
     annotations: {}
   # -- Run containers as user `enterprise-logs(uid=10001)`
-  securityContext:
+  podSecurityContext:
     runAsNonRoot: true
     runAsGroup: 10001
     runAsUser: 10001


### PR DESCRIPTION
* Update loki-distributed to 0.55.0
* Harmonize `securityContext` configs with loki-distributed:
  - Rename `adminApi.securityContext` option to `adminApi.podSecurityContext`
  - Add `adminApi.securityContext` option
  - Rename `tokengen.securityContext` option to `tokengen.podSecurityContext`
  - Add `tokengen.securityContext` option
  - Rename `compactor.securityContext` to `compactor.podSecurityContext`
  - Rename `gateway.securityContext` to `gateway.podSecurityContext`