### PR TITLE
[loki-distributed] enable customization of readiness and liveness probe configuration for Loki Ingester

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.6.1
-version: 0.55.4
+version: 0.55.5
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.6.1
-version: 0.55.5
+version: 0.55.6
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.55.5](https://img.shields.io/badge/Version-0.55.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 0.55.6](https://img.shields.io/badge/Version-0.55.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.55.4](https://img.shields.io/badge/Version-0.55.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 0.55.5](https://img.shields.io/badge/Version-0.55.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 
@@ -208,7 +208,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | ingester.image.repository | string | `nil` | Docker image repository for the ingester image. Overrides `loki.image.repository` |
 | ingester.image.tag | string | `nil` | Docker image tag for the ingester image. Overrides `loki.image.tag` |
 | ingester.kind | string | `"StatefulSet"` | Kind of deployment [StatefulSet/Deployment] |
-| ingester.livenessProbe | object | `{}` | livenessProbe configuration for Ingester StatefulSet |
+| ingester.livenessProbe | object | `{}` | liveness probe settings for ingester pods. If empty use `loki.livenessProbe` |
 | ingester.nodeSelector | object | `{}` | Node selector for ingester pods |
 | ingester.persistence.enabled | bool | `false` | Enable creating PVCs which is required when using boltdb-shipper |
 | ingester.persistence.size | string | `"10Gi"` | Size of persistent disk |
@@ -216,7 +216,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | ingester.podAnnotations | object | `{}` | Annotations for ingester pods |
 | ingester.podLabels | object | `{}` | Labels for ingester pods |
 | ingester.priorityClassName | string | `nil` | The name of the PriorityClass for ingester pods |
-| ingester.readinessProbe | object | `{}` | readinessProbe configuration for Ingester StatefulSet |
+| ingester.readinessProbe | object | `{}` | readiness probe settings for ingester pods. If empty, use `loki.readinessProbe` |
 | ingester.replicas | int | `1` | Number of replicas for the ingester |
 | ingester.resources | object | `{}` | Resource requests and limits for the ingester |
 | ingester.serviceLabels | object | `{}` | Labels for ingestor service |

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -208,6 +208,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | ingester.image.repository | string | `nil` | Docker image repository for the ingester image. Overrides `loki.image.repository` |
 | ingester.image.tag | string | `nil` | Docker image tag for the ingester image. Overrides `loki.image.tag` |
 | ingester.kind | string | `"StatefulSet"` | Kind of deployment [StatefulSet/Deployment] |
+| ingester.livenessProbe | object | `{}` | livenessProbe configuration for Ingester StatefulSet |
 | ingester.nodeSelector | object | `{}` | Node selector for ingester pods |
 | ingester.persistence.enabled | bool | `false` | Enable creating PVCs which is required when using boltdb-shipper |
 | ingester.persistence.size | string | `"10Gi"` | Size of persistent disk |
@@ -215,6 +216,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | ingester.podAnnotations | object | `{}` | Annotations for ingester pods |
 | ingester.podLabels | object | `{}` | Labels for ingester pods |
 | ingester.priorityClassName | string | `nil` | The name of the PriorityClass for ingester pods |
+| ingester.readinessProbe | object | `{}` | readinessProbe configuration for Ingester StatefulSet |
 | ingester.replicas | int | `1` | Number of replicas for the ingester |
 | ingester.resources | object | `{}` | Resource requests and limits for the ingester |
 | ingester.serviceLabels | object | `{}` | Labels for ingestor service |

--- a/charts/loki-distributed/templates/_helpers.tpl
+++ b/charts/loki-distributed/templates/_helpers.tpl
@@ -140,3 +140,27 @@ Return the appropriate apiVersion for PodDisruptionBudget.
     {{- print "policy/v1beta1" -}}
   {{- end -}}
 {{- end -}}
+
+{{- define "loki.ingester.readinessProbe" -}}
+{{- with .Values.ingester.readinessProbe }}  
+readinessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- else }}
+{{- with .Values.loki.readinessProbe }}
+readinessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "loki.ingester.livenessProbe" -}}
+{{- with .Values.ingester.livenessProbe }}
+livenessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- else }}
+{{- with .Values.loki.livenessProbe }}
+livenessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/loki-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/statefulset-ingester.yaml
@@ -83,9 +83,17 @@ spec:
           securityContext:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
           readinessProbe:
+            {{- if .Values.ingester.readinessProbe }}
+            {{- toYaml .Values.ingester.readinessProbe | nindent 12 }}
+            {{- else }}
             {{- toYaml .Values.loki.readinessProbe | nindent 12 }}
+            {{- end }}
           livenessProbe:
+            {{- if .Values.ingester.livenessProbe }}
+            {{- toYaml .Values.ingester.livenessProbe | nindent 12 }}
+            {{- else }}
             {{- toYaml .Values.loki.livenessProbe | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config

--- a/charts/loki-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/statefulset-ingester.yaml
@@ -82,18 +82,8 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
-          readinessProbe:
-            {{- if .Values.ingester.readinessProbe }}
-            {{- toYaml .Values.ingester.readinessProbe | nindent 12 }}
-            {{- else }}
-            {{- toYaml .Values.loki.readinessProbe | nindent 12 }}
-            {{- end }}
-          livenessProbe:
-            {{- if .Values.ingester.livenessProbe }}
-            {{- toYaml .Values.ingester.livenessProbe | nindent 12 }}
-            {{- else }}
-            {{- toYaml .Values.loki.livenessProbe | nindent 12 }}
-            {{- end }}
+          {{- include "loki.ingester.readinessProbe" . | nindent 10 }}
+          {{- include "loki.ingester.livenessProbe" . | nindent 10 }}
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config
@@ -102,8 +92,10 @@ spec:
             {{- with .Values.ingester.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.ingester.resources }}
           resources:
-            {{- toYaml .Values.ingester.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- if .Values.ingester.extraContainers }}
         {{- toYaml .Values.ingester.extraContainers | nindent 8}}
         {{- end }}

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -318,6 +318,10 @@ ingester:
   nodeSelector: {}
   # -- Tolerations for ingester pods
   tolerations: []
+  # -- readiness probe settings for ingester pods. If empty, use `loki.readinessProbe`
+  readinessProbe: {}
+  # -- liveness probe settings for ingester pods. If empty use `loki.livenessProbe`
+  livenessProbe: {}
   persistence:
     # -- Enable creating PVCs which is required when using boltdb-shipper
     enabled: false


### PR DESCRIPTION
now the readiness and liveness probe configs are for every component. I want to be able to customize these configs for Ingester only. 

Signed-off-by: Youhua Li <webcraft@gmail.com>