### PR TITLE
[grafana] Make grafana server domain default to ingress host

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.32.13
+version: 6.32.15
 appVersion: 9.0.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -595,6 +595,8 @@ grafana.ini:
     mode: console
   grafana_net:
     url: https://grafana.net
+  server:
+    domain: "{{ if (and .Values.ingress.enabled .Values.ingress.hosts) }}{{ .Values.ingress.hosts | first }}{{ end }}"
 ## grafana Authentication can be enabled with the following values on grafana.ini
  # server:
       # The full public facing url you use in browser, used for redirects and emails


### PR DESCRIPTION
Fixes #1685

At the moment if you enable ingress on the Grafana chart you also have to remember to specify the hostname again in the grafana.ini file to make sure redirects work properly. This update defaults the ini value to the first hostname in the ingress object to save repeating information.

