### PR TITLE
[loki-stack] Disable tests is loki is disabled

### DIFF
--- a/charts/loki-stack/Chart.yaml
+++ b/charts/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 2.8.2
+version: 2.8.3
 appVersion: v2.6.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki-stack/templates/tests/loki-test-configmap.yaml
+++ b/charts/loki-stack/templates/tests/loki-test-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.loki.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -39,3 +40,4 @@ data:
       curl -sG ${LOKI_URI}/loki/api/v1/query_range?limit=1 --data-urlencode 'query={app="loki-test"}' | \
       jq -e '.data.result[].values[][1] == "foobar"'
     }
+{{- end }}

--- a/charts/loki-stack/templates/tests/loki-test-pod.yaml
+++ b/charts/loki-stack/templates/tests/loki-test-pod.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.loki.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -41,3 +42,4 @@ spec:
   - name: tests
     configMap:
       name: {{ template "loki-stack.fullname" . }}-test
+{{- end }}


### PR DESCRIPTION
Chart does not allow loki to be disabled in values, because of some variables used i tests templates (like  here https://github.com/grafana/helm-charts/blob/main/charts/loki-stack/templates/tests/loki-test-pod.yaml#L23)

This pr just make such resources optionals by testing if loki is enabled.

Same as https://github.com/grafana/helm-charts/pull/481 but without any lawyers involved ;)