### PR TITLE
[grafana] fix: Respect templating in service.annotations as specified in documentation

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.34.0
+version: 6.35.0
 appVersion: 9.1.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/service.yaml
+++ b/charts/grafana/templates/service.yaml
@@ -9,9 +9,10 @@ metadata:
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}
+{{- $root := . }}
 {{- with .Values.service.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
+{{ tpl (toYaml . | indent 4) $root }}
 {{- end }}
 spec:
 {{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -158,6 +158,7 @@ service:
   port: 80
   targetPort: 3000
     # targetPort: 4181 To be used with a proxy extraContainer
+  ## Service annotations. Can be templated.
   annotations: {}
   labels: {}
   portName: service


### PR DESCRIPTION
Currently, there is a bug where user-provided service annotations
are not passed through the templating engine, even though the docs suggest
that they are. This patch applies the same strategy as the serviceAccount
annotations to the service annotations.

Signed-off-by: Michael Bauer <mbauer@relativityspace.com>

## Testing

Testing is run with an `overrides.yaml` file containing the following:

```
service:
  annotations:
    something.io/test: "{{ .Release.Name }}-test"
```

The expected outcome is that the result of `helm template . -f overrides.yaml` will produce a service with the annotation:

```
something.io/test: release-name-test
```

### Before fix

```
~/rs/ext/helm-charts/charts/grafana grafana-service-annotation-templating*
❯ helm template -f overrides.yaml . | grep "something.io/test" --context=1
  annotations:
    something.io/test: '{{ .Release.Name }}-test'
```


### After Fix

```
~/rs/ext/helm-charts/charts/grafana grafana-service-annotation-templating*
❯ helm template -f overrides.yaml . | grep "something.io/test" --context=1
  annotations:
    something.io/test: 'release-name-test'
```