### PR TITLE
[promtail] feat: support extraContainers for Promtail Deployments

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.6.1
-version: 6.3.1
+version: 6.4.0
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 6.3.1](https://img.shields.io/badge/Version-6.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 6.4.0](https://img.shields.io/badge/Version-6.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -91,6 +91,7 @@ The new release which will pick up again from the existing `positions.yaml`.
 | deployment.enabled | bool | `false` | Deploys Promtail as a Deployment |
 | deployment.replicaCount | int | `1` |  |
 | extraArgs | list | `[]` |  |
+| extraContainers | object | `{}` |  |
 | extraEnv | list | `[]` | Extra environment variables |
 | extraEnvFrom | list | `[]` | Extra environment variables from secrets or configmaps |
 | extraObjects | list | `[]` | Extra K8s manifests to deploy |

--- a/charts/promtail/templates/_pod.tpl
+++ b/charts/promtail/templates/_pod.tpl
@@ -81,6 +81,12 @@ Pod template used in Daemonset and Deployment
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- if .Values.deployment.enabled }}
+      {{- range $name, $values := .Values.extraContainers }}
+        - name: {{ $name }}
+      {{ toYaml $values | nindent 10 }}
+      {{- end }}
+      {{- end }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -204,6 +204,17 @@ serviceMonitor:
   # (defines `metric_relabel_configs`)
   metricRelabelings: []
 
+# Extra containers created as part of a Promtail Deployment resource
+# - spec for Container:
+#   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#container-v1-core
+#
+# Note that the key is used as the `name` field, i.e. below will create a
+# container named `promtail-proxy`.
+extraContainers: {}
+  # promtail-proxy:
+  #   image: nginx
+  #   ...
+
 # -- Configure additional ports and services. For each configured port, a corresponding service is created.
 # See values.yaml for details
 extraPorts: {}


### PR DESCRIPTION
Closes #1805 (see there for motivation) #1727 (didn't realise this existed before)

I am not a Helm templating expert. Typically I see this sort of extra being done as a List, but I couldn't get it to render with the necessary - at the beginning of the extra containers in the overall list, so I went with the name: values hash approach. Feel free to improve that.

Signed-off-by: Conor Evans <coevans@tcd.ie>

redo of #1806 which i messed up spectacularly