### PR TITLE
[loki] Fix bug in poddisruptionbudget(s) & remove pod-sec

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 2.15.1
+version: 2.15.2
 appVersion: v2.6.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki/templates/_helpers.tpl
+++ b/charts/loki/templates/_helpers.tpl
@@ -79,15 +79,7 @@ Handle backwards compatible api versions for:
     - podSecurityPolicy (policy/v1beta1)
 */}}
 {{- define "loki.podDisruptionBudget.apiVersion" -}}
-{{ if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
-{{- print "policy/v1" -}}
-{{- else -}}
-{{- print "policy/v1beta1" -}}
-{{- end -}}
-{{- end -}}
-
-{{- define "loki.podSecurityPolicy.apiVersion" -}}
-{{ if .Capabilities.APIVersions.Has "policy/v1/PodSecurityPolicy" -}}
+{{ if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudgets" -}}
 {{- print "policy/v1" -}}
 {{- else -}}
 {{- print "policy/v1beta1" -}}

--- a/charts/loki/templates/podsecuritypolicy.yaml
+++ b/charts/loki/templates/podsecuritypolicy.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: {{ include "loki.podSecurityPolicy.apiVersion" . }}
 kind: PodSecurityPolicy
 metadata:
@@ -35,4 +36,5 @@ spec:
   readOnlyRootFilesystem: true
   requiredDropCapabilities:
     - ALL
+{{- end }}
 {{- end }}

--- a/charts/loki/templates/podsecuritypolicy.yaml
+++ b/charts/loki/templates/podsecuritypolicy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.pspEnabled }}
 {{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
-apiVersion: {{ include "loki.podSecurityPolicy.apiVersion" . }}
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "loki.fullname" . }}


### PR DESCRIPTION
@zanhsieh This PR fixes a bug in the resource naming for PodDisruptionBudgets. The resource ends in `s` and is plural.

Secondly, PodSecurityPolicy resource was removed in 1.25 according to the documentation and replaced with Pod Security Admission which would be a major update to the way it handles pod security policies as its a feature now of k8s. I added a check before enabling that when `pspEnabled` is set which should only deploy it if the legacy `PodSecurityPolicy` is available.

See deprecation notices and more [HERE](https://kubernetes.io/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/)

Also, I created an [issue (1735)](https://github.com/grafana/helm-charts/pull/1735) to track the deprecation and some work/resolution as the fix I apply here is really a patch that needs a future state also depending on the path Grafana want to take. 