### PR TITLE
[grafana] add namespace to horizontal pod autoscaling

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.38.1
+version: 6.38.2
 appVersion: 9.1.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.38.2
+version: 6.38.3
 appVersion: 9.1.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/hpa.yaml
+++ b/charts/grafana/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "grafana.fullname" . }}
+  namespace: {{ template "grafana.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "grafana.name" . }}
     helm.sh/chart: {{ template "grafana.chart" . }}


### PR DESCRIPTION
This pull request will add the **namespace** field to the Grafana horizontal pod autoscaling metadata. 

Both [deployment.yaml](https://github.com/grafana/helm-charts/blob/main/charts/grafana/templates/deployment.yaml#L6) and [service.yaml](https://github.com/grafana/helm-charts/blob/main/charts/grafana/templates/service.yaml#L6) use the [namespaceOverride](https://github.com/grafana/helm-charts/blob/main/charts/grafana/templates/_helpers.tpl#L56)-value from [values.yaml ](https://github.com/grafana/helm-charts/blob/main/charts/grafana/values.yaml#L924) file. The [hpa.yaml](https://github.com/grafana/helm-charts/blob/main/charts/grafana/templates/hpa.yaml) doesn't. This can cause a situation where the horizontal pod autoscaling and the deployment are on two different namespaces.