### PR TITLE
[promtail] update config file name to match docker image

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.6.1
-version: 6.3.0
+version: 6.3.1
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 6.3.0](https://img.shields.io/badge/Version-6.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 6.3.1](https://img.shields.io/badge/Version-6.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/templates/_pod.tpl
+++ b/charts/promtail/templates/_pod.tpl
@@ -33,7 +33,7 @@ Pod template used in Daemonset and Deployment
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - "-config.file=/etc/promtail/promtail.yaml"
+            - "-config.file=/etc/promtail/config.yml"
             {{- with .Values.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
According to the official image, the config file name is "lconfig.yml", instead to the one in the chart "promtail.yaml"
This missmatch in names makes the container crash and neve reach the desired state.
Correct value:
"-config.file=/etc/promtail/config.yml"
Wrong value:
"-config.file=/etc/promtail/promtail.yaml"

### Official image configuration:
![image](https://user-images.githubusercontent.com/57230398/187247104-fcdfff7e-ee53-4833-b5ad-81b678708f57.png)

### Error:
![image](https://user-images.githubusercontent.com/57230398/187247232-0d0978a6-b442-4018-9a4b-e18a7c55c09b.png)

### The chart for the entire deployment is as follows:
```
filepath: ""
environments:
default:
values:
- jx-values.yaml
namespace: jx-observability
repositories:

name: jxgh
url: https://jenkins-x-charts.github.io/repo
name: grafana
url: https://grafana.github.io/helm-charts
name: prometheus-community
url: https://prometheus-community.github.io/helm-charts
releases:
chart: jxgh/grafana-dashboard
version: 0.2.2
name: grafana-dashboard
values:
../../versionStream/charts/jxgh/grafana-dashboard/values.yaml.gotmpl
jx-values.yaml
chart: grafana/loki
version: 2.5.0
name: loki
values:
../../versionStream/charts/grafana/loki/values.yaml
jx-values.yaml
chart: grafana/promtail
version: 3.5.0
name: promtail
values:
../../versionStream/charts/grafana/promtail/values.yaml
jx-values.yaml
chart: grafana/tempo
version: 0.6.8
name: tempo
values:
../../versionStream/charts/grafana/tempo/values.yaml
jx-values.yaml
chart: grafana/grafana
version: 6.17.4
name: grafana
values:
../../versionStream/charts/grafana/grafana/values.yaml.gotmpl
jx-values.yaml
chart: prometheus-community/prometheus
version: 13.6.0
name: prometheus
values:
../../versionStream/charts/prometheus-community/prometheus/values.yaml
jx-values.yaml
templates: {}
renderedvalues: {}
```
### The daemon set yaml is:
```
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: promtail
  namespace: default
  labels:
    helm.sh/chart: promtail-3.5.0
    app.kubernetes.io/name: promtail
    app.kubernetes.io/instance: promtail
    app.kubernetes.io/version: "2.2.1"
    app.kubernetes.io/managed-by: Helm
    gitops.jenkins-x.io/pipeline: 'namespaces'
  annotations:
    meta.helm.sh/release-name: 'promtail'
    namespace: jx-observability
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: promtail
      app.kubernetes.io/instance: promtail
  updateStrategy: {}
  template:
    metadata:
      labels:
        app.kubernetes.io/name: promtail
        app.kubernetes.io/instance: promtail
      annotations:
        checksum/config: b7fbbaca1d3ebda96f03f974fd349255d5bdfc4cad0bbab14fca8da7e2406b11
        prometheus.io/port: http-metrics
        prometheus.io/scrape: "true"
    spec:
      serviceAccountName: promtail
      securityContext:
        runAsGroup: 0
        runAsUser: 0
      containers:
        - name: promtail
          image: "docker.io/grafana/promtail:2.2.0"
          imagePullPolicy: IfNotPresent
          args:
            - "-config.file=/etc/promtail/promtail.yaml"
          volumeMounts:
            - name: config
              mountPath: /etc/promtail
            - name: run
              mountPath: /run/promtail
            - mountPath: /var/lib/docker/containers
              name: containers
              readOnly: true
            - mountPath: /var/log/pods
              name: pods
              readOnly: true
          env:
            - name: HOSTNAME
              valueFrom:
                fieldRef:
                  fieldPath: spec.nodeName
          ports:
            - name: http-metrics
              containerPort: 3101
              protocol: TCP
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
          readinessProbe:
            failureThreshold: 5
            httpGet:
              path: /ready
              port: http-metrics
            initialDelaySeconds: 10
            periodSeconds: 10
            successThreshold: 1
            timeoutSeconds: 1
      tolerations:
        - effect: NoSchedule
          key: node-role.kubernetes.io/master
          operator: Exists
        - effect: NoSchedule
          key: node-role.kubernetes.io/control-plane
          operator: Exists
      volumes:
        - name: config
          secret:
            secretName: promtail
        - hostPath:
            path: /run/promtail
          name: run
        - hostPath:
            path: /var/lib/docker/containers
          name: containers
        - hostPath:
            path: /var/log/pods
          name: pods
```


Signed-off-by: gonzalochief <gonzalochief@gmail.com>