### PR TITLE
[grafana] upgrade to 9.1.5

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.38.0
-appVersion: 9.1.4
+version: 6.38.1
+appVersion: 9.1.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net


### PR DESCRIPTION
Straight forward hotfix update of the `appVersion` in the `grafana/Chart.yaml` from 9.1.4 to 9.1.5.

See: https://github.com/grafana/grafana/releases/tag/v9.1.5