### PR TITLE
[agent-operator] Add container SecurityContext

### DIFF
--- a/charts/agent-operator/Chart.yaml
+++ b/charts/agent-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: grafana-agent-operator
 description: A Helm chart for Grafana Agent Operator
 type: application
-version: 0.2.6
+version: 0.2.7
 appVersion: "0.27.1"
 home: https://grafana.com/docs/agent/v0.27/
 icon: https://raw.githubusercontent.com/grafana/agent/v0.27.1/docs/assets/logo_and_name.png

--- a/charts/agent-operator/README.md
+++ b/charts/agent-operator/README.md
@@ -1,6 +1,6 @@
 # grafana-agent-operator
 
-![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.27.1](https://img.shields.io/badge/AppVersion-0.27.1-informational?style=flat-square)
+![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.27.1](https://img.shields.io/badge/AppVersion-0.27.1-informational?style=flat-square)
 
 A Helm chart for Grafana Agent Operator
 
@@ -55,6 +55,7 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Pod affinity configuration |
 | annotations | object | `{}` | Annotations for the Deployment |
+| containerSecurityContext | object | `{}` | Container security context (allowPrivilegeEscalation, etc.) |
 | extraArgs | list | `[]` | List of additional cli arguments to configure agent-operator (example: `--log.level`) |
 | fullnameOverride | string | `""` | Overrides the chart's computed fullname |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |

--- a/charts/agent-operator/templates/operator-deployment.yaml
+++ b/charts/agent-operator/templates/operator-deployment.yaml
@@ -34,6 +34,10 @@ spec:
       - name: {{ include "ga-operator.name" . }}
         image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.containerSecurityContext }}
+        securityContext:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
         {{- with .Values.resources }}
         resources:
         {{- toYaml . | nindent 10 }}

--- a/charts/agent-operator/values.yaml
+++ b/charts/agent-operator/values.yaml
@@ -16,6 +16,9 @@ podLabels: {}
 # -- Pod security context (runAsUser, etc.)
 podSecurityContext: {}
 
+# -- Container security context (allowPrivilegeEscalation, etc.)
+containerSecurityContext: {}
+
 rbac:
   # -- Toggle to create ClusterRole and ClusterRoleBinding
   create: true


### PR DESCRIPTION
This is useful for when running in a restricted environment. For example when running in a namespace using the [Restricted policy](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted) (either via a [PodSecurityPolicy](https://v1-24.docs.kubernetes.io/docs/concepts/security/pod-security-policy/) or via the new [namespace labels](https://kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-namespace-labels/)), the agent-operator container should not be allowed privilege escalation and should only have access to a read-only root filesystem.

These are already configurable in the CRDs for the Grafana Agent pods that the operator creates, but the operator doesn't have them.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>
