### PR TITLE
[loki-simple-scalable] Allows loki s3 http_config block to be configured

### DIFF
--- a/charts/loki-simple-scalable/CHANGELOG.md
+++ b/charts/loki-simple-scalable/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## 1.8.12
+
+- [ENHANCEMENT] Loki s3 http_config block can now be configured via values.yaml
+
 ## 1.8.10
 
 - [ENHANCEMENT] Loki server block can now be configured via values.yaml

--- a/charts/loki-simple-scalable/Chart.yaml
+++ b/charts/loki-simple-scalable/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-simple-scalable
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.6.1
-version: 1.8.11
+version: 1.8.12
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-simple-scalable/README.md
+++ b/charts/loki-simple-scalable/README.md
@@ -1,6 +1,6 @@
 # loki-simple-scalable
 
-![Version: 1.8.11](https://img.shields.io/badge/Version-1.8.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 1.8.12](https://img.shields.io/badge/Version-1.8.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 
@@ -140,6 +140,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | loki.storage.s3.s3 | string | `nil` |  |
 | loki.storage.s3.s3ForcePathStyle | bool | `false` |  |
 | loki.storage.s3.secretAccessKey | string | `nil` |  |
+| loki.storage.s3.http_config | object | `{}` | Check https://grafana.com/docs/loki/latest/configuration/#s3_storage_config for more info on how to configure http_config |
 | loki.storage.type | string | `"s3"` |  |
 | loki.storage_config | object | `{"hedging":{"at":"250ms","max_per_second":20,"up_to":3}}` | Additional storage config |
 | loki.structuredConfig | object | `{}` | Structured loki configuration, takes precedence over `loki.config`, `loki.schemaConfig`, `loki.storageConfig` |

--- a/charts/loki-simple-scalable/templates/_helpers.tpl
+++ b/charts/loki-simple-scalable/templates/_helpers.tpl
@@ -141,6 +141,21 @@ s3:
   {{- end }}
   s3forcepathstyle: {{ .s3ForcePathStyle }}
   insecure: {{ .insecure }}
+  {{- with .http_config}}
+  http_config:
+    {{- with .idle_conn_timeout }}
+    idle_conn_timeout: {{ . }}
+    {{- end}}
+    {{- with .response_header_timeout }}
+    response_header_timeout: {{ . }}
+    {{- end}}
+    {{- with .insecure_skip_verify }}
+    insecure_skip_verify: {{ . }}
+    {{- end}}
+    {{- with .ca_file}}
+    ca_file: {{ . }}
+    {{- end}}
+  {{- end }}
 {{- end -}}
 {{- else if eq .Values.loki.storage.type "gcs" -}}
 {{- with .Values.loki.storage.gcs }}

--- a/charts/loki-simple-scalable/values.yaml
+++ b/charts/loki-simple-scalable/values.yaml
@@ -185,6 +185,7 @@ loki:
       accessKeyId: null
       s3ForcePathStyle: false
       insecure: false
+      http_config: {}
     gcs:
       chunkBufferSize: 0
       requestTimeout: "0s"

--- a/charts/loki-simple-scalable/values.yaml
+++ b/charts/loki-simple-scalable/values.yaml
@@ -185,6 +185,7 @@ loki:
       accessKeyId: null
       s3ForcePathStyle: false
       insecure: false
+      # -- Check https://grafana.com/docs/loki/latest/configuration/#s3_storage_config for more info on how to configure http_config
       http_config: {}
     gcs:
       chunkBufferSize: 0


### PR DESCRIPTION
Fix for #1762 

This will allow users of the chart to configure the s3 http_config block as documented here [https://grafana.com/docs/loki/latest/configuration/#s3_storage_config](https://grafana.com/docs/loki/latest/configuration/#s3_storage_config) through values.

Signed-off-by: CAJNA Jarod <contact@jarodcajna.fr>