### PR TITLE
[loki-distributed] Feature: Deploy query-scheduler as an independent component

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.6.1
-version: 0.55.7
+version: 0.56.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -419,7 +419,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | queryFrontend.terminationGracePeriodSeconds | int | `30` | Grace period to allow the query-frontend to shutdown before it is killed |
 | queryFrontend.tolerations | list | `[]` | Tolerations for query-frontend pods |
 | queryScheduler.affinity | string | Hard node and soft zone anti-affinity | Affinity for query-scheduler pods. Passed through `tpl` and, thus, to be configured as string |
-| queryScheduler.enabled | bool | `false` |  |
+| queryScheduler.enabled | bool | `false` | Specifies whether the query-scheduler should be decoupled from the query-frontend |
 | queryScheduler.extraArgs | list | `[]` | Additional CLI args for the query-scheduler |
 | queryScheduler.extraContainers | list | `[]` | Containers to add to the query-scheduler pods |
 | queryScheduler.extraEnv | list | `[]` | Environment variables to add to the query-scheduler pods |

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -433,7 +433,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | queryScheduler.podAnnotations | object | `{}` | Annotations for query-scheduler pods |
 | queryScheduler.podLabels | object | `{}` | Labels for query-scheduler pods |
 | queryScheduler.priorityClassName | string | `nil` | The name of the PriorityClass for query-scheduler pods |
-| queryScheduler.replicas | int | `2` | Number of replicas for the query-scheduler. It should be lower than `-querier.max-concurrent` to avoid generating back-pressure in queriers; it's also recommended that this value evenly divides the latter  |
+| queryScheduler.replicas | int | `2` | Number of replicas for the query-scheduler. It should be lower than `-querier.max-concurrent` to avoid generating back-pressure in queriers; it's also recommended that this value evenly divides the latter |
 | queryScheduler.resources | object | `{}` | Resource requests and limits for the query-scheduler |
 | queryScheduler.serviceLabels | object | `{}` | Labels for query-scheduler service |
 | queryScheduler.terminationGracePeriodSeconds | int | `30` | Grace period to allow the query-scheduler to shutdown before it is killed |

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.55.7](https://img.shields.io/badge/Version-0.55.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 0.56.0](https://img.shields.io/badge/Version-0.56.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 
@@ -418,6 +418,26 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | queryFrontend.serviceLabels | object | `{}` | Labels for query-frontend service |
 | queryFrontend.terminationGracePeriodSeconds | int | `30` | Grace period to allow the query-frontend to shutdown before it is killed |
 | queryFrontend.tolerations | list | `[]` | Tolerations for query-frontend pods |
+| queryScheduler.affinity | string | Hard node and soft zone anti-affinity | Affinity for query-scheduler pods. Passed through `tpl` and, thus, to be configured as string |
+| queryScheduler.enabled | bool | `false` |  |
+| queryScheduler.extraArgs | list | `[]` | Additional CLI args for the query-scheduler |
+| queryScheduler.extraContainers | list | `[]` | Containers to add to the query-scheduler pods |
+| queryScheduler.extraEnv | list | `[]` | Environment variables to add to the query-scheduler pods |
+| queryScheduler.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the query-scheduler pods |
+| queryScheduler.extraVolumeMounts | list | `[]` | Volume mounts to add to the query-scheduler pods |
+| queryScheduler.extraVolumes | list | `[]` | Volumes to add to the query-scheduler pods |
+| queryScheduler.image.registry | string | `nil` | The Docker registry for the query-scheduler image. Overrides `loki.image.registry` |
+| queryScheduler.image.repository | string | `nil` | Docker image repository for the query-scheduler image. Overrides `loki.image.repository` |
+| queryScheduler.image.tag | string | `nil` | Docker image tag for the query-scheduler image. Overrides `loki.image.tag` |
+| queryScheduler.nodeSelector | object | `{}` | Node selector for query-scheduler pods |
+| queryScheduler.podAnnotations | object | `{}` | Annotations for query-scheduler pods |
+| queryScheduler.podLabels | object | `{}` | Labels for query-scheduler pods |
+| queryScheduler.priorityClassName | string | `nil` | The name of the PriorityClass for query-scheduler pods |
+| queryScheduler.replicas | int | `2` | Number of replicas for the query-scheduler. It should be lower than `-querier.max-concurrent` to avoid generating back-pressure in queriers; it's also recommended that this value evenly divides the latter  |
+| queryScheduler.resources | object | `{}` | Resource requests and limits for the query-scheduler |
+| queryScheduler.serviceLabels | object | `{}` | Labels for query-scheduler service |
+| queryScheduler.terminationGracePeriodSeconds | int | `30` | Grace period to allow the query-scheduler to shutdown before it is killed |
+| queryScheduler.tolerations | list | `[]` | Tolerations for query-scheduler pods |
 | rbac.pspEnabled | bool | `false` | If pspEnabled true, a PodSecurityPolicy is created for K8s that use psp. |
 | rbac.sccEnabled | bool | `false` | For OpenShift set pspEnabled to 'false' and sccEnabled to 'true' to use the SecurityContextConstraints. |
 | ruler.affinity | string | Hard node and soft zone anti-affinity | Affinity for ruler pods. Passed through `tpl` and, thus, to be configured as string |

--- a/charts/loki-distributed/templates/NOTES.txt
+++ b/charts/loki-distributed/templates/NOTES.txt
@@ -12,7 +12,7 @@ Installed components:
 * distributor
 * querier
 * query-frontend
-{{- if .Values.queryScheduler.enabled}}
+{{- if .Values.queryScheduler.enabled }}
 * query-scheduler
 {{- end }}
 {{- if .Values.tableManager.enabled }}

--- a/charts/loki-distributed/templates/NOTES.txt
+++ b/charts/loki-distributed/templates/NOTES.txt
@@ -12,6 +12,9 @@ Installed components:
 * distributor
 * querier
 * query-frontend
+{{- if .Values.queryScheduler.enabled}}
+* query-scheduler
+{{- end }}
 {{- if .Values.tableManager.enabled }}
 * table-manager
 {{- end }}

--- a/charts/loki-distributed/templates/query-scheduler/_helpers-query-scheduler.tpl
+++ b/charts/loki-distributed/templates/query-scheduler/_helpers-query-scheduler.tpl
@@ -1,0 +1,40 @@
+{{/*
+query-scheduler fullname
+*/}}
+{{- define "loki.querySchedulerFullname" -}}
+{{ include "loki.fullname" . }}-query-scheduler
+{{- end }}
+
+{{/*
+query-scheduler common labels
+*/}}
+{{- define "loki.querySchedulerLabels" -}}
+{{ include "loki.labels" . }}
+app.kubernetes.io/component: query-scheduler
+{{- end }}
+
+{{/*
+query-scheduler selector labels
+*/}}
+{{- define "loki.querySchedulerSelectorLabels" -}}
+{{ include "loki.selectorLabels" . }}
+app.kubernetes.io/component: query-scheduler
+{{- end }}
+
+{{/*
+query-scheduler image
+*/}}
+{{- define "loki.querySchedulerImage" -}}
+{{- $dict := dict "loki" .Values.loki.image "service" .Values.queryScheduler.image "global" .Values.global.image "defaultVersion" .Chart.AppVersion -}}
+{{- include "loki.lokiImage" $dict -}}
+{{- end }}
+
+{{/*
+query-scheduler priority class name
+*/}}
+{{- define "loki.querySchedulerPriorityClassName" -}}
+{{- $pcn := coalesce .Values.global.priorityClassName .Values.queryScheduler.priorityClassName -}}
+{{- if $pcn }}
+priorityClassName: {{ $pcn }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/query-scheduler/deployment-query-scheduler.yaml
+++ b/charts/loki-distributed/templates/query-scheduler/deployment-query-scheduler.yaml
@@ -1,0 +1,116 @@
+{{- if .Values.queryScheduler.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "loki.querySchedulerFullname" . }}
+  labels:
+    {{- include "loki.querySchedulerLabels" . | nindent 4 }}
+  {{- with .Values.loki.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.queryScheduler.replicas }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "loki.querySchedulerSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.loki.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.queryScheduler.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "loki.querySchedulerSelectorLabels" . | nindent 8 }}
+        {{- with .Values.loki.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.queryScheduler.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "loki.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "loki.querySchedulerPriorityClassName" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.loki.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.queryScheduler.terminationGracePeriodSeconds }}
+      containers:
+        - name: query-scheduler
+          image: {{ include "loki.querySchedulerImage" . }}
+          imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
+          args:
+            - -config.file=/etc/loki/config/config.yaml
+            - -target=query-scheduler
+            {{- with .Values.queryScheduler.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 3100
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+          {{- with .Values.queryScheduler.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.queryScheduler.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.loki.readinessProbe | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.loki.livenessProbe | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki/config
+            {{- with .Values.queryScheduler.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.queryScheduler.resources | nindent 12 }}
+        {{- if .Values.queryScheduler.extraContainers }}
+        {{- toYaml .Values.queryScheduler.extraContainers | nindent 8}}
+        {{- end }}
+      {{- with .Values.queryScheduler.affinity }}
+      affinity:
+        {{- tpl . $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.queryScheduler.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.queryScheduler.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          {{- if .Values.loki.existingSecretForConfig }}
+          secret:
+            secretName: {{ .Values.loki.existingSecretForConfig }}
+          {{- else }}
+          configMap:
+            name: {{ include "loki.fullname" . }}
+          {{- end }}
+        {{- with .Values.queryScheduler.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/query-scheduler/deployment-query-scheduler.yaml
+++ b/charts/loki-distributed/templates/query-scheduler/deployment-query-scheduler.yaml
@@ -84,8 +84,10 @@ spec:
             {{- with .Values.queryScheduler.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.queryScheduler.resources }}
           resources:
-            {{- toYaml .Values.queryScheduler.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- if .Values.queryScheduler.extraContainers }}
         {{- toYaml .Values.queryScheduler.extraContainers | nindent 8}}
         {{- end }}

--- a/charts/loki-distributed/templates/query-scheduler/poddisruptionbudget-query-scheduler.yaml
+++ b/charts/loki-distributed/templates/query-scheduler/poddisruptionbudget-query-scheduler.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.queryScheduler.enabled }}
+{{- if gt (int .Values.queryScheduler.replicas) 1 }}
+apiVersion: {{ include "loki.pdb.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "loki.querySchedulerFullname" . }}
+  labels:
+    {{- include "loki.querySchedulerLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "loki.querySchedulerSelectorLabels" . | nindent 6 }}
+  maxUnavailable: 1
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/query-scheduler/service-query-scheduler.yaml
+++ b/charts/loki-distributed/templates/query-scheduler/service-query-scheduler.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.queryScheduler.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.querySchedulerFullname" . }}
+  labels:
+    {{- include "loki.querySchedulerLabels" . | nindent 4 }}
+    {{- with .Values.queryScheduler.serviceLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.loki.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: http
+      port: 3100
+      targetPort: http
+      protocol: TCP
+    - name: grpclb
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+  selector:
+    {{- include "loki.querySchedulerSelectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/loki-distributed/templates/query-scheduler/servicemonitor-query-scheduler.yaml
+++ b/charts/loki-distributed/templates/query-scheduler/servicemonitor-query-scheduler.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.queryScheduler.enabled }}
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "loki.querySchedulerFullname" $ }}
+  {{- with .namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "loki.querySchedulerLabels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .namespaceSelector }}
+  namespaceSelector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "loki.querySchedulerSelectorLabels" $ | nindent 6 }}
+  endpoints:
+    - port: http
+      {{- with .interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -563,6 +563,7 @@ queryFrontend:
 
 # Configuration for the query-scheduler
 queryScheduler:
+  # -- Specifies whether the query-scheduler should be decoupled from the query-frontend
   enabled: false
   # -- Number of replicas for the query-scheduler.
   # It should be lower than `-querier.max-concurrent` to avoid generating back-pressure in queriers;

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -144,11 +144,18 @@ loki:
             ttl: 24h
 
     frontend_worker:
+      {{- if .Values.queryScheduler.enabled }}
+      scheduler_address: {{ include "loki.querySchedulerFullname" . }}:9095
+      {{- else }}
       frontend_address: {{ include "loki.queryFrontendFullname" . }}:9095
+      {{- end }}
 
     frontend:
       log_queries_longer_than: 5s
       compress_responses: true
+      {{- if .Values.queryScheduler.enabled }}
+      scheduler_address: {{ include "loki.querySchedulerFullname" . }}:9095
+      {{- end }}
       tail_proxy_url: http://{{ include "loki.querierFullname" . }}:3100
 
     compactor:
@@ -552,6 +559,65 @@ queryFrontend:
   # -- Node selector for query-frontend pods
   nodeSelector: {}
   # -- Tolerations for query-frontend pods
+  tolerations: []
+
+# Configuration for the query-scheduler
+queryScheduler:
+  enabled: false
+  # -- Number of replicas for the query-scheduler.
+  # It should be lower than `-querier.max-concurrent` to avoid generating back-pressure in queriers;
+  # it's also recommended that this value evenly divides the latter 
+  replicas: 2
+  image:
+    # -- The Docker registry for the query-scheduler image. Overrides `loki.image.registry`
+    registry: null
+    # -- Docker image repository for the query-scheduler image. Overrides `loki.image.repository`
+    repository: null
+    # -- Docker image tag for the query-scheduler image. Overrides `loki.image.tag`
+    tag: null
+  # -- The name of the PriorityClass for query-scheduler pods
+  priorityClassName: null
+  # -- Labels for query-scheduler pods
+  podLabels: {}
+  # -- Annotations for query-scheduler pods
+  podAnnotations: {}
+  # -- Labels for query-scheduler service
+  serviceLabels: {}
+  # -- Additional CLI args for the query-scheduler
+  extraArgs: []
+  # -- Environment variables to add to the query-scheduler pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to the query-scheduler pods
+  extraEnvFrom: []
+  # -- Volume mounts to add to the query-scheduler pods
+  extraVolumeMounts: []
+  # -- Volumes to add to the query-scheduler pods
+  extraVolumes: []
+  # -- Resource requests and limits for the query-scheduler
+  resources: {}
+  # -- Containers to add to the query-scheduler pods
+  extraContainers: []
+  # -- Grace period to allow the query-scheduler to shutdown before it is killed
+  terminationGracePeriodSeconds: 30
+  # -- Affinity for query-scheduler pods. Passed through `tpl` and, thus, to be configured as string
+  # @default -- Hard node and soft zone anti-affinity
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              {{- include "loki.querySchedulerSelectorLabels" . | nindent 10 }}
+          topologyKey: kubernetes.io/hostname
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                {{- include "loki.querySchedulerSelectorLabels" . | nindent 12 }}
+            topologyKey: failure-domain.beta.kubernetes.io/zone
+  # -- Node selector for query-scheduler pods
+  nodeSelector: {}
+  # -- Tolerations for query-scheduler pods
   tolerations: []
 
 # Configuration for the table-manager

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -567,7 +567,7 @@ queryScheduler:
   enabled: false
   # -- Number of replicas for the query-scheduler.
   # It should be lower than `-querier.max-concurrent` to avoid generating back-pressure in queriers;
-  # it's also recommended that this value evenly divides the latter 
+  # it's also recommended that this value evenly divides the latter
   replicas: 2
   image:
     # -- The Docker registry for the query-scheduler image. Overrides `loki.image.registry`


### PR DESCRIPTION
### Rationale

Linked to #1574, the recommended approach for the _read-path_ is to deploy the `query-scheduler` as an independent component which allows us to scale `query-frontend` regardless of restriction imposed by `-querier.max-concurrent`.
If you want to learn more about this limitation I invite you to check the [Why Query Frontend Scalability is Limited](https://grafana.com/docs/mimir/latest/operators-guide/architecture/components/query-frontend/#why-query-frontend-scalability-is-limited) article from _Mimir_.

Among other benefits, it allows users to benefit from more metrics in the frontend as well as metrics from the scheduler components; which, in turn, allow users to follow the new [operational guide to auto-scale the queriers](https://github.com/grafana/loki/pull/6801) by @salvacorts.

### TBD

#### Should it be the default?

I think the independent `query-scheduler` setup should be the default. I chose to left it as an "opt-in" (`query-scheduler.enabled` is `false` by default) because it can mess with current installations (breaking change). If you think the BC is worth it to promote the usage of the `query-scheduler` we should announce a breaking change.

#### Should we let users configure memberlist over DNS resolution?

By default, when both `scheduler_address` and `frontend_address` are undefined, components default to using memberlist to resolve schedulers. From my codebase crawling it looks like the DNS resolution is the recommended approach ATM (even though I don't know why) so my PR does not support memberlist option.
Should we support it? If yes, in this PR or in another to keep things atomic?

### Tests made

I released the chart on a lab, here is what I looked for:

- `query-schedulers` are deployed when enabled is `true`,
- The service is headless so DNS SRV records are created,
- The DNS resolution from queriers and frontend is working,
- frontend, querier and scheduler logs look fine,
- I can query my cluster.