### PR TITLE
[promtail] feat: support extraContainers for Promtail Deployments

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.37.1
+version: 6.37.2
 appVersion: 9.1.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -1,4 +1,3 @@
-
 {{- define "grafana.pod" -}}
 {{- if .Values.schedulerName }}
 schedulerName: "{{ .Values.schedulerName }}"
@@ -614,8 +613,10 @@ containers:
 {{- if .Values.lifecycleHooks }}
     lifecycle: {{ tpl (.Values.lifecycleHooks | toYaml) . | nindent 6 }}
 {{- end }}
+{{- if .Values.resources }}
     resources:
-{{ toYaml .Values.resources | indent 6 }}
+      {{- toYaml . | nindent 6 }}
+{{- end }}
 {{- with .Values.extraContainers }}
 {{ tpl . $ | indent 2 }}
 {{- end }}

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -4,13 +4,13 @@ schedulerName: "{{ .Values.schedulerName }}"
 {{- end }}
 serviceAccountName: {{ template "grafana.serviceAccountName" . }}
 automountServiceAccountToken: {{ .Values.serviceAccount.autoMount }}
-{{- if .Values.securityContext }}
+{{- with .Values.securityContext }}
 securityContext:
-{{ toYaml .Values.securityContext | indent 2 }}
+  {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- if .Values.hostAliases }}
+{{- with .Values.hostAliases }}
 hostAliases:
-{{ toYaml .Values.hostAliases | indent 2 }}
+  {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- if .Values.priorityClassName }}
 priorityClassName: {{ .Values.priorityClassName }}
@@ -30,8 +30,10 @@ initContainers:
       runAsNonRoot: false
       runAsUser: 0
     command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsGroup }}", "/var/lib/grafana"]
+    {{- with .Values.initChownData.resources }}
     resources:
-{{ toYaml .Values.initChownData.resources | indent 6 }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     volumeMounts:
       - name: storage
         mountPath: "/var/lib/grafana"
@@ -49,17 +51,19 @@ initContainers:
     imagePullPolicy: {{ .Values.downloadDashboardsImage.pullPolicy }}
     command: ["/bin/sh"]
     args: [ "-c", "mkdir -p /var/lib/grafana/dashboards/default && /bin/sh -x /etc/grafana/download_dashboards.sh" ]
+    {{- with .Values.downloadDashboards.resources }}
     resources:
-{{ toYaml .Values.downloadDashboards.resources | indent 6 }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     env:
 {{- range $key, $value := .Values.downloadDashboards.env }}
       - name: "{{ $key }}"
         value: "{{ $value }}"
 {{- end }}
-{{- if .Values.downloadDashboards.securityContext }}
+    {{- with .Values.downloadDashboards.securityContext }}
     securityContext:
-{{- toYaml .Values.downloadDashboards.securityContext | nindent 6 }}
-{{- end }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{- if .Values.downloadDashboards.envFromSecret }}
     envFrom:
       - secretRef:
@@ -113,12 +117,14 @@ initContainers:
       - name: SKIP_TLS_VERIFY
         value: "{{ .Values.sidecar.skipTlsVerify }}"
       {{- end }}
+    {{- with .Values.sidecar.resources }}
     resources:
-{{ toYaml .Values.sidecar.resources | indent 6 }}
-{{- if .Values.sidecar.securityContext }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.securityContext }}
     securityContext:
-{{- toYaml .Values.sidecar.securityContext | nindent 6 }}
-{{- end }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     volumeMounts:
       - name: sc-datasources-volume
         mountPath: "/etc/grafana/provisioning/datasources"
@@ -152,20 +158,22 @@ initContainers:
       - name: SKIP_TLS_VERIFY
         value: "{{ .Values.sidecar.skipTlsVerify }}"
       {{- end }}
-{{- if .Values.sidecar.livenessProbe }}
+    {{- with .Values.sidecar.livenessProbe }}
     livenessProbe:
-{{ toYaml .Values.livenessProbe | indent 6 }}
-{{- end }}
-{{- if .Values.sidecar.readinessProbe }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.readinessProbe }}
     readinessProbe:
-{{ toYaml .Values.readinessProbe | indent 6 }}
-{{- end }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.resources }}
     resources:
-{{ toYaml .Values.sidecar.resources | indent 6 }}
-{{- if .Values.sidecar.securityContext }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.securityContext }}
     securityContext:
-{{- toYaml .Values.sidecar.securityContext | nindent 6 }}
-{{- end }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     volumeMounts:
       - name: sc-notifiers-volume
         mountPath: "/etc/grafana/provisioning/notifiers"
@@ -241,20 +249,22 @@ containers:
       - name: WATCH_CLIENT_TIMEOUT
         value: "{{ .Values.sidecar.dashboards.watchClientTimeout }}"
       {{- end }}
-{{- if .Values.sidecar.livenessProbe }}
+    {{- with .Values.sidecar.livenessProbe }}
     livenessProbe:
-{{ toYaml .Values.livenessProbe | indent 6 }}
-{{- end }}
-{{- if .Values.sidecar.readinessProbe }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.readinessProbe }}
     readinessProbe:
-{{ toYaml .Values.readinessProbe | indent 6 }}
-{{- end }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.resources }}
     resources:
-{{ toYaml .Values.sidecar.resources | indent 6 }}
-{{- if .Values.sidecar.securityContext }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.securityContext }}
     securityContext:
-{{- toYaml .Values.sidecar.securityContext | nindent 6 }}
-{{- end }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     volumeMounts:
       - name: sc-dashboard-volume
         mountPath: {{ .Values.sidecar.dashboards.folder | quote }}
@@ -315,20 +325,22 @@ containers:
       - name: REQ_METHOD
         value: POST
       {{- end }}
-{{- if .Values.sidecar.livenessProbe }}
+    {{- with .Values.sidecar.livenessProbe }}
     livenessProbe:
-{{ toYaml .Values.livenessProbe | indent 6 }}
-{{- end }}
-{{- if .Values.sidecar.readinessProbe }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.readinessProbe }}
     readinessProbe:
-{{ toYaml .Values.readinessProbe | indent 6 }}
-{{- end }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.resources }}
     resources:
-{{ toYaml .Values.sidecar.resources | indent 6 }}
-{{- if .Values.sidecar.securityContext }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.securityContext }}
     securityContext:
-{{- toYaml .Values.sidecar.securityContext | nindent 6 }}
-{{- end }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     volumeMounts:
       - name: sc-datasources-volume
         mountPath: "/etc/grafana/provisioning/datasources"
@@ -386,20 +398,22 @@ containers:
       - name: REQ_METHOD
         value: POST
       {{- end }}
-{{- if .Values.sidecar.livenessProbe }}
+    {{- with .Values.sidecar.livenessProbe }}
     livenessProbe:
-{{ toYaml .Values.livenessProbe | indent 6 }}
-{{- end }}
-{{- if .Values.sidecar.readinessProbe }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.readinessProbe }}
     readinessProbe:
-{{ toYaml .Values.readinessProbe | indent 6 }}
-{{- end }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.resources }}
     resources:
-{{ toYaml .Values.sidecar.resources | indent 6 }}
-{{- if .Values.sidecar.securityContext }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.securityContext }}
     securityContext:
-{{- toYaml .Values.sidecar.securityContext | nindent 6 }}
-{{- end }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     volumeMounts:
       - name: sc-plugins-volume
         mountPath: "/etc/grafana/provisioning/plugins"
@@ -417,10 +431,10 @@ containers:
       - {{ . }}
     {{- end }}
   {{- end}}
-{{- if .Values.containerSecurityContext }}
+    {{- with .Values.containerSecurityContext }}
     securityContext:
-{{- toYaml .Values.containerSecurityContext | nindent 6 }}
-{{- end }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     volumeMounts:
       - name: config
         mountPath: "/etc/grafana/grafana.ini"
@@ -606,23 +620,27 @@ containers:
           optional: {{ .optional | default false }}
     {{- end }}
     {{- end }}
+    {{- with .Values.livenessProbe }}
     livenessProbe:
-{{ toYaml .Values.livenessProbe | indent 6 }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.readinessProbe }}
     readinessProbe:
-{{ toYaml .Values.readinessProbe | indent 6 }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{- if .Values.lifecycleHooks }}
     lifecycle: {{ tpl (.Values.lifecycleHooks | toYaml) . | nindent 6 }}
 {{- end }}
-{{- if .Values.resources }}
+    {{- with .Values.resources }}
     resources:
       {{- toYaml . | nindent 6 }}
-{{- end }}
+    {{- end }}
 {{- with .Values.extraContainers }}
 {{ tpl . $ | indent 2 }}
 {{- end }}
 {{- with .Values.nodeSelector }}
 nodeSelector:
-{{ toYaml . | indent 2 }}
+  {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- $root := . }}
 {{- with .Values.affinity }}
@@ -631,11 +649,11 @@ affinity:
 {{- end }}
 {{- with .Values.topologySpreadConstraints }}
 topologySpreadConstraints:
-{{ toYaml . | indent 2 }}
+  {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- with .Values.tolerations }}
 tolerations:
-{{ toYaml . | indent 2 }}
+  {{- toYaml . | nindent 2 }}
 {{- end }}
 volumes:
   - name: config

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -57,6 +57,10 @@ initContainers:
       - name: "{{ $key }}"
         value: "{{ $value }}"
 {{- end }}
+{{- if .Values.downloadDashboards.securityContext }}
+    securityContext:
+{{- toYaml .Values.downloadDashboards.securityContext | nindent 6 }}
+{{- end }}
 {{- if .Values.downloadDashboards.envFromSecret }}
     envFrom:
       - secretRef:

--- a/charts/grafana/templates/deployment.yaml
+++ b/charts/grafana/templates/deployment.yaml
@@ -46,5 +46,5 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
-      {{- include "grafana.pod" . | nindent 6 }}
+      {{- include "grafana.pod" . | indent 6 }}
 {{- end }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -136,6 +136,7 @@ downloadDashboards:
   env: {}
   envFromSecret: ""
   resources: {}
+  securityContext: {}
 
 ## Pod Annotations
 # podAnnotations: {}

--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.6.1
-version: 0.56.7
+version: 0.56.8
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.6.1
-version: 0.56.6
+version: 0.56.7
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.56.6](https://img.shields.io/badge/Version-0.56.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 0.56.7](https://img.shields.io/badge/Version-0.56.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 
@@ -323,6 +323,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | memcachedFrontend.extraContainers | list | `[]` | Containers to add to the memcached-frontend pods |
 | memcachedFrontend.extraEnv | list | `[]` | Environment variables to add to memcached-frontend pods |
 | memcachedFrontend.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to memcached-frontend pods |
+| memcachedFrontend.maxUnavailable | int | `1` | Pod Disruption Budget maxUnavailable |
 | memcachedFrontend.nodeSelector | object | `{}` | Node selector for memcached-frontend pods |
 | memcachedFrontend.podAnnotations | object | `{}` | Annotations for memcached-frontend pods |
 | memcachedFrontend.podLabels | object | `{}` | Labels for memcached-frontend pods |
@@ -455,6 +456,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | queryScheduler.image.registry | string | `nil` | The Docker registry for the query-scheduler image. Overrides `loki.image.registry` |
 | queryScheduler.image.repository | string | `nil` | Docker image repository for the query-scheduler image. Overrides `loki.image.repository` |
 | queryScheduler.image.tag | string | `nil` | Docker image tag for the query-scheduler image. Overrides `loki.image.tag` |
+| queryScheduler.maxUnavailable | int | `1` | Pod Disruption Budget maxUnavailable |
 | queryScheduler.nodeSelector | object | `{}` | Node selector for query-scheduler pods |
 | queryScheduler.podAnnotations | object | `{}` | Annotations for query-scheduler pods |
 | queryScheduler.podLabels | object | `{}` | Labels for query-scheduler pods |

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.56.7](https://img.shields.io/badge/Version-0.56.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 0.56.8](https://img.shields.io/badge/Version-0.56.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/templates/compactor/service-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/service-compactor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.compactor.enabled .Values.compactor.enabled }}
+{{- if .Values.compactor.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/loki-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
+++ b/charts/loki-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.distributor.enabled (gt (int .Values.distributor.replicas) 1) }}
+{{- if gt (int .Values.distributor.replicas) 1 }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/loki-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
+++ b/charts/loki-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
@@ -1,4 +1,4 @@
-{{- if gt (int .Values.distributor.replicas) 1 }}
+{{- if and .Values.distributor.enabled (gt (int .Values.distributor.replicas) 1) }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/loki-distributed/templates/gateway/poddisruptionbudget-gateway.yaml
+++ b/charts/loki-distributed/templates/gateway/poddisruptionbudget-gateway.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.gateway.enabled }}
-{{- if gt (int .Values.gateway.replicas) 1 }}
+{{- if and .Values.gateway.enabled (gt (int .Values.gateway.replicas) 1) }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -10,8 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.gatewaySelectorLabels" . | nindent 6 }}
-  {{- with .Values.distributor.maxUnavailable }}
+  {{- with .Values.gateway.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
-{{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/index-gateway/poddisruptionbudget-index-gateway.yaml
+++ b/charts/loki-distributed/templates/index-gateway/poddisruptionbudget-index-gateway.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.indexGateway.enabled }}
-{{- if gt (int .Values.indexGateway.replicas) 1 }}
+{{- if and .Values.indexGateway.enabled (gt (int .Values.indexGateway.replicas) 1) }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -10,8 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.indexGatewaySelectorLabels" . | nindent 6 }}
-  {{- with .Values.distributor.maxUnavailable }}
+  {{- with .Values.indexGateway.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
-{{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingester.enabled (gt (int .Values.ingester.replicas) 1) }}
+{{- if gt (int .Values.ingester.replicas) 1 }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/loki-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
@@ -1,4 +1,4 @@
-{{- if gt (int .Values.ingester.replicas) 1 }}
+{{- if and .Values.ingester.enabled (gt (int .Values.ingester.replicas) 1) }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.ingesterSelectorLabels" . | nindent 6 }}
-  {{- with .Values.distributor.maxUnavailable }}
+  {{- with .Values.ingester.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/memcached-chunks/poddisruptionbudget-memcached-chunks.yaml
+++ b/charts/loki-distributed/templates/memcached-chunks/poddisruptionbudget-memcached-chunks.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.memcachedChunksSelectorLabels" . | nindent 6 }}
-  {{- with .Values.distributor.maxUnavailable }}
+  {{- with .Values.memcachedChunks.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/memcached-frontend/poddisruptionbudget-memcached-frontend.yaml
+++ b/charts/loki-distributed/templates/memcached-frontend/poddisruptionbudget-memcached-frontend.yaml
@@ -9,5 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.memcachedFrontendSelectorLabels" . | nindent 6 }}
-  maxUnavailable: 1
+  {{- with .Values.memcachedFrontend.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/memcached-index-queries/poddisruptionbudget-memcached-index-queries.yaml
+++ b/charts/loki-distributed/templates/memcached-index-queries/poddisruptionbudget-memcached-index-queries.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.memcachedIndexQueriesSelectorLabels" . | nindent 6 }}
-  {{- with .Values.distributor.maxUnavailable }}
+  {{- with .Values.memcachedIndexQueries.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/memcached-index-writes/poddisruptionbudget-memcached-index-writes.yaml
+++ b/charts/loki-distributed/templates/memcached-index-writes/poddisruptionbudget-memcached-index-writes.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.memcachedIndexWritesSelectorLabels" . | nindent 6 }}
-  {{- with .Values.distributor.maxUnavailable }}
+  {{- with .Values.memcachedIndexWrites.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/querier/poddisruptionbudget-querier.yaml
+++ b/charts/loki-distributed/templates/querier/poddisruptionbudget-querier.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.querier.enabled (gt (int .Values.querier.replicas) 1) }}
+{{- if gt (int .Values.querier.replicas) 1 }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/loki-distributed/templates/querier/poddisruptionbudget-querier.yaml
+++ b/charts/loki-distributed/templates/querier/poddisruptionbudget-querier.yaml
@@ -1,4 +1,4 @@
-{{- if gt (int .Values.querier.replicas) 1 }}
+{{- if and .Values.querier.enabled (gt (int .Values.querier.replicas) 1) }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.querierSelectorLabels" . | nindent 6 }}
-  {{- with .Values.distributor.maxUnavailable }}
+  {{- with .Values.querier.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/query-frontend/poddisruptionbudget-query-frontent.yaml
+++ b/charts/loki-distributed/templates/query-frontend/poddisruptionbudget-query-frontent.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.queryFrontend.enabled (gt (int .Values.queryFrontend.replicas) 1) }}
+{{- if gt (int .Values.queryFrontend.replicas) 1 }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/loki-distributed/templates/query-frontend/poddisruptionbudget-query-frontent.yaml
+++ b/charts/loki-distributed/templates/query-frontend/poddisruptionbudget-query-frontent.yaml
@@ -1,4 +1,4 @@
-{{- if gt (int .Values.queryFrontend.replicas) 1 }}
+{{- if and .Values.queryFrontend.enabled (gt (int .Values.queryFrontend.replicas) 1) }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.queryFrontendSelectorLabels" . | nindent 6 }}
-  {{- with .Values.distributor.maxUnavailable }}
+  {{- with .Values.queryFrontend.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/query-scheduler/poddisruptionbudget-query-scheduler.yaml
+++ b/charts/loki-distributed/templates/query-scheduler/poddisruptionbudget-query-scheduler.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.queryScheduler.enabled }}
-{{- if gt (int .Values.queryScheduler.replicas) 1 }}
+{{- if and .Values.queryScheduler.enabled (gt (int .Values.queryScheduler.replicas) 1) }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -10,6 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.querySchedulerSelectorLabels" . | nindent 6 }}
-  maxUnavailable: 1
-{{- end }}
+  {{- with .Values.queryScheduler.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/ruler/poddisruptionbudget-ruler.yaml
+++ b/charts/loki-distributed/templates/ruler/poddisruptionbudget-ruler.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.ruler.enabled }}
-{{- if gt (int .Values.ruler.replicas) 1 }}
+{{- if and .Values.ruler.enabled (gt (int .Values.ruler.replicas) 1) }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -10,8 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.rulerSelectorLabels" . | nindent 6 }}
-  {{- with .Values.distributor.maxUnavailable }}
+  {{- with .Values.ruler.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
-{{- end }}
 {{- end }}

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -670,6 +670,8 @@ queryScheduler:
               matchLabels:
                 {{- include "loki.querySchedulerSelectorLabels" . | nindent 12 }}
             topologyKey: failure-domain.beta.kubernetes.io/zone
+  # -- Pod Disruption Budget maxUnavailable
+  maxUnavailable: 1
   # -- Node selector for query-scheduler pods
   nodeSelector: {}
   # -- Tolerations for query-scheduler pods
@@ -1495,6 +1497,8 @@ memcachedFrontend:
               matchLabels:
                 {{- include "loki.memcachedFrontendSelectorLabels" . | nindent 12 }}
             topologyKey: failure-domain.beta.kubernetes.io/zone
+  # -- Pod Disruption Budget maxUnavailable
+  maxUnavailable: 1
   # -- Node selector for memcached-frontend pods
   nodeSelector: {}
   # -- Tolerations for memcached-frontend pods

--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.6.1
-version: 6.3.0
+version: 6.4.0
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -95,7 +95,7 @@ The new release which will pick up again from the existing `positions.yaml`.
 | deployment.enabled | bool | `false` | Deploys Promtail as a Deployment |
 | deployment.replicaCount | int | `1` |  |
 | extraArgs | list | `[]` |  |
-| extraContainers | object | `{}` |  |
+| extraContainers | object | `{}` | Extra containers to deploy alongside a Promtail Deployment (only), e.g. an auth proxy |
 | extraEnv | list | `[]` | Extra environment variables |
 | extraEnvFrom | list | `[]` | Extra environment variables from secrets or configmaps |
 | extraObjects | list | `[]` | Extra K8s manifests to deploy |

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -270,8 +270,8 @@ config:
       log_level: {{ .Values.config.logLevel }}
       http_listen_port: {{ .Values.config.serverPort }}
 
-    client:
-      url: {{ .Values.config.lokiAddress }}
+    clients:
+      - url: {{ .Values.config.lokiAddress }}
 
     positions:
       filename: /run/promtail/positions.yaml

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 6.3.0](https://img.shields.io/badge/Version-6.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 6.4.0](https://img.shields.io/badge/Version-6.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 
@@ -91,6 +91,7 @@ The new release which will pick up again from the existing `positions.yaml`.
 | deployment.enabled | bool | `false` | Deploys Promtail as a Deployment |
 | deployment.replicaCount | int | `1` |  |
 | extraArgs | list | `[]` |  |
+| extraContainers | object | `{}` |  |
 | extraEnv | list | `[]` | Extra environment variables |
 | extraEnvFrom | list | `[]` | Extra environment variables from secrets or configmaps |
 | extraObjects | list | `[]` | Extra K8s manifests to deploy |

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,10 @@
 # promtail
 
+<<<<<<< HEAD
 ![Version: 6.4.0](https://img.shields.io/badge/Version-6.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+=======
+![Version: 6.3.1](https://img.shields.io/badge/Version-6.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+>>>>>>> 22fd300c (fix: run helm-docs)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/README.md.gotmpl
+++ b/charts/promtail/README.md.gotmpl
@@ -195,8 +195,8 @@ config:
       log_level: {{"{{"}} .Values.config.logLevel {{"}}"}}
       http_listen_port: {{"{{"}} .Values.config.serverPort {{"}}"}}
 
-    client:
-      url: {{"{{"}} .Values.config.lokiAddress {{"}}"}}
+    clients:
+      - url: {{"{{"}} .Values.config.lokiAddress {{"}}"}}
 
     positions:
       filename: /run/promtail/positions.yaml

--- a/charts/promtail/templates/_pod.tpl
+++ b/charts/promtail/templates/_pod.tpl
@@ -81,6 +81,12 @@ Pod template used in Daemonset and Deployment
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- if .Values.deployment.enabled }}
+      {{- range $name, $values := .Values.extraContainers }}
+        - name: {{ $name }}
+      {{ toYaml $values | nindent 10 }}
+      {{- end }}
+      {{- end }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -204,6 +204,17 @@ serviceMonitor:
   # (defines `metric_relabel_configs`)
   metricRelabelings: []
 
+# Extra containers created as part of a Promtail Deployment resource
+# - spec for Container:
+#   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#container-v1-core
+#
+# Note that the key is used as the `name` field, i.e. below will create a
+# container named `promtail-proxy`.
+extraContainers: {}
+  # promtail-proxy:
+  #   image: nginx
+  #   ...
+
 # -- Configure additional ports and services. For each configured port, a corresponding service is created.
 # See values.yaml for details
 extraPorts: {}

--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.26.2
+version: 0.26.3
 appVersion: 1.5.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.26.3
+version: 0.26.4
 appVersion: 1.5.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.26.2](https://img.shields.io/badge/Version-0.26.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.26.3](https://img.shields.io/badge/Version-0.26.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.26.3](https://img.shields.io/badge/Version-0.26.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.26.4](https://img.shields.io/badge/Version-0.26.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
@@ -9,5 +9,5 @@ spec:
   selector:
     matchLabels:
       {{- include "tempo.ingesterSelectorLabels" . | nindent 6 }}
-  maxUnavailable: {{ sub (.Values.ingester.replicas) (.Values.ingester.config.replication_factor) }}
+  maxUnavailable: {{ sub (.Values.ingester.replicas) (add (div .Values.ingester.config.replication_factor 2) 1) }}
 {{- end }}

--- a/charts/tempo-distributed/templates/query-frontend/service-query-frontend-discovery.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/service-query-frontend-discovery.yaml
@@ -20,15 +20,17 @@ spec:
       port: 9095
       protocol: TCP
       targetPort: 9095
+    - name: grpclb
+      port: 9096
+      protocol: TCP
+      targetPort: grpc
+    {{- if .Values.queryFrontend.query.enabled }}
     - name: tempo-query-jaeger-ui
       port: 16686
       targetPort: 16686
     - name: tempo-query-metrics
       port: 16687
       targetPort: jaeger-metrics
-    - name: grpclb
-      port: 9096
-      targetPort: grpc
-      protocol: TCP
+    {{- end }}
   selector:
     {{- include "tempo.queryFrontendSelectorLabels" . | nindent 4 }}


### PR DESCRIPTION
Closes #1805 (see there for motivation) #1727 (didn't realise this existed before)

I am not a Helm templating expert. Typically I see this sort of `extra` being done as a List, but I couldn't get it to render with the necessary `-` at the beginning of the extra containers in the overall list, so I went with the `name: values` hash approach. Feel free to improve that.

Signed-off-by: Conor Evans <coevans@tcd.ie>