### PR TITLE
[tempo-distributed] fix: remove extraneous ports from query-frontend-discovery service

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.26.3
+version: 0.26.4
 appVersion: 1.5.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.26.3](https://img.shields.io/badge/Version-0.26.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.26.4](https://img.shields.io/badge/Version-0.26.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/query-frontend/service-query-frontend-discovery.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/service-query-frontend-discovery.yaml
@@ -20,15 +20,17 @@ spec:
       port: 9095
       protocol: TCP
       targetPort: 9095
+    - name: grpclb
+      port: 9096
+      protocol: TCP
+      targetPort: grpc
+    {{- if .Values.queryFrontend.query.enabled }}
     - name: tempo-query-jaeger-ui
       port: 16686
       targetPort: 16686
     - name: tempo-query-metrics
       port: 16687
       targetPort: jaeger-metrics
-    - name: grpclb
-      port: 9096
-      targetPort: grpc
-      protocol: TCP
+    {{- end }}
   selector:
     {{- include "tempo.queryFrontendSelectorLabels" . | nindent 4 }}


### PR DESCRIPTION
This PR ensures service ports related to the optional `tempo-query` component are only configured when `tempo-query` is enabled. This is consistent with the existing `query-frontend` service configuration.

Additionally, the `grpclb` port has been moved immediately below `grpc`, so that all the ports are listed in order.