### PR TITLE
[tempo-distributed] switch poddisruptionbudget to v1 policy

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.26.1
+version: 0.27.0
 appVersion: 1.5.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.26.1](https://img.shields.io/badge/Version-0.26.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.27.0](https://img.shields.io/badge/Version-0.27.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -19,6 +19,12 @@ helm repo add grafana https://grafana.github.io/helm-charts
 ## Upgrading
 
 A major chart version change indicates that there is an incompatible breaking change needing manual actions.
+
+### From chart version < 0.27.0
+
+Version 0.27.0
+
+* Switches PodDisruptionBudget from api version policy/v1beta1 to policy/v1, making it incompatible with k8s < 1.21.0
 
 ### From chart version < 0.26.0
 

--- a/charts/tempo-distributed/README.md.gotmpl
+++ b/charts/tempo-distributed/README.md.gotmpl
@@ -20,6 +20,12 @@ helm repo add grafana https://grafana.github.io/helm-charts
 
 A major chart version change indicates that there is an incompatible breaking change needing manual actions.
 
+### From chart version < 0.27.0
+
+Version 0.27.0
+
+* Switches PodDisruptionBudget from api version policy/v1beta1 to policy/v1, making it incompatible with k8s < 1.21.0
+
 ### From chart version < 0.26.0
 
 Version 0.26.0

--- a/charts/tempo-distributed/templates/compactor/poddisruptionbudget-compactor.yaml
+++ b/charts/tempo-distributed/templates/compactor/poddisruptionbudget-compactor.yaml
@@ -1,5 +1,5 @@
 {{- if gt (int .Values.compactor.replicas) 1 }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "tempo.compactorFullname" . }}

--- a/charts/tempo-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
@@ -1,5 +1,5 @@
 {{- if gt (int .Values.distributor.replicas) 1 }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "tempo.distributorFullname" . }}

--- a/charts/tempo-distributed/templates/gateway/poddisruptionbudget-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/poddisruptionbudget-gateway.yaml
@@ -1,5 +1,5 @@
 {{- if gt (int .Values.gateway.replicas) 1 }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "tempo.gatewayFullname" . }}

--- a/charts/tempo-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
@@ -1,5 +1,5 @@
 {{- if gt (int .Values.ingester.replicas) 1 }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "tempo.ingesterFullname" . }}

--- a/charts/tempo-distributed/templates/memcached/poddisruptionbudget-memcached.yaml
+++ b/charts/tempo-distributed/templates/memcached/poddisruptionbudget-memcached.yaml
@@ -1,5 +1,5 @@
 {{- if gt (int .Values.memcached.replicas) 1 }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "tempo.memcachedFullname" . }}

--- a/charts/tempo-distributed/templates/metrics-generator/poddisruptionbudget-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/poddisruptionbudget-metrics-generator.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.metricsGenerator.enabled }}
 {{- if gt (int .Values.metricsGenerator.replicas) 1 }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "tempo.metricsGeneratorFullname" . }}

--- a/charts/tempo-distributed/templates/querier/poddisruptionbudget-querier.yaml
+++ b/charts/tempo-distributed/templates/querier/poddisruptionbudget-querier.yaml
@@ -1,5 +1,5 @@
 {{- if gt (int .Values.querier.replicas) 1 }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "tempo.querierFullname" . }}

--- a/charts/tempo-distributed/templates/query-frontend/poddisruptionbudget-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/poddisruptionbudget-query-frontend.yaml
@@ -1,5 +1,5 @@
 {{- if gt (int .Values.queryFrontend.replicas) 1 }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "tempo.queryFrontendFullname" . }}


### PR DESCRIPTION
pdb v1beta1 has been deprecated since k8s 1.21, which is EOL already. 
Migrate it to v1, making it compatible with k8s 1.25, but breaking compatibility with k8s <1.21