### PR TITLE
[loki-simple-scalable] GEL release 1.5.1

### DIFF
--- a/charts/loki-simple-scalable/CHANGELOG.md
+++ b/charts/loki-simple-scalable/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## 1.8.7
+
+- [CHANGE] Bump GEL version to v1.5.1 to use version with a fix for GEL Node API.
+
 ## 1.7.5
 
 - [ENHANCEMENT] Update dashboards, include recording and alerting rules

--- a/charts/loki-simple-scalable/Chart.yaml
+++ b/charts/loki-simple-scalable/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-simple-scalable
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.6.1
-version: 1.8.6
+version: 1.8.7
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-simple-scalable/README.md
+++ b/charts/loki-simple-scalable/README.md
@@ -1,6 +1,6 @@
 # loki-simple-scalable
 
-![Version: 1.8.6](https://img.shields.io/badge/Version-1.8.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 1.8.7](https://img.shields.io/badge/Version-1.8.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 
@@ -50,7 +50,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | enterprise.tokengen.labels | object | `{}` | Additional labels for the `tokengen` Job |
 | enterprise.tokengen.securityContext | object | `{"fsGroup":10001,"runAsGroup":10001,"runAsNonRoot":true,"runAsUser":10001}` | Run containers as user `enterprise-logs(uid=10001)` |
 | enterprise.useExternalLicense | bool | `false` | Set to true when providing an external license |
-| enterprise.version | string | `"v1.5.0"` |  |
+| enterprise.version | string | `"v1.5.1"` |  |
 | fullnameOverride | string | `nil` | Overrides the chart's computed fullname |
 | gateway.affinity | string | Hard node and soft zone anti-affinity | Affinity for gateway pods. Passed through `tpl` and, thus, to be configured as string |
 | gateway.autoscaling.enabled | bool | `false` | Enable autoscaling for the gateway |

--- a/charts/loki-simple-scalable/values.yaml
+++ b/charts/loki-simple-scalable/values.yaml
@@ -221,7 +221,7 @@ enterprise:
   enabled: false
 
   # Default verion of GEL to deploy
-  version: v1.5.0
+  version: v1.5.1
 
   # -- Grafana Enterprise Logs license
   # In order to use Grafana Enterprise Logs features, you will need to provide


### PR DESCRIPTION
bumped GEL version to 1.5.1
Signed-off-by: Vladyslav Diachenko <vlad.diachenko@grafana.com>