### PR TITLE
[loki] Update statefulset.yaml fix mismatch in config file names between chart and container that prevents pod launch in k8s

### DIFF
--- a/charts/loki/templates/statefulset.yaml
+++ b/charts/loki/templates/statefulset.yaml
@@ -53,7 +53,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - "-config.file=/etc/loki/loki.yaml"
+            - "-config.file=/etc/loki/local-config.yaml"
           {{- range $key, $value := .Values.extraArgs }}
             - "-{{ $key }}={{ $value }}"
           {{- end }}


### PR DESCRIPTION
The name of the config file is not matching the name of the config file in the official container
![Screen Shot 2022-08-19 at 8 37 00 PM](https://user-images.githubusercontent.com/57230398/185725493-926f8cc4-f010-4393-abf9-0ac53a0187ad.png)
<img width="459" alt="Screen Shot 2022-08-19 at 8 38 34 PM" src="https://user-images.githubusercontent.com/57230398/185725499-25d08522-6dab-499f-b5d9-78f7793d664d.png">

