### PR TITLE
[loki-stack] update loki chart dependency

### DIFF
--- a/charts/loki-stack/Chart.yaml
+++ b/charts/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 2.8.0
+version: 2.8.1
 appVersion: v2.6.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki-stack/requirements.yaml
+++ b/charts/loki-stack/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - name: "loki"
   condition: loki.enabled
   repository: "https://grafana.github.io/helm-charts"
-  version: "^2.14.1"
+  version: "^2.15.2"
 - name: "promtail"
   condition: promtail.enabled
   repository: "https://grafana.github.io/helm-charts"


### PR DESCRIPTION
This is mostly an attempt to get a k8s v1.25 compatible install.  I hope it's really this easy, but this PR mostly exists to see if CI passes ;)

The "contributing guidelines" suggest bumping the version number for each change.  I don't know if that's actually the procedure, but I did it.  It seems like there were no breaking changes mentioned in the Loki README since 2.13.0 (i.e. not from 2.14 to 2.15 which this PR updates), so I just did a patch number bump here.