### PR TITLE
fix typo in deployment-compactor.yaml for ports

### DIFF
--- a/charts/loki-distributed/templates/compactor/deployment-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/deployment-compactor.yaml
@@ -62,7 +62,7 @@ spec:
               containerPort: 3100
               protocol: TCP
             - name: http-memberlist
-              ontainerPort: 7946
+              containerPort: 7946
               protocol: TCP
           {{- with .Values.compactor.extraEnv }}
           env:


### PR DESCRIPTION
`ontainerPort` should be `containerPort`