### PR TITLE
[grafana] Fix sidecar dashboard configmap creation

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.40.0
+version: 6.40.1
 appVersion: 9.1.6
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/configmap-dashboard-provider.yaml
+++ b/charts/grafana/templates/configmap-dashboard-provider.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.sidecar.dashboards.enabled }}
+{{- if and .Values.sidecar.dashboards.enabled .Values.sidecar.dashboards.SCProvider }}
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
## Fixes
- Add an additional condition for creating the ConfigMap defining the provider for the dashboards sidecar, that `.Values.sidecar.dashboards.SCProvider` is true. This doesn't affect the default behavior, but allows for a cleaner deployment when not using SCProvider