### PR TITLE
[loki-simple-scalable] Allow loki server block to be configured

### DIFF
--- a/charts/loki-simple-scalable/CHANGELOG.md
+++ b/charts/loki-simple-scalable/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## 1.8.10
+
+- [ENHANCEMENT] Loki server block can now be configured via values.yaml
+
 ## 1.8.7
 
 - [CHANGE] Bump GEL version to v1.5.1 to use version with a fix for GEL Node API.

--- a/charts/loki-simple-scalable/Chart.yaml
+++ b/charts/loki-simple-scalable/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-simple-scalable
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.6.1
-version: 1.8.9
+version: 1.8.10
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-simple-scalable/README.md
+++ b/charts/loki-simple-scalable/README.md
@@ -1,6 +1,6 @@
 # loki-simple-scalable
 
-![Version: 1.8.9](https://img.shields.io/badge/Version-1.8.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 1.8.10](https://img.shields.io/badge/Version-1.8.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 
@@ -113,6 +113,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | loki.config | string | See values.yaml | Config file contents for Loki |
 | loki.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The SecurityContext for Loki containers |
 | loki.existingSecretForConfig | string | `""` | Specify an existing secret containing loki configuration. If non-empty, overrides `loki.config` |
+| loki.extraServerConfig | object | `{}` | Extra server configurations. Check https://grafana.com/docs/loki/latest/configuration/#server for more info |
 | loki.image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | loki.image.registry | string | `"docker.io"` | The Docker registry |
 | loki.image.repository | string | `"grafana/loki"` | Docker image repository |

--- a/charts/loki-simple-scalable/values.yaml
+++ b/charts/loki-simple-scalable/values.yaml
@@ -69,6 +69,9 @@ loki:
     server:
       http_listen_port: 3100
       grpc_listen_port: 9095
+      {{- if .Values.loki.extraServerConfig }}
+      {{- toYaml .Values.loki.extraServerConfig | nindent 2 }}
+      {{- end }}
 
     memberlist:
       join_members:
@@ -161,6 +164,9 @@ loki:
   commonConfig:
     path_prefix: /var/loki
     replication_factor: 3
+
+  # -- Extra server configurations. Check https://grafana.com/docs/loki/latest/configuration/#server for more info
+  extraServerConfig: {}
 
   storage:
     bucketNames:

--- a/charts/loki-simple-scalable/values.yaml
+++ b/charts/loki-simple-scalable/values.yaml
@@ -69,8 +69,8 @@ loki:
     server:
       http_listen_port: 3100
       grpc_listen_port: 9095
-      {{- if .Values.loki.extraServerConfig }}
-      {{- toYaml .Values.loki.extraServerConfig | nindent 2 }}
+      {{- with .Values.loki.extraServerConfig }}
+      {{- toYaml . | nindent 2 }}
       {{- end }}
 
     memberlist:


### PR DESCRIPTION
Fixes https://github.com/grafana/helm-charts/issues/1695

- This will allow users of the chart to configure the server block as documented here https://grafana.com/docs/loki/latest/configuration/#server through values.

Signed-off-by: cebidhem <cebidhem@pm.me>