### PR TITLE
[tempo-distributed] Add log_received_spans option

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.24.2
+version: 0.25.0
 appVersion: 1.5.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.24.2](https://img.shields.io/badge/Version-0.24.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.25.0](https://img.shields.io/badge/Version-0.25.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -157,7 +157,8 @@ The memcached default args are removed and should be provided manually. The sett
 | distributor.autoscaling.targetCPUUtilizationPercentage | int | `60` | Target CPU utilisation percentage for the distributor |
 | distributor.autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory utilisation percentage for the distributor |
 | distributor.config.extend_writes | string | `nil` | Disables write extension with inactive ingesters |
-| distributor.config.log_received_traces | string | `nil` | Enable to log every received trace id to help debug ingestion |
+| distributor.config.log_received_spans | object | `{"enabled":false,"filter_by_status_error":false,"include_all_attributes":false}` | Enable to log every received span to help debug ingestion or calculate span error distributions using the logs |
+| distributor.config.log_received_traces | string | `nil` | WARNING: Deprecated. Use log_received_spans instead. |
 | distributor.config.search_tags_deny_list | list | `[]` | List of tags that will not be extracted from trace data for search lookups |
 | distributor.extraArgs | list | `[]` | Additional CLI args for the distributor |
 | distributor.extraEnv | list | `[]` | Environment variables to add to the distributor pods |

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -317,7 +317,13 @@ distributor:
   extraVolumes: []
   config:
     # -- Enable to log every received trace id to help debug ingestion
+    # -- WARNING: Deprecated. Use log_received_spans instead.
     log_received_traces: null
+    # -- Enable to log every received span to help debug ingestion or calculate span error distributions using the logs
+    log_received_spans:
+      enabled: false
+      include_all_attributes: false
+      filter_by_status_error: false
     # -- Disables write extension with inactive ingesters
     extend_writes: null
     # -- List of tags that will not be extracted from trace data for search lookups
@@ -655,8 +661,11 @@ config: |
       kafka:
         {{- toYaml .Values.traces.kafka | nindent 6 }}
       {{- end }}
-    {{- if .Values.distributor.config.log_received_traces }}
-    log_received_traces: {{ .Values.distributor.config.log_received_traces }}
+    {{- if or .Values.distributor.config.log_received_traces .Values.distributor.config.log_received_spans.enabled }}
+    log_received_spans:
+      enabled: {{ or .Values.distributor.config.log_received_traces .Values.distributor.config.log_received_spans.enabled }}
+      include_all_attributes: {{ .Values.distributor.config.log_received_spans.include_all_attributes }}
+      filter_by_status_error: {{ .Values.distributor.config.log_received_spans.filter_by_status_error }}
     {{- end }}
     {{- if .Values.distributor.config.extend_writes }}
     extend_writes: {{ .Values.distributor.config.extend_writes }}


### PR DESCRIPTION
The feature https://github.com/grafana/tempo/pull/1465 was added to Tempo v1.5.0 which made `log_received_traces` deprecated and replaced with `log_received_spans` with extra options.