### PR TITLE
[loki-distributed] fix: pdbs should take the right value

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.6.1
-version: 0.56.6
+version: 0.56.7
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.56.6](https://img.shields.io/badge/Version-0.56.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 0.56.7](https://img.shields.io/badge/Version-0.56.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 
@@ -323,6 +323,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | memcachedFrontend.extraContainers | list | `[]` | Containers to add to the memcached-frontend pods |
 | memcachedFrontend.extraEnv | list | `[]` | Environment variables to add to memcached-frontend pods |
 | memcachedFrontend.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to memcached-frontend pods |
+| memcachedFrontend.maxUnavailable | int | `1` | Pod Disruption Budget maxUnavailable |
 | memcachedFrontend.nodeSelector | object | `{}` | Node selector for memcached-frontend pods |
 | memcachedFrontend.podAnnotations | object | `{}` | Annotations for memcached-frontend pods |
 | memcachedFrontend.podLabels | object | `{}` | Labels for memcached-frontend pods |
@@ -455,6 +456,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | queryScheduler.image.registry | string | `nil` | The Docker registry for the query-scheduler image. Overrides `loki.image.registry` |
 | queryScheduler.image.repository | string | `nil` | Docker image repository for the query-scheduler image. Overrides `loki.image.repository` |
 | queryScheduler.image.tag | string | `nil` | Docker image tag for the query-scheduler image. Overrides `loki.image.tag` |
+| queryScheduler.maxUnavailable | int | `1` | Pod Disruption Budget maxUnavailable |
 | queryScheduler.nodeSelector | object | `{}` | Node selector for query-scheduler pods |
 | queryScheduler.podAnnotations | object | `{}` | Annotations for query-scheduler pods |
 | queryScheduler.podLabels | object | `{}` | Labels for query-scheduler pods |

--- a/charts/loki-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
+++ b/charts/loki-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
@@ -1,4 +1,4 @@
-{{- if gt (int .Values.distributor.replicas) 1 }}
+{{- if and .Values.distributor.enabled (gt (int .Values.distributor.replicas) 1) }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/loki-distributed/templates/gateway/poddisruptionbudget-gateway.yaml
+++ b/charts/loki-distributed/templates/gateway/poddisruptionbudget-gateway.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.gateway.enabled }}
-{{- if gt (int .Values.gateway.replicas) 1 }}
+{{- if and .Values.gateway.enabled (gt (int .Values.gateway.replicas) 1) }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -10,8 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.gatewaySelectorLabels" . | nindent 6 }}
-  {{- with .Values.distributor.maxUnavailable }}
+  {{- with .Values.gateway.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
-{{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/index-gateway/poddisruptionbudget-index-gateway.yaml
+++ b/charts/loki-distributed/templates/index-gateway/poddisruptionbudget-index-gateway.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.indexGateway.enabled }}
-{{- if gt (int .Values.indexGateway.replicas) 1 }}
+{{- if and .Values.indexGateway.enabled (gt (int .Values.indexGateway.replicas) 1) }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -10,8 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.indexGatewaySelectorLabels" . | nindent 6 }}
-  {{- with .Values.distributor.maxUnavailable }}
+  {{- with .Values.indexGateway.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
-{{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
@@ -1,4 +1,4 @@
-{{- if gt (int .Values.ingester.replicas) 1 }}
+{{- if and .Values.ingester.enabled (gt (int .Values.ingester.replicas) 1) }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.ingesterSelectorLabels" . | nindent 6 }}
-  {{- with .Values.distributor.maxUnavailable }}
+  {{- with .Values.ingester.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/memcached-chunks/poddisruptionbudget-memcached-chunks.yaml
+++ b/charts/loki-distributed/templates/memcached-chunks/poddisruptionbudget-memcached-chunks.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.memcachedChunksSelectorLabels" . | nindent 6 }}
-  {{- with .Values.distributor.maxUnavailable }}
+  {{- with .Values.memcachedChunks.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/memcached-frontend/poddisruptionbudget-memcached-frontend.yaml
+++ b/charts/loki-distributed/templates/memcached-frontend/poddisruptionbudget-memcached-frontend.yaml
@@ -9,5 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.memcachedFrontendSelectorLabels" . | nindent 6 }}
-  maxUnavailable: 1
+  {{- with .Values.memcachedFrontend.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/memcached-index-queries/poddisruptionbudget-memcached-index-queries.yaml
+++ b/charts/loki-distributed/templates/memcached-index-queries/poddisruptionbudget-memcached-index-queries.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.memcachedIndexQueriesSelectorLabels" . | nindent 6 }}
-  {{- with .Values.distributor.maxUnavailable }}
+  {{- with .Values.memcachedIndexQueries.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/memcached-index-writes/poddisruptionbudget-memcached-index-writes.yaml
+++ b/charts/loki-distributed/templates/memcached-index-writes/poddisruptionbudget-memcached-index-writes.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.memcachedIndexWritesSelectorLabels" . | nindent 6 }}
-  {{- with .Values.distributor.maxUnavailable }}
+  {{- with .Values.memcachedIndexWrites.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/querier/poddisruptionbudget-querier.yaml
+++ b/charts/loki-distributed/templates/querier/poddisruptionbudget-querier.yaml
@@ -1,4 +1,4 @@
-{{- if gt (int .Values.querier.replicas) 1 }}
+{{- if and .Values.querier.enabled (gt (int .Values.querier.replicas) 1) }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.querierSelectorLabels" . | nindent 6 }}
-  {{- with .Values.distributor.maxUnavailable }}
+  {{- with .Values.querier.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/query-frontend/poddisruptionbudget-query-frontent.yaml
+++ b/charts/loki-distributed/templates/query-frontend/poddisruptionbudget-query-frontent.yaml
@@ -1,4 +1,4 @@
-{{- if gt (int .Values.queryFrontend.replicas) 1 }}
+{{- if and .Values.queryFrontend.enabled (gt (int .Values.queryFrontend.replicas) 1) }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.queryFrontendSelectorLabels" . | nindent 6 }}
-  {{- with .Values.distributor.maxUnavailable }}
+  {{- with .Values.queryFrontend.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/query-scheduler/poddisruptionbudget-query-scheduler.yaml
+++ b/charts/loki-distributed/templates/query-scheduler/poddisruptionbudget-query-scheduler.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.queryScheduler.enabled }}
-{{- if gt (int .Values.queryScheduler.replicas) 1 }}
+{{- if and .Values.queryScheduler.enabled (gt (int .Values.queryScheduler.replicas) 1) }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -10,6 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.querySchedulerSelectorLabels" . | nindent 6 }}
-  maxUnavailable: 1
-{{- end }}
+  {{- with .Values.queryScheduler.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/ruler/poddisruptionbudget-ruler.yaml
+++ b/charts/loki-distributed/templates/ruler/poddisruptionbudget-ruler.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.ruler.enabled }}
-{{- if gt (int .Values.ruler.replicas) 1 }}
+{{- if and .Values.ruler.enabled (gt (int .Values.ruler.replicas) 1) }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -10,8 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.rulerSelectorLabels" . | nindent 6 }}
-  {{- with .Values.distributor.maxUnavailable }}
+  {{- with .Values.ruler.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
-{{- end }}
 {{- end }}

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -670,6 +670,8 @@ queryScheduler:
               matchLabels:
                 {{- include "loki.querySchedulerSelectorLabels" . | nindent 12 }}
             topologyKey: failure-domain.beta.kubernetes.io/zone
+  # -- Pod Disruption Budget maxUnavailable
+  maxUnavailable: 1
   # -- Node selector for query-scheduler pods
   nodeSelector: {}
   # -- Tolerations for query-scheduler pods
@@ -1495,6 +1497,8 @@ memcachedFrontend:
               matchLabels:
                 {{- include "loki.memcachedFrontendSelectorLabels" . | nindent 12 }}
             topologyKey: failure-domain.beta.kubernetes.io/zone
+  # -- Pod Disruption Budget maxUnavailable
+  maxUnavailable: 1
   # -- Node selector for memcached-frontend pods
   nodeSelector: {}
   # -- Tolerations for memcached-frontend pods


### PR DESCRIPTION
Almost all Loki distributed PDBs takes them values from the `distributor` configuration. 
Also, PDBs are deployed for services that are not enabled.

This PR fixes these two issues.