### PR TITLE
[loki-distributed] Introduce runtimeConfig

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.6.1
-version: 0.57.0
+version: 0.58.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.57.0](https://img.shields.io/badge/Version-0.57.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 0.58.0](https://img.shields.io/badge/Version-0.58.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 
@@ -501,6 +501,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | ruler.serviceLabels | object | `{}` | Labels for ruler service |
 | ruler.terminationGracePeriodSeconds | int | `300` | Grace period to allow the ruler to shutdown before it is killed |
 | ruler.tolerations | list | `[]` | Tolerations for ruler pods |
+| runtimeConfig | object | `{}` | Provides a reloadable runtime configuration file for some specific configuration |
 | serviceAccount.annotations | object | `{}` | Annotations for the service account |
 | serviceAccount.automountServiceAccountToken | bool | `true` | Set this toggle to false to opt out of automounting API credentials for the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a ServiceAccount should be created |

--- a/charts/loki-distributed/templates/compactor/deployment-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/deployment-compactor.yaml
@@ -87,6 +87,8 @@ spec:
               mountPath: /tmp
             - name: config
               mountPath: /etc/loki/config
+            - name: runtime-config
+              mountPath: /var/{{ include "loki.name" . }}-runtime
             - name: data
               mountPath: /var/loki
             {{- with .Values.compactor.extraVolumeMounts }}
@@ -120,6 +122,9 @@ spec:
           configMap:
             name: {{ include "loki.fullname" . }}
           {{- end }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "loki.fullname" . }}-runtime
         - name: data
           {{- if .Values.compactor.persistence.enabled }}
           persistentVolumeClaim:

--- a/charts/loki-distributed/templates/distributor/deployment-distributor.yaml
+++ b/charts/loki-distributed/templates/distributor/deployment-distributor.yaml
@@ -91,6 +91,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config
+            - name: runtime-config
+              mountPath: /var/{{ include "loki.name" . }}-runtime
             {{- with .Values.distributor.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -120,6 +122,9 @@ spec:
           configMap:
             name: {{ include "loki.fullname" . }}
           {{- end }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "loki.fullname" . }}-runtime
         {{- with .Values.distributor.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/loki-distributed/templates/index-gateway/statefulset-index-gateway.yaml
+++ b/charts/loki-distributed/templates/index-gateway/statefulset-index-gateway.yaml
@@ -85,6 +85,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config
+            - name: runtime-config
+              mountPath: /var/{{ include "loki.name" . }}-runtime
             - name: data
               mountPath: /var/loki
             {{- with .Values.indexGateway.extraVolumeMounts }}
@@ -116,6 +118,9 @@ spec:
           configMap:
             name: {{ include "loki.fullname" . }}
           {{- end }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "loki.fullname" . }}-runtime
         {{- with .Values.indexGateway.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/loki-distributed/templates/ingester/deployment-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/deployment-ingester.yaml
@@ -84,6 +84,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config
+            - name: runtime-config
+              mountPath: /var/{{ include "loki.name" . }}-runtime
             - name: data
               mountPath: /var/loki
             {{- with .Values.ingester.extraVolumeMounts }}
@@ -115,6 +117,9 @@ spec:
           configMap:
             name: {{ include "loki.fullname" . }}
           {{- end }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "loki.fullname" . }}-runtime
         {{- with .Values.ingester.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/loki-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/statefulset-ingester.yaml
@@ -99,6 +99,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config
+            - name: runtime-config
+              mountPath: /var/{{ include "loki.name" . }}-runtime
             - name: data
               mountPath: /var/loki
             {{- with .Values.ingester.extraVolumeMounts }}
@@ -132,6 +134,9 @@ spec:
           configMap:
             name: {{ include "loki.fullname" . }}
           {{- end }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "loki.fullname" . }}-runtime
         {{- with .Values.ingester.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/loki-distributed/templates/querier/deployment-querier.yaml
+++ b/charts/loki-distributed/templates/querier/deployment-querier.yaml
@@ -92,6 +92,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config
+            - name: runtime-config
+              mountPath: /var/{{ include "loki.name" . }}-runtime
             - name: data
               mountPath: /var/loki
             {{- with .Values.querier.extraVolumeMounts }}
@@ -127,6 +129,9 @@ spec:
           configMap:
             name: {{ include "loki.fullname" . }}
           {{- end }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "loki.fullname" . }}-runtime
         - name: data
           emptyDir: {}
         {{- with .Values.querier.extraVolumes }}

--- a/charts/loki-distributed/templates/querier/statefulset-querier.yaml
+++ b/charts/loki-distributed/templates/querier/statefulset-querier.yaml
@@ -95,6 +95,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config
+            - name: runtime-config
+              mountPath: /var/{{ include "loki.name" . }}-runtime
             - name: data
               mountPath: /var/loki
             {{- with .Values.querier.extraVolumeMounts }}
@@ -130,6 +132,9 @@ spec:
           configMap:
             name: {{ include "loki.fullname" . }}
           {{- end }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "loki.fullname" . }}-runtime
         {{- with .Values.querier.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/loki-distributed/templates/query-frontend/deployment-query-frontend.yaml
+++ b/charts/loki-distributed/templates/query-frontend/deployment-query-frontend.yaml
@@ -86,6 +86,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config
+            - name: runtime-config
+              mountPath: /var/{{ include "loki.name" . }}-runtime
             {{- with .Values.queryFrontend.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -115,6 +117,9 @@ spec:
           configMap:
             name: {{ include "loki.fullname" . }}
           {{- end }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "loki.fullname" . }}-runtime
         {{- with .Values.queryFrontend.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/loki-distributed/templates/query-scheduler/deployment-query-scheduler.yaml
+++ b/charts/loki-distributed/templates/query-scheduler/deployment-query-scheduler.yaml
@@ -81,6 +81,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config
+            - name: runtime-config
+              mountPath: /var/{{ include "loki.name" . }}-runtime
             {{- with .Values.queryScheduler.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -112,6 +114,9 @@ spec:
           configMap:
             name: {{ include "loki.fullname" . }}
           {{- end }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "loki.fullname" . }}-runtime
         {{- with .Values.queryScheduler.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/loki-distributed/templates/ruler/deployment-ruler.yaml
+++ b/charts/loki-distributed/templates/ruler/deployment-ruler.yaml
@@ -91,6 +91,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config
+            - name: runtime-config
+              mountPath: /var/{{ include "loki.name" . }}-runtime
             - name: data
               mountPath: /var/loki
             - name: tmp
@@ -132,6 +134,9 @@ spec:
           configMap:
             name: {{ include "loki.fullname" . }}
           {{- end }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "loki.fullname" . }}-runtime
         {{- range $dir, $_ := .Values.ruler.directories }}
         - name: {{ include "loki.rulerRulesDirName" $dir }}
           configMap:

--- a/charts/loki-distributed/templates/ruler/statefulset-ruler.yaml
+++ b/charts/loki-distributed/templates/ruler/statefulset-ruler.yaml
@@ -84,6 +84,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config
+            - name: runtime-config
+              mountPath: /var/{{ include "loki.name" . }}-runtime
             - name: data
               mountPath: /var/loki
             - name: tmp
@@ -122,6 +124,9 @@ spec:
           configMap:
             name: {{ include "loki.fullname" . }}
           {{- end }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "loki.fullname" . }}-runtime
         {{- range $dir, $_ := .Values.ruler.directories }}
         - name: {{ include "loki.rulerRulesDirName" $dir }}
           configMap:

--- a/charts/loki-distributed/templates/runtime-configmap.yaml
+++ b/charts/loki-distributed/templates/runtime-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "loki.fullname" . }}-runtime
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+data:
+  runtime.yaml: |
+    {{ tpl (toYaml .Values.runtimeConfig) . | nindent 4 }}

--- a/charts/loki-distributed/templates/table-manager/deployment-table-manager.yaml
+++ b/charts/loki-distributed/templates/table-manager/deployment-table-manager.yaml
@@ -81,6 +81,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config
+            - name: runtime-config
+              mountPath: /var/{{ include "loki.name" . }}-runtime
             {{- with .Values.tableManager.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -110,6 +112,9 @@ spec:
           configMap:
             name: {{ include "loki.fullname" . }}
           {{- end }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "loki.fullname" . }}-runtime
         {{- with .Values.tableManager.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -125,6 +125,9 @@ loki:
     {{- toYaml .Values.loki.storageConfig | nindent 2}}
     {{- end}}
 
+    runtime_config:
+      file: /var/{{ include "loki.name" . }}-runtime/runtime.yaml
+
     chunk_store_config:
       max_look_back_period: 0s
 
@@ -201,6 +204,10 @@ loki:
 
   # -- Structured loki configuration, takes precedence over `loki.config`, `loki.schemaConfig`, `loki.storageConfig`
   structuredConfig: {}
+
+# -- Provides a reloadable runtime configuration file for some specific configuration
+runtimeConfig: {}
+
 serviceAccount:
   # -- Specifies whether a ServiceAccount should be created
   create: true


### PR DESCRIPTION
This is largely inspired by similar value available in [mimir-distributed](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed) helm chart.

The idea is to have a dedicated configmap to handle [runtime_config](https://grafana.com/docs/loki/latest/configuration/#runtime-configuration-file), alway present even if empty. This way, having it seperately from main config, components pods are guaranteed not to restart for any changes.

```yaml
runtimeConfig:
  overrides:
    tenant1:
      ingestion_rate_mb: 10
      max_streams_per_user: 100000
      max_chunks_per_query: 100000
    tenant2:
      max_streams_per_user: 1000000
      max_chunks_per_query: 1000000

  multi_kv_config:
      mirror-enabled: false
      primary: consul
```

Some questionable details:

1. Like in `mimir-distributed`, `runtimeConfig` is available at values root (`.Values.runtimeConfig`). I feel a bit uncomfortable with this, i would have preferred `.Values.loki.runtimeConfig`, but having kind-of compatibility with `mimir-distributed` seems more desirable.
2. `mimir-distributed` uses `/data` for mounting data and `/var/mimir` for mounting runtime config. As `loki-distributed` uses `/var/loki` for mounting its data, i've decided to stay in `/var` directory and uses `/var/loki-runtime` for its runtime config.