### PR TITLE
[loki-stack] Update promtail dependency to ^6.2.3

### DIFF
--- a/charts/loki-stack/Chart.yaml
+++ b/charts/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 2.6.9
+version: 2.7.0
 appVersion: v2.4.2
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki-stack/requirements.yaml
+++ b/charts/loki-stack/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
 - name: "promtail"
   condition: promtail.enabled
   repository: "https://grafana.github.io/helm-charts"
-  version: "^3.11.0"
+  version: "^6.2.3"
 - name: "fluent-bit"
   condition: fluent-bit.enabled
   repository: "https://grafana.github.io/helm-charts"

--- a/charts/loki-stack/values.yaml
+++ b/charts/loki-stack/values.yaml
@@ -2,7 +2,6 @@ test_pod:
   image: bats/bats:v1.1.0
   pullPolicy: IfNotPresent
 
-
 loki:
   enabled: true
   isDefault: true
@@ -22,7 +21,10 @@ loki:
 promtail:
   enabled: true
   config:
-    lokiAddress: http://{{ .Release.Name }}:3100/loki/api/v1/push
+    logLevel: info
+    serverPort: 3101
+    clients:
+      - url: http://{{ .Release.Name }}:3100/loki/api/v1/push
 
 fluent-bit:
   enabled: false


### PR DESCRIPTION
The promtail version included in loki-stack is currently pretty old. This updates it to the same version as loki itself.

This would supersede #1605 and #925.