### PR TITLE
[tempo-distributed] Fix ingester pdb to use rep. factor properly

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.26.2
+version: 0.26.3
 appVersion: 1.5.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.26.2](https://img.shields.io/badge/Version-0.26.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.26.3](https://img.shields.io/badge/Version-0.26.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
@@ -9,5 +9,5 @@ spec:
   selector:
     matchLabels:
       {{- include "tempo.ingesterSelectorLabels" . | nindent 6 }}
-  maxUnavailable: {{ sub (.Values.ingester.replicas) (.Values.ingester.config.replication_factor) }}
+  maxUnavailable: {{ sub (.Values.ingester.replicas) (add (div .Values.ingester.config.replication_factor 2) 1) }}
 {{- end }}


### PR DESCRIPTION
The ingester pdb should specify a maxUnavailable equal to (total number of desired replicas) - (number of replicas in the ring required to ACK a write). Currently in main the calculation is incorrect.