### PR TITLE
[grafana] Add support for alerting provisioning present in grafana 9.1

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.33.2
+version: 6.34.0
 appVersion: 9.1.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -128,6 +128,7 @@ This version requires Helm >= 3.1.0.
 | `extraEmptyDirMounts`                     | Additional grafana server emptyDir volume mounts | `[]`                                                 |
 | `plugins`                                 | Plugins to be loaded along with Grafana       | `[]`                                                    |
 | `datasources`                             | Configure grafana datasources (passed through tpl) | `{}`                                               |
+| `alerting`                                | Configure grafana alerting                    | `{}`                                                    |
 | `notifiers`                               | Configure grafana notifiers                   | `{}`                                                    |
 | `dashboardProviders`                      | Configure grafana dashboard providers         | `{}`                                                    |
 | `dashboards`                              | Dashboards to import                          | `{}`                                                    |

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -128,7 +128,7 @@ This version requires Helm >= 3.1.0.
 | `extraEmptyDirMounts`                     | Additional grafana server emptyDir volume mounts | `[]`                                                 |
 | `plugins`                                 | Plugins to be loaded along with Grafana       | `[]`                                                    |
 | `datasources`                             | Configure grafana datasources (passed through tpl) | `{}`                                               |
-| `alerting`                                | Configure grafana alerting                    | `{}`                                                    |
+| `alerting`                                | Configure grafana alerting (passed through tpl) | `{}`                                                  |
 | `notifiers`                               | Configure grafana notifiers                   | `{}`                                                    |
 | `dashboardProviders`                      | Configure grafana dashboard providers         | `{}`                                                    |
 | `dashboards`                              | Dashboards to import                          | `{}`                                                    |

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -470,6 +470,13 @@ containers:
         subPath: {{ . | quote }}
 {{- end }}
 {{- end }}
+{{- if .Values.alerting }}
+{{- range (keys .Values.alerting | sortAlpha) }}
+      - name: config
+        mountPath: "/etc/grafana/provisioning/alerting/{{ . }}"
+        subPath: {{ . | quote }}
+{{- end }}
+{{- end }}
 {{- if .Values.dashboardProviders }}
 {{- range (keys .Values.dashboardProviders | sortAlpha) }}
       - name: config

--- a/charts/grafana/templates/configmap.yaml
+++ b/charts/grafana/templates/configmap.yaml
@@ -56,6 +56,13 @@ data:
   {{- end -}}
 {{- end -}}
 
+{{- if .Values.alerting }}
+  {{- range $key, $value := .Values.alerting }}
+  {{ $key }}: |
+{{ toYaml $value | indent 4 }}
+  {{- end -}}
+{{- end -}}
+
 {{- if .Values.dashboardProviders }}
   {{- range $key, $value := .Values.dashboardProviders }}
   {{ $key }}: |

--- a/charts/grafana/templates/configmap.yaml
+++ b/charts/grafana/templates/configmap.yaml
@@ -57,9 +57,10 @@ data:
 {{- end -}}
 
 {{- if .Values.alerting }}
+{{ $root := . }}
   {{- range $key, $value := .Values.alerting }}
   {{ $key }}: |
-{{ toYaml $value | indent 4 }}
+{{ tpl $value $root | indent 4 }}
   {{- end -}}
 {{- end -}}
 

--- a/charts/grafana/templates/tests/test-configmap.yaml
+++ b/charts/grafana/templates/tests/test-configmap.yaml
@@ -11,7 +11,7 @@ data:
     @test "Test Health" {
       url="http://{{ template "grafana.fullname" . }}/api/health"
 
-      code=$(wget --server-response --spider --timeout 10 --tries 1 ${url} 2>&1 | awk '/^  HTTP/{print $2}')
+      code=$(wget --server-response --spider --timeout 90 --tries 10 ${url} 2>&1 | awk '/^  HTTP/{print $2}')
       [ "$code" == "200" ]
     }
 {{- end }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -504,6 +504,29 @@ datasources: {}
 #        authType: default
 #        defaultRegion: us-east-1
 
+## Configure grafana alerting
+## ref: http://docs.grafana.org/administration/provisioning/#alerting
+##
+alerting: {}
+#  rules.yaml:
+#    apiVersion: 1
+#    groups:
+#    - orgId: 1
+#      name: my_rule_group
+#      folder: my_first_folder
+#      interval: 60s
+#      rules:
+#      - uid: my_id_1
+#        ...
+#  contactpoints.yaml:
+#    apiVersion: 1
+#    contactPoints:
+#    - orgId: 1
+#      name: cp_1
+#      receivers:
+#      - uid: first_uid
+#        ...
+
 ## Configure notifiers
 ## ref: http://docs.grafana.org/administration/provisioning/#alert-notification-channels
 ##

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -504,28 +504,70 @@ datasources: {}
 #        authType: default
 #        defaultRegion: us-east-1
 
-## Configure grafana alerting
+## Configure grafana alerting (can be templated)
 ## ref: http://docs.grafana.org/administration/provisioning/#alerting
 ##
 alerting: {}
-#  rules.yaml:
+#  rules.yaml: |
 #    apiVersion: 1
 #    groups:
-#    - orgId: 1
-#      name: my_rule_group
-#      folder: my_first_folder
-#      interval: 60s
-#      rules:
-#      - uid: my_id_1
-#        ...
-#  contactpoints.yaml:
+#      - orgId: 1
+#        name: {{ .Chart.Name }}_my_rule_group
+#        folder: my_first_folder
+#        interval: 60s
+#        rules:
+#          - uid: my_id_1
+#            title: my_first_rule
+#            condition: A
+#            data:
+#              - refId: A
+#                datasourceUid: '-100'
+#                model:
+#                  conditions:
+#                    - evaluator:
+#                        params:
+#                          - 3
+#                        type: gt
+#                      operator:
+#                        type: and
+#                      query:
+#                        params:
+#                          - A
+#                      reducer:
+#                        type: last
+#                      type: query
+#                  datasource:
+#                    type: __expr__
+#                    uid: '-100'
+#                  expression: 1==0
+#                  intervalMs: 1000
+#                  maxDataPoints: 43200
+#                  refId: A
+#                  type: math
+#            dashboardUid: my_dashboard
+#            panelId: 123
+#            noDataState: Alerting
+#            for: 60s
+#            annotations:
+#              some_key: some_value
+#            labels:
+#              team: sre_team_1
+#  contactpoints.yaml: |
 #    apiVersion: 1
 #    contactPoints:
-#    - orgId: 1
-#      name: cp_1
-#      receivers:
-#      - uid: first_uid
-#        ...
+#      - orgId: 1
+#        name: cp_1
+#        receivers:
+#          - uid: first_uid
+#            type: pagerduty
+#            settings:
+#              integrationKey: XXX
+#              severity: critical
+#              class: ping failure
+#              component: Grafana
+#              group: app-stack
+#              summary: |
+#                {{ `{{ template "default.message" . }}` }}
 
 ## Configure notifiers
 ## ref: http://docs.grafana.org/administration/provisioning/#alert-notification-channels


### PR DESCRIPTION
This should allow provisioning of files via the [grafana provisioning support](https://grafana.com/docs/grafana/latest/administration/provisioning/#alerting) and should address #1710.
This will only work when using the chart with Grafana 9.1

Example usage:
```yaml
alerting:
  rules.yaml:
    apiVersion: 1
    groups:
    ....
  contactpoints.yaml:
    apiVersion: 1
    contactPoints:
    ....
```