### PR TITLE
[agent-operator] Allow using PodSecurityPolicy

### DIFF
--- a/charts/agent-operator/Chart.yaml
+++ b/charts/agent-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: grafana-agent-operator
 description: A Helm chart for Grafana Agent Operator
 type: application
-version: 0.2.5
+version: 0.2.6
 appVersion: "0.27.1"
 home: https://grafana.com/docs/agent/v0.27/
 icon: https://raw.githubusercontent.com/grafana/agent/v0.27.1/docs/assets/logo_and_name.png

--- a/charts/agent-operator/README.md
+++ b/charts/agent-operator/README.md
@@ -1,6 +1,6 @@
 # grafana-agent-operator
 
-![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.27.1](https://img.shields.io/badge/AppVersion-0.27.1-informational?style=flat-square)
+![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.27.1](https://img.shields.io/badge/AppVersion-0.27.1-informational?style=flat-square)
 
 A Helm chart for Grafana Agent Operator
 
@@ -68,7 +68,8 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 | podAnnotations | object | `{}` | Annotations for the Deployment Pods |
 | podLabels | object | `{}` | Annotations for the Deployment Pods |
 | podSecurityContext | object | `{}` | Pod security context (runAsUser, etc.) |
-| rbac | object | `{"create":true}` | Toggle to create ClusterRole and ClusterRoleBinding |
+| rbac.create | bool | `true` | Toggle to create ClusterRole and ClusterRoleBinding |
+| rbac.podSecurityPolicyName | string | `""` | Name of a PodSecurityPolicy to use in the ClusterRole. If unset, no PodSecurityPolicy is used. |
 | resources | object | `{}` | Resource limits and requests config |
 | serviceAccount.create | bool | `true` | Toggle to create ServiceAccount |
 | serviceAccount.name | string | `nil` | Service account name |

--- a/charts/agent-operator/README.md
+++ b/charts/agent-operator/README.md
@@ -1,6 +1,6 @@
 # grafana-agent-operator
 
-![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.27.1](https://img.shields.io/badge/AppVersion-0.27.1-informational?style=flat-square)
+![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.27.1](https://img.shields.io/badge/AppVersion-0.27.1-informational?style=flat-square)
 
 A Helm chart for Grafana Agent Operator
 

--- a/charts/agent-operator/templates/operator-clusterrole.yaml
+++ b/charts/agent-operator/templates/operator-clusterrole.yaml
@@ -52,4 +52,11 @@ rules:
   - daemonsets
   - deployments
   verbs: [get, list, watch, create, update, patch, delete]
+{{- with .Values.rbac.podSecurityPolicyName }}
+- apiGroups: [policy]
+  resources:
+  - podsecuritypolicies
+  verbs:         [use]
+  resourceNames: [ {{ . }} ]
+{{- end -}}
 {{- end -}}

--- a/charts/agent-operator/values.yaml
+++ b/charts/agent-operator/values.yaml
@@ -16,9 +16,11 @@ podLabels: {}
 # -- Pod security context (runAsUser, etc.)
 podSecurityContext: {}
 
-# -- Toggle to create ClusterRole and ClusterRoleBinding
 rbac:
+  # -- Toggle to create ClusterRole and ClusterRoleBinding
   create: true
+  # -- Name of a PodSecurityPolicy to use in the ClusterRole. If unset, no PodSecurityPolicy is used.
+  podSecurityPolicyName: ''
 
 serviceAccount:
   # -- Toggle to create ServiceAccount


### PR DESCRIPTION
This is useful when the agent-operator is being used as a subchart and
the parent chart is using a PodSecurityPolicy. This new value will allow
the user of the parent chart to configure the agent to use the same
PSP as the parent chart.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>
