### PR TITLE
[grafana] Fix whitespace issue due to empty value

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.38.4
+version: 6.38.5
 appVersion: 9.1.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -678,7 +678,7 @@ grafana.ini:
   grafana_net:
     url: https://grafana.net
   server:
-    domain: "{{ if (and .Values.ingress.enabled .Values.ingress.hosts) }}{{ .Values.ingress.hosts | first }}{{ end }}"
+    domain: "{{ if (and .Values.ingress.enabled .Values.ingress.hosts) }}{{ .Values.ingress.hosts | first }}{{ else }}''{{ end }}"
 ## grafana Authentication can be enabled with the following values on grafana.ini
  # server:
       # The full public facing url you use in browser, used for redirects and emails


### PR DESCRIPTION
If not using the ingress feature the domain value would be empty. This resulted in the template producing an ini file with a line like this:

`domain = \n`

This would cause issues when passing the resource through a tool like kustomize, which would turn the multiline block into an encoded single line string in order to preserve trailing whitespace, resulting in kubectl diffs that are very hard to review.