### PR TITLE
Patch 1: Fix missmatch in the name of config files between chart and image for loki and promtail 

### DIFF
--- a/charts/loki/templates/statefulset.yaml
+++ b/charts/loki/templates/statefulset.yaml
@@ -53,7 +53,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - "-config.file=/etc/loki/loki.yaml"
+            - "-config.file=/etc/loki/local-config.yaml"
           {{- range $key, $value := .Values.extraArgs }}
             - "-{{ $key }}={{ $value }}"
           {{- end }}

--- a/charts/promtail/templates/_pod.tpl
+++ b/charts/promtail/templates/_pod.tpl
@@ -33,7 +33,7 @@ Pod template used in Daemonset and Deployment
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - "-config.file=/etc/promtail/promtail.yaml"
+            - "-config.file=/etc/promtail/config.yml"
             {{- with .Values.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
The patch addresses a missmatch in the naming of the config files between the chart and the docker images. both changes reflect the config file location documented in the official repositories for the images.
loki:
"-config.file=/etc/loki/local-config.yml"
promtail:
"-config.file=/etc/promtail/config.yml"

The missmatch causes both pods to fail and never reaach the desired state, as no config file is found.


Signed-off-by: gonzalochief <gonzalochief@gmail.com>