### PR TITLE
[loki] update config file name to match docker image

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 2.14.1
+version: 2.14.2
 appVersion: v2.6.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 2.16.0
+version: 2.16.1
 appVersion: v2.6.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki/templates/statefulset.yaml
+++ b/charts/loki/templates/statefulset.yaml
@@ -53,7 +53,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - "-config.file=/etc/loki/loki.yaml"
+            - "-config.file=/etc/loki/local-config.yaml"
           {{- range $key, $value := .Values.extraArgs }}
             - "-{{ $key }}={{ $value }}"
           {{- end }}


### PR DESCRIPTION
According to the official docker image, the config file name is "local-config.yaml", instead to the one in the chart "loki.yaml"
This missmatch in names makes the container crash and neve reach the desired state.
Correct value:
"-config.file=/etc/loki/local-config.yaml"
Wrong value:
"-config.file=/etc/loki/loki.yaml"

### **docker image configuration:**
![image](https://user-images.githubusercontent.com/57230398/187243821-43626e88-726b-49f2-916d-d948b4073865.png)


### The following is the helm file of the entire deployment
```
filepath: ""
environments:
default:
values:
- jx-values.yaml
namespace: jx-observability
repositories:

name: jxgh
url: https://jenkins-x-charts.github.io/repo
name: grafana
url: https://grafana.github.io/helm-charts
name: prometheus-community
url: https://prometheus-community.github.io/helm-charts
releases:
chart: jxgh/grafana-dashboard
version: 0.2.2
name: grafana-dashboard
values:
../../versionStream/charts/jxgh/grafana-dashboard/values.yaml.gotmpl
jx-values.yaml
chart: grafana/loki
version: 2.5.0
name: loki
values:
../../versionStream/charts/grafana/loki/values.yaml
jx-values.yaml
chart: grafana/promtail
version: 3.5.0
name: promtail
values:
../../versionStream/charts/grafana/promtail/values.yaml
jx-values.yaml
chart: grafana/tempo
version: 0.6.8
name: tempo
values:
../../versionStream/charts/grafana/tempo/values.yaml
jx-values.yaml
chart: grafana/grafana
version: 6.17.4
name: grafana
values:
../../versionStream/charts/grafana/grafana/values.yaml.gotmpl
jx-values.yaml
chart: prometheus-community/prometheus
version: 13.6.0
name: prometheus
values:
../../versionStream/charts/prometheus-community/prometheus/values.yaml
jx-values.yaml
templates: {}
renderedvalues: {}
```
### The chart with the mismatch is:
```
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: loki
  namespace: jx-observability
  labels:
    app: loki
    chart: loki-2.14.1
    release: loki
    heritage: Helm
  annotations:
    meta.helm.sh/release-name: 'loki'
spec:
  podManagementPolicy: OrderedReady
  replicas: 1
  selector:
    matchLabels:
      app: loki
      release: loki
  serviceName: loki-headless
  updateStrategy:
    type: RollingUpdate
  template:
    metadata:
      labels:
        app: loki
        name: loki
        release: loki
      annotations:
        checksum/config: 78f6997851c726eba6b0b34b514bc4b3e16f10411d45e7ba4f60c7fb9e9d26b3
        prometheus.io/port: http-metrics
        prometheus.io/scrape: "true"
    spec:
      serviceAccountName: loki
      securityContext:
        fsGroup: 10001
        runAsGroup: 10001
        runAsNonRoot: true
        runAsUser: 10001
      initContainers:
        []
      containers:
        - name: loki
          image: "grafana/loki:2.2.0"
          imagePullPolicy: IfNotPresent
          args:
            - "-config.file=/etc/loki/local-config.yaml"
          volumeMounts:
            - name: tmp
              mountPath: /tmp
            - name: config
              mountPath: /etc/loki
            - name: storage
              mountPath: "/data"
              subPath:
          ports:
            - name: http-metrics
              containerPort: 3100
              protocol: TCP
            - name: grpc
              containerPort: 9095
              protocol: TCP
            - name: memberlist-port
              containerPort: 7946
              protocol: TCP
          livenessProbe:
            httpGet:
              path: /ready
              port: http-metrics
            initialDelaySeconds: 45
          readinessProbe:
            httpGet:
              path: /ready
              port: http-metrics
            initialDelaySeconds: 45
          resources:
            {}
          securityContext:
            readOnlyRootFilesystem: true
          env:
      nodeSelector: {}
      affinity: {}
      tolerations: []
      terminationGracePeriodSeconds: 4800
      volumes:
        - name: tmp
          emptyDir: {}
        - name: config
          secret:
            secretName: loki
        - name: storage
          emptyDir: {}
      volumeClaimTemplates:
        - metadata:
            name: storage
            annotations: {}
          spec:
            accessModes:
              - ReadWriteOnce
            resources:
              requests:
                storage: "10Gi"
            storageClassName:
```

Signed-off-by: gonzalochief <gonzalochief@gmail.com>