### PR TITLE
[tempo-distributed] chore: support full metrics_generator config in tempo-distributed

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.25.0
+version: 0.26.0
 appVersion: 1.5.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -20,6 +20,13 @@ helm repo add grafana https://grafana.github.io/helm-charts
 
 A major chart version change indicates that there is an incompatible breaking change needing manual actions.
 
+### From chart version < 0.26.0
+
+Version 0.26.0
+
+* Moves metricsGenerator.config.storage_remote_write to metricsGenerator.config.storage.remote_write
+* Moves metricsGenerator.config.service_graphs_max_items to metricsGenerator.config.processor.service_graphs.max_items
+
 ### From chart version < 0.23.0
 
 Version 0.23.0:
@@ -293,38 +300,10 @@ The memcached default args are removed and should be provided manually. The sett
 | memcachedExporter.resources | object | `{}` |  |
 | metricsGenerator.affinity | string | Hard node and soft zone anti-affinity | Affinity for metrics-generator pods. Passed through `tpl` and, thus, to be configured as string |
 | metricsGenerator.annotations | object | `{}` | Annotations for the metrics-generator StatefulSet |
-| metricsGenerator.config.processor.service_graphs.dimensions | list | `[]` |  |
-| metricsGenerator.config.processor.service_graphs.histogram_buckets[0] | float | `0.1` |  |
-| metricsGenerator.config.processor.service_graphs.histogram_buckets[1] | float | `0.2` |  |
-| metricsGenerator.config.processor.service_graphs.histogram_buckets[2] | float | `0.4` |  |
-| metricsGenerator.config.processor.service_graphs.histogram_buckets[3] | float | `0.8` |  |
-| metricsGenerator.config.processor.service_graphs.histogram_buckets[4] | float | `1.6` |  |
-| metricsGenerator.config.processor.service_graphs.histogram_buckets[5] | float | `3.2` |  |
-| metricsGenerator.config.processor.service_graphs.histogram_buckets[6] | float | `6.4` |  |
-| metricsGenerator.config.processor.service_graphs.histogram_buckets[7] | float | `12.8` |  |
-| metricsGenerator.config.processor.service_graphs.max_items | int | `10000` |  |
-| metricsGenerator.config.processor.service_graphs.wait | string | `"10s"` |  |
-| metricsGenerator.config.processor.service_graphs.workers | int | `10` |  |
-| metricsGenerator.config.processor.span_metrics.dimensions | list | `[]` |  |
-| metricsGenerator.config.processor.span_metrics.histogram_buckets[0] | float | `0.002` |  |
-| metricsGenerator.config.processor.span_metrics.histogram_buckets[10] | float | `2.05` |  |
-| metricsGenerator.config.processor.span_metrics.histogram_buckets[11] | float | `4.1` |  |
-| metricsGenerator.config.processor.span_metrics.histogram_buckets[1] | float | `0.004` |  |
-| metricsGenerator.config.processor.span_metrics.histogram_buckets[2] | float | `0.008` |  |
-| metricsGenerator.config.processor.span_metrics.histogram_buckets[3] | float | `0.016` |  |
-| metricsGenerator.config.processor.span_metrics.histogram_buckets[4] | float | `0.032` |  |
-| metricsGenerator.config.processor.span_metrics.histogram_buckets[5] | float | `0.064` |  |
-| metricsGenerator.config.processor.span_metrics.histogram_buckets[6] | float | `0.128` |  |
-| metricsGenerator.config.processor.span_metrics.histogram_buckets[7] | float | `0.256` |  |
-| metricsGenerator.config.processor.span_metrics.histogram_buckets[8] | float | `0.512` |  |
-| metricsGenerator.config.processor.span_metrics.histogram_buckets[9] | float | `1.02` |  |
-| metricsGenerator.config.registry.collection_interval | string | `"15s"` |  |
-| metricsGenerator.config.registry.external_labels | object | `{}` |  |
-| metricsGenerator.config.registry.stale_duration | string | `"15m"` |  |
-| metricsGenerator.config.storage.path | string | `"/var/tempo/wal"` |  |
-| metricsGenerator.config.storage.remote_write | list | `[]` |  |
-| metricsGenerator.config.storage.remote_write_flush_deadline | string | `"1m"` |  |
-| metricsGenerator.config.storage.wal | string | `nil` |  |
+| metricsGenerator.config | object | `{"processor":{"service_graphs":{"dimensions":[],"histogram_buckets":[0.1,0.2,0.4,0.8,1.6,3.2,6.4,12.8],"max_items":10000,"wait":"10s","workers":10},"span_metrics":{"dimensions":[],"histogram_buckets":[0.002,0.004,0.008,0.016,0.032,0.064,0.128,0.256,0.512,1.02,2.05,4.1]}},"registry":{"collection_interval":"15s","external_labels":{},"stale_duration":"15m"},"storage":{"path":"/var/tempo/wal","remote_write":[],"remote_write_flush_deadline":"1m","wal":null}}` | More information on configuration: https://grafana.com/docs/tempo/latest/configuration/#metrics-generator |
+| metricsGenerator.config.processor.service_graphs.dimensions | list | `[]` | resource and span attributes and are added to the metrics if present. |
+| metricsGenerator.config.processor.span_metrics.dimensions | list | `[]` | Dimensions are searched for in the resource and span attributes and are added to the metrics if present. |
+| metricsGenerator.config.storage.remote_write | list | `[]` | https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write |
 | metricsGenerator.enabled | bool | `false` | Specifies whether a metrics-generator should be deployed |
 | metricsGenerator.extraArgs | list | `[]` | Additional CLI args for the metrics-generator |
 | metricsGenerator.extraEnv | list | `[]` | Environment variables to add to the metrics-generator pods |

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.25.0](https://img.shields.io/badge/Version-0.25.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.26.0](https://img.shields.io/badge/Version-0.26.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -293,8 +293,38 @@ The memcached default args are removed and should be provided manually. The sett
 | memcachedExporter.resources | object | `{}` |  |
 | metricsGenerator.affinity | string | Hard node and soft zone anti-affinity | Affinity for metrics-generator pods. Passed through `tpl` and, thus, to be configured as string |
 | metricsGenerator.annotations | object | `{}` | Annotations for the metrics-generator StatefulSet |
-| metricsGenerator.config.service_graphs_max_items | int | `10000` |  |
-| metricsGenerator.config.storage_remote_write | list | `[]` |  |
+| metricsGenerator.config.processor.service_graphs.dimensions | list | `[]` |  |
+| metricsGenerator.config.processor.service_graphs.histogram_buckets[0] | float | `0.1` |  |
+| metricsGenerator.config.processor.service_graphs.histogram_buckets[1] | float | `0.2` |  |
+| metricsGenerator.config.processor.service_graphs.histogram_buckets[2] | float | `0.4` |  |
+| metricsGenerator.config.processor.service_graphs.histogram_buckets[3] | float | `0.8` |  |
+| metricsGenerator.config.processor.service_graphs.histogram_buckets[4] | float | `1.6` |  |
+| metricsGenerator.config.processor.service_graphs.histogram_buckets[5] | float | `3.2` |  |
+| metricsGenerator.config.processor.service_graphs.histogram_buckets[6] | float | `6.4` |  |
+| metricsGenerator.config.processor.service_graphs.histogram_buckets[7] | float | `12.8` |  |
+| metricsGenerator.config.processor.service_graphs.max_items | int | `10000` |  |
+| metricsGenerator.config.processor.service_graphs.wait | string | `"10s"` |  |
+| metricsGenerator.config.processor.service_graphs.workers | int | `10` |  |
+| metricsGenerator.config.processor.span_metrics.dimensions | list | `[]` |  |
+| metricsGenerator.config.processor.span_metrics.histogram_buckets[0] | float | `0.002` |  |
+| metricsGenerator.config.processor.span_metrics.histogram_buckets[10] | float | `2.05` |  |
+| metricsGenerator.config.processor.span_metrics.histogram_buckets[11] | float | `4.1` |  |
+| metricsGenerator.config.processor.span_metrics.histogram_buckets[1] | float | `0.004` |  |
+| metricsGenerator.config.processor.span_metrics.histogram_buckets[2] | float | `0.008` |  |
+| metricsGenerator.config.processor.span_metrics.histogram_buckets[3] | float | `0.016` |  |
+| metricsGenerator.config.processor.span_metrics.histogram_buckets[4] | float | `0.032` |  |
+| metricsGenerator.config.processor.span_metrics.histogram_buckets[5] | float | `0.064` |  |
+| metricsGenerator.config.processor.span_metrics.histogram_buckets[6] | float | `0.128` |  |
+| metricsGenerator.config.processor.span_metrics.histogram_buckets[7] | float | `0.256` |  |
+| metricsGenerator.config.processor.span_metrics.histogram_buckets[8] | float | `0.512` |  |
+| metricsGenerator.config.processor.span_metrics.histogram_buckets[9] | float | `1.02` |  |
+| metricsGenerator.config.registry.collection_interval | string | `"15s"` |  |
+| metricsGenerator.config.registry.external_labels | object | `{}` |  |
+| metricsGenerator.config.registry.stale_duration | string | `"15m"` |  |
+| metricsGenerator.config.storage.path | string | `"/var/tempo/wal"` |  |
+| metricsGenerator.config.storage.remote_write | list | `[]` |  |
+| metricsGenerator.config.storage.remote_write_flush_deadline | string | `"1m"` |  |
+| metricsGenerator.config.storage.wal | string | `nil` |  |
 | metricsGenerator.enabled | bool | `false` | Specifies whether a metrics-generator should be deployed |
 | metricsGenerator.extraArgs | list | `[]` | Additional CLI args for the metrics-generator |
 | metricsGenerator.extraEnv | list | `[]` | Environment variables to add to the metrics-generator pods |

--- a/charts/tempo-distributed/README.md.gotmpl
+++ b/charts/tempo-distributed/README.md.gotmpl
@@ -20,6 +20,13 @@ helm repo add grafana https://grafana.github.io/helm-charts
 
 A major chart version change indicates that there is an incompatible breaking change needing manual actions.
 
+### From chart version < 0.26.0
+
+Version 0.26.0
+
+* Moves metricsGenerator.config.storage_remote_write to metricsGenerator.config.storage.remote_write
+* Moves metricsGenerator.config.service_graphs_max_items to metricsGenerator.config.processor.service_graphs.max_items
+
 ### From chart version < 0.23.0
 
 Version 0.23.0:

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -232,14 +232,33 @@ metricsGenerator:
     - name: http
       port: 3100
       service: true
+  # https://grafana.com/docs/tempo/latest/configuration/#metrics-generator
   config:
-    #  MaxItems is the amount of edges that will be stored in the store.
-    service_graphs_max_items: 10000
-    storage_remote_write: []
-    # - url: http://cortex/api/v1/push
-    #   send_exemplars: true
-    #   headers:
-    #     x-scope-orgid: operations
+    registry:
+      collection_interval: 15s
+      external_labels: {}
+      stale_duration: 15m
+    processor:
+      service_graphs:
+        # Additional dimensions to add to the metrics. Dimensions are searched for in the
+        # resource and span attributes and are added to the metrics if present.
+        dimensions: []
+        histogram_buckets: [0.1, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8]
+        max_items: 10000
+        wait: 10s
+        workers: 10
+      span_metrics:
+        # Additional dimensions to add to the metrics along with the default dimensions.
+        # Dimensions are searched for in the resource and span attributes and are added to the metrics if present.
+        dimensions: []
+        histogram_buckets: [0.002, 0.004, 0.008, 0.016, 0.032, 0.064, 0.128, 0.256, 0.512, 1.02, 2.05, 4.10]
+    storage:
+      path: /var/tempo/wal
+      wal:
+      remote_write_flush_deadline: 1m
+      # A list of remote write endpoints.
+      # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
+      remote_write: []
   service:
     # -- Annotations for Metrics Generator service
     annotations: {}
@@ -597,12 +616,11 @@ config: |
       kvstore:
         store: memberlist
     processor:
-      service_graphs:
-        max_items: {{ .Values.metricsGenerator.config.service_graphs_max_items }}
+      {{- toYaml .Values.metricsGenerator.config.processor | nindent 6 }}
     storage:
-      path: /var/tempo/wal
-      remote_write:
-        {{- toYaml .Values.metricsGenerator.config.storage_remote_write | nindent 6}}
+      {{- toYaml .Values.metricsGenerator.config.storage | nindent 6 }}
+    registry:
+      {{- toYaml .Values.metricsGenerator.config.registry | nindent 6 }}
   {{- end }}
   distributor:
     ring:

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -232,7 +232,7 @@ metricsGenerator:
     - name: http
       port: 3100
       service: true
-  # https://grafana.com/docs/tempo/latest/configuration/#metrics-generator
+  # -- More information on configuration: https://grafana.com/docs/tempo/latest/configuration/#metrics-generator
   config:
     registry:
       collection_interval: 15s
@@ -240,24 +240,24 @@ metricsGenerator:
       stale_duration: 15m
     processor:
       service_graphs:
-        # Additional dimensions to add to the metrics. Dimensions are searched for in the
-        # resource and span attributes and are added to the metrics if present.
+        # -- Additional dimensions to add to the metrics. Dimensions are searched for in the
+        # -- resource and span attributes and are added to the metrics if present.
         dimensions: []
         histogram_buckets: [0.1, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8]
         max_items: 10000
         wait: 10s
         workers: 10
       span_metrics:
-        # Additional dimensions to add to the metrics along with the default dimensions.
-        # Dimensions are searched for in the resource and span attributes and are added to the metrics if present.
+        # -- Additional dimensions to add to the metrics along with the default dimensions.
+        # -- Dimensions are searched for in the resource and span attributes and are added to the metrics if present.
         dimensions: []
         histogram_buckets: [0.002, 0.004, 0.008, 0.016, 0.032, 0.064, 0.128, 0.256, 0.512, 1.02, 2.05, 4.10]
     storage:
       path: /var/tempo/wal
       wal:
       remote_write_flush_deadline: 1m
-      # A list of remote write endpoints.
-      # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
+      # -- A list of remote write endpoints.
+      # -- https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
       remote_write: []
   service:
     # -- Annotations for Metrics Generator service


### PR DESCRIPTION
Adds support for the entire [metrics_generator config](https://grafana.com/docs/tempo/latest/configuration/#metrics-generator) in the `tempo-distributed` chart, matching the config structure. It looks like the `tempo` chart has a bit more of a bespoke configuration so I did not update that but I can if needed.

Addresses https://github.com/grafana/helm-charts/issues/1621

Important breaking change note:

- Moves `metricsGenerator.config.storage_remote_write` to `metricsGenerator.config.storage.remote_write`
- Moves `metricsGenerator.config.service_graphs_max_items` to `metricsGenerator.config.processor.service_graphs.max_items`

I can add these back to make things backwards compatible if needed. I only bumped a minor version but will bump a major if it's more appropriate, given the breaking change.