### PR TITLE
[grafana] allow download dashboard from gitlab

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.32.11
+version: 6.32.12
 appVersion: 9.0.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/configmap.yaml
+++ b/charts/grafana/templates/configmap.yaml
@@ -86,6 +86,10 @@ data:
         {{- if $value.token }}
     -H "Authorization: token {{ $value.token }}" \
         {{- end }}
+        -H "Accept: application/json" \
+        {{- if $value.gitlabToken }}
+    -H "PRIVATE-TOKEN: {{ $value.token }}" \
+        {{- end }}
     -H "Content-Type: application/json;charset=UTF-8" \
       {{ end }}
     {{- $dpPath := "" -}}

--- a/charts/grafana/templates/configmap.yaml
+++ b/charts/grafana/templates/configmap.yaml
@@ -86,7 +86,6 @@ data:
         {{- if $value.token }}
     -H "Authorization: token {{ $value.token }}" \
         {{- end }}
-        -H "Accept: application/json" \
         {{- if $value.gitlabToken }}
     -H "PRIVATE-TOKEN: {{ $value.token }}" \
         {{- end }}

--- a/charts/grafana/templates/configmap.yaml
+++ b/charts/grafana/templates/configmap.yaml
@@ -87,7 +87,7 @@ data:
     -H "Authorization: token {{ $value.token }}" \
         {{- end }}
         {{- if $value.gitlabToken }}
-    -H "PRIVATE-TOKEN: {{ $value.token }}" \
+    -H "PRIVATE-TOKEN: {{ $value.gitlabToken }}" \
         {{- end }}
     -H "Content-Type: application/json;charset=UTF-8" \
       {{ end }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -564,6 +564,9 @@ dashboards: {}
   #     url: https://example.com/repository/test-b64.json
   #     token: ''
   #     b64content: true
+  #   local-dashboard-gitlab:
+  #     url: https://example.com/repository/test-gitlab.json
+  #     gitlabToken: ''
 
 ## Reference to external ConfigMap per provider. Use provider name as key and ConfigMap name as value.
 ## A provider dashboards must be defined either by external ConfigMaps or in values.yaml, not in both.


### PR DESCRIPTION
Current chart cannot download dashboard.json from gitlab repository from this line
https://github.com/grafana/helm-charts/blob/main/charts/grafana/templates/configmap.yaml#L87

In order to make this compatible with gitlab token we need to set header as PRIVATE-TOKEN: xxx instead
This PR will make it able to.

To test just simple create 1 token in gitlab and curl to some file in a repo with that token
