### PR TITLE
[loki-distributed] add appProtocol grpc field and add compactor to memberlist

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.6.1
-version: 0.56.0
+version: 0.56.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -86,6 +86,8 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | compactor.terminationGracePeriodSeconds | int | `30` | Grace period to allow the compactor to shutdown before it is killed |
 | compactor.tolerations | list | `[]` | Tolerations for compactor pods |
 | distributor.affinity | string | Hard node and soft zone anti-affinity | Affinity for distributor pods. Passed through `tpl` and, thus, to be configured as string |
+| distributor.appProtocol | object | `{"grpc":""}` | Adds the appProtocol field to the distributor service. This allows distributor to work with istio protocol selection. |
+| distributor.appProtocol.grpc | string | `""` | Set the optional grpc service protocol. Ex: "grpc", "http2" or "https" |
 | distributor.autoscaling.enabled | bool | `false` | Enable autoscaling for the distributor |
 | distributor.autoscaling.maxReplicas | int | `3` | Maximum autoscaling replicas for the distributor |
 | distributor.autoscaling.minReplicas | int | `1` | Minimum autoscaling replicas for the distributor |
@@ -201,6 +203,8 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | indexGateway.terminationGracePeriodSeconds | int | `300` | Grace period to allow the index-gateway to shutdown before it is killed. |
 | indexGateway.tolerations | list | `[]` | Tolerations for index-gateway pods |
 | ingester.affinity | object | Hard node and soft zone anti-affinity | Affinity for ingester pods. Passed through `tpl` and, thus, to be configured as string |
+| ingester.appProtocol | object | `{"grpc":""}` | Adds the appProtocol field to the ingester service. This allows ingester to work with istio protocol selection. |
+| ingester.appProtocol.grpc | string | `""` | Set the optional grpc service protocol. Ex: "grpc", "http2" or "https" |
 | ingester.command | string | `nil` | Command to execute instead of defined in Docker image |
 | ingester.extraArgs | list | `[]` | Additional CLI args for the ingester |
 | ingester.extraContainers | list | `[]` | Containers to add to the ingester pods |
@@ -365,6 +369,8 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | prometheusRule.labels | object | `{}` | Additional PrometheusRule labels |
 | prometheusRule.namespace | string | `nil` | Alternative namespace for the PrometheusRule resource |
 | querier.affinity | string | Hard node and soft zone anti-affinity | Affinity for querier pods. Passed through `tpl` and, thus, to be configured as string |
+| querier.appProtocol | object | `{"grpc":""}` | Adds the appProtocol field to the querier service. This allows querier to work with istio protocol selection. |
+| querier.appProtocol.grpc | string | `""` | Set the optional grpc service protocol. Ex: "grpc", "http2" or "https" |
 | querier.autoscaling.enabled | bool | `false` | Enable autoscaling for the querier, this is only used if `queryIndex.enabled: true` |
 | querier.autoscaling.maxReplicas | int | `3` | Maximum autoscaling replicas for the querier |
 | querier.autoscaling.minReplicas | int | `1` | Minimum autoscaling replicas for the querier |
@@ -394,6 +400,8 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | querier.terminationGracePeriodSeconds | int | `30` | Grace period to allow the querier to shutdown before it is killed |
 | querier.tolerations | list | `[]` | Tolerations for querier pods |
 | queryFrontend.affinity | string | Hard node and soft zone anti-affinity | Affinity for query-frontend pods. Passed through `tpl` and, thus, to be configured as string |
+| queryFrontend.appProtocol | object | `{"grpc":""}` | Adds the appProtocol field to the queryFrontend service. This allows queryFrontend to work with istio protocol selection. |
+| queryFrontend.appProtocol.grpc | string | `""` | Set the optional grpc service protocol. Ex: "grpc", "http2" or "https" |
 | queryFrontend.autoscaling.enabled | bool | `false` | Enable autoscaling for the query-frontend |
 | queryFrontend.autoscaling.maxReplicas | int | `3` | Maximum autoscaling replicas for the query-frontend |
 | queryFrontend.autoscaling.minReplicas | int | `1` | Minimum autoscaling replicas for the query-frontend |

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.56.2](https://img.shields.io/badge/Version-0.56.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 0.56.3](https://img.shields.io/badge/Version-0.56.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/templates/compactor/deployment-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/deployment-compactor.yaml
@@ -25,6 +25,7 @@ spec:
         {{- end }}
       labels:
         {{- include "loki.compactorSelectorLabels" . | nindent 8 }}
+        app.kubernetes.io/part-of: memberlist
         {{- with .Values.loki.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -59,6 +60,9 @@ spec:
           ports:
             - name: http
               containerPort: 3100
+              protocol: TCP
+            - name: http-memberlist
+              ontainerPort: 7946
               protocol: TCP
           {{- with .Values.compactor.extraEnv }}
           env:

--- a/charts/loki-distributed/templates/distributor/service-distributor.yaml
+++ b/charts/loki-distributed/templates/distributor/service-distributor.yaml
@@ -22,5 +22,8 @@ spec:
       port: 9095
       targetPort: grpc
       protocol: TCP
+      {{- if .Values.distributor.appProtocol.grpc }}
+      appProtocol: {{ .Values.distributor.appProtocol.grpc }}
+      {{- end }}
   selector:
     {{- include "loki.distributorSelectorLabels" . | nindent 4 }}

--- a/charts/loki-distributed/templates/ingester/service-ingester-headless.yaml
+++ b/charts/loki-distributed/templates/ingester/service-ingester-headless.yaml
@@ -17,5 +17,8 @@ spec:
       port: 9095
       targetPort: grpc
       protocol: TCP
+      {{- if .Values.ingester.appProtocol.grpc }}
+      appProtocol: {{ .Values.ingester.appProtocol.grpc }}
+      {{- end }}
   selector:
     {{- include "loki.ingesterSelectorLabels" . | nindent 4 }}

--- a/charts/loki-distributed/templates/ingester/service-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/service-ingester.yaml
@@ -22,5 +22,8 @@ spec:
       port: 9095
       targetPort: grpc
       protocol: TCP
+      {{- if .Values.ingester.appProtocol.grpc }}
+      appProtocol: {{ .Values.ingester.appProtocol.grpc }}
+      {{- end }}
   selector:
     {{- include "loki.ingesterSelectorLabels" . | nindent 4 }}

--- a/charts/loki-distributed/templates/querier/service-querier-headless.yaml
+++ b/charts/loki-distributed/templates/querier/service-querier-headless.yaml
@@ -18,6 +18,9 @@ spec:
       port: 9095
       targetPort: grpc
       protocol: TCP
+      {{- if .Values.querier.appProtocol.grpc }}
+      appProtocol: {{ .Values.querier.appProtocol.grpc }}
+      {{- end }}
   selector:
     {{- include "loki.querierSelectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/loki-distributed/templates/querier/service-querier.yaml
+++ b/charts/loki-distributed/templates/querier/service-querier.yaml
@@ -22,5 +22,8 @@ spec:
       port: 9095
       targetPort: grpc
       protocol: TCP
+      {{- if .Values.querier.appProtocol.grpc }}
+      appProtocol: {{ .Values.querier.appProtocol.grpc }}
+      {{- end }}
   selector:
     {{- include "loki.querierSelectorLabels" . | nindent 4 }}

--- a/charts/loki-distributed/templates/query-frontend/service-query-frontend.yaml
+++ b/charts/loki-distributed/templates/query-frontend/service-query-frontend.yaml
@@ -24,9 +24,15 @@ spec:
       port: 9095
       targetPort: grpc
       protocol: TCP
+      {{- if .Values.queryFrontend.appProtocol.grpc }}
+      appProtocol: {{ .Values.queryFrontend.appProtocol.grpc }}
+      {{- end }}
     - name: grpclb
       port: 9096
       targetPort: grpc
       protocol: TCP
+      {{- if .Values.queryFrontend.appProtocol.grpc }}
+      appProtocol: {{ .Values.queryFrontend.appProtocol.grpc }}
+      {{- end }}
   selector:
     {{- include "loki.queryFrontendSelectorLabels" . | nindent 4 }}

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -340,6 +340,10 @@ ingester:
     # If empty or set to null, no storageClassName spec is
     # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
     storageClass: null
+  # -- Adds the appProtocol field to the ingester service. This allows ingester to work with istio protocol selection.
+  appProtocol:
+    # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
+    grpc: ""
 
 # Configuration for the distributor
 distributor:
@@ -409,6 +413,10 @@ distributor:
   nodeSelector: {}
   # -- Tolerations for distributor pods
   tolerations: []
+    # -- Adds the appProtocol field to the distributor service. This allows distributor to work with istio protocol selection.
+  appProtocol:
+    # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
+    grpc: ""
 
 # Configuration for the querier
 querier:
@@ -491,6 +499,10 @@ querier:
     # If empty or set to null, no storageClassName spec is
     # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
     storageClass: null
+  # -- Adds the appProtocol field to the querier service. This allows querier to work with istio protocol selection.
+  appProtocol:
+    # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
+    grpc: ""
 
 # Configuration for the query-frontend
 queryFrontend:
@@ -560,6 +572,10 @@ queryFrontend:
   nodeSelector: {}
   # -- Tolerations for query-frontend pods
   tolerations: []
+  # -- Adds the appProtocol field to the queryFrontend service. This allows queryFrontend to work with istio protocol selection.
+  appProtocol:
+    # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
+    grpc: ""
 
 # Configuration for the query-scheduler
 queryScheduler:


### PR DESCRIPTION
When Istio is configured with `PeerAuthentication`-[policy](https://istio.io/latest/docs/concepts/security/#authentication-policies) mode set to `STRICT`, mutual TLS is enforced by default. Istio is relying on [protocol selection](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/) to proxy traffic. This pull request will introduce an optional `appProtocol.grpc`-option for the ingester-, distributor-, querier- and query-frontend-service.

Feedback on the field name, `x.appProtocol.grpc`,  and documentation are welcome.

This merge request will also add the compactor to the memberlist as stated in the [loki documentation](https://grafana.com/docs/loki/latest/fundamentals/architecture/rings/). There is an ongoing merge request, [1390](https://github.com/grafana/helm-charts/pull/1390), where the `app.kubernetes.io/part-of: memberlist`-label is added to the compactor deployment template. Adding the label is not enough to silence the warnings, so this pull request will also add the `http-memberlist` port to the compactor deployment template.

```yaml
ports:
  - containerPort: 7946
    name: http-memberlist
    protocol: TCP
```

When the compactor is not part of the memberlist there is a steady stream of warnings in the logs.

example logs
```
caller=memberlist_logger.go:74 level=info msg="Suspect loki-loki-distributed-querier-0-ba2c8291 has failed, no acks received"
caller=memberlist_logger.go:74 level=error msg="Failed fallback TCP ping: EOF"
caller=memberlist_logger.go:74 level=info msg="Suspect loki-loki-distributed-ingester-0-ab67d204 has failed, no acks received"
caller=memberlist_logger.go:74 level=error msg="Failed fallback TCP ping: EOF"
caller=memberlist_logger.go:74 level=info msg="Suspect loki-loki-distributed-compactor-6f6667f854-kpp4k-1bd430de has failed, no acks received"
caller=memberlist_logger.go:74 level=info msg="Suspect loki-loki-distributed-compactor-7dd664b7f7-q9crf-8403062f has failed, no acks received"
```
and
```
caller=memberlist_logger.go:74 level=warn msg="Refuting a suspect message (from: loki-loki-distributed-compactor-7dd664b7f7-q9crf-8403062f)"
caller=memberlist_logger.go:74 level=warn msg="Was able to connect to loki-loki-distributed-querier-0-ba2c8291 over TCP but UDP probes failed, network may be misconfigured"
caller=memberlist_logger.go:74 level=warn msg="Was able to connect to loki-loki-distributed-distributor-5f5879f9b6-xdnp4-13c6a156 over TCP but UDP probes failed, network may be misconfigured"
caller=memberlist_logger.go:74 level=warn msg="Was able to connect to loki-loki-distributed-ingester-0-ab67d204 over TCP but UDP probes failed, network may be misconfigured"
caller=memberlist_logger.go:74 level=warn msg="Was able to connect to loki-loki-distributed-ingester-0-ab67d204 over TCP but UDP probes failed, network may be misconfigured"
```