### PR TITLE
[promtail] Update _pod.tpl to fix name mismatch for config file between chart and container  that prevents pod to launch in k8s

### DIFF
--- a/charts/promtail/templates/_pod.tpl
+++ b/charts/promtail/templates/_pod.tpl
@@ -33,7 +33,7 @@ Pod template used in Daemonset and Deployment
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - "-config.file=/etc/promtail/promtail.yaml"
+            - "-config.file=/etc/promtail/config.yml"
             {{- with .Values.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
The name of the config file is not matching the name in the official container image
 "-config.file=/etc/promtail/config.yml"
This causes an error when deploying the container with kubernetes
Replicate:
1. run docker pull docker.io/grafana/promtail:2.2.0
2. run docker inspect on the image (or you can check it on dockerhub)
3. compare with the template

<img width="938" alt="Screen Shot 2022-08-19 at 8 19 36 PM" src="https://user-images.githubusercontent.com/57230398/185724165-44e656db-5544-4495-83f9-1a043a78c333.png">

this would fix the error
![Uploading Screen Shot 2022-08-19 at 8.33.00 PM.png…]()
