### PR TITLE
Add optional helm tag prefix to release job

### DIFF
--- a/.github/workflows/update-helm-repo.yaml
+++ b/.github/workflows/update-helm-repo.yaml
@@ -18,6 +18,11 @@ on:
         default: ct.yaml
         required: false
         type: string
+      helm_tag_prefix:
+        description: prefix to use when publishing helm tags
+        default: ""
+        required: false
+        type: string
     secrets:
       helm_repo_token:
         description: GitHub api token to use against the helm-charts repository
@@ -33,6 +38,7 @@ env:
   CR_KEYRING: "${{ github.workspace }}/.cr-gpg/secring.gpg"
   CR_PACKAGE_PATH: "${{ github.workspace }}/.cr-release-packages"
   CR_TOOL_PATH: "${{ github.workspace }}/.cr-tool"
+  HELM_TAG_PREFIX: "${{ inputs.helm_tag_prefix }}"
 
 jobs:
   setup:
@@ -172,8 +178,12 @@ jobs:
       - name: Create tag and check if exists on origin
         run: |
           cd source
-          echo "Making tag ${{ steps.parse-chart.outputs.tagname }}"
-          git tag "${{ steps.parse-chart.outputs.tagname }}"
+          tag="${{ steps.parse-chart.outputs.tagname }}"
+          if [[ -n "$HELM_TAG_PREFIX" ]]; do
+            tag="$HELM_TAG_PREFIX-${{ steps.parse-chart.outputs.tagname }}"
+          fi
+          echo "Making tag $tag"
+          git tag "$tag"
 
       - name: Make github release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Add optional tag prefix for publishing helm charts. Useful for when this workflow is invoked from another repository.