### PR TITLE
[loki-distributed] Updated selection process for PodSecurityPolicy or SecurityContextCon…

### DIFF
--- a/charts/loki-distributed/templates/_helpers.tpl
+++ b/charts/loki-distributed/templates/_helpers.tpl
@@ -164,3 +164,22 @@ livenessProbe:
 {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/* Allow KubeVersion to be overridden. */}}
+{{- define "loki.kubeVersion" -}}
+  {{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
+{{- end -}}
+
+{{/*
+Return if we should create a PodSecurityPoliPodSecurityPolicycy. Takes into account user values and supported kubernetes versions.
+*/}}
+{{- define "loki.rbac.usePodSecurityPolicy" -}}
+{{- and (semverCompare "< 1.25-0" (include "loki.kubeVersion" .)) (and .Values.rbac.create (eq .Values.rbac.type "psp")) -}}
+{{- end -}}
+
+{{/*
+Return if we should create a SecurityContextConstraints. Takes into account user values and supported openshift versions.
+*/}}
+{{- define "loki.rbac.useSecurityContextConstraints" -}}
+{{- and .Values.rbac.create (eq .Values.rbac.type "scc") -}}
+{{- end -}}

--- a/charts/loki-distributed/templates/podsecuritypolicy.yaml
+++ b/charts/loki-distributed/templates/podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.pspEnabled }}
+{{- if eq (include "loki.rbac.usePodSecurityPolicy" .) "true" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/loki-distributed/templates/role.yaml
+++ b/charts/loki-distributed/templates/role.yaml
@@ -1,4 +1,6 @@
-{{- if or .Values.rbac.pspEnabled .Values.rbac.sccEnabled }}
+{{- $usePSP := (eq (include "loki.rbac.usePodSecurityPolicy" .) "true") }}
+{{- $useSCC := (eq (include "loki.rbac.useSecurityContextConstraints" .) "true") }}
+{{- if or $usePSP $useSCC }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -6,7 +8,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
-{{- if .Values.rbac.pspEnabled }}
+{{- if $usePSP }}
 rules:
   - apiGroups:
       - policy
@@ -17,7 +19,7 @@ rules:
     resourceNames:
       - {{ include "loki.fullname" . }}
 {{- end }}
-{{- if .Values.rbac.sccEnabled }}
+{{- if $useSCC }}
 rules:
 - apiGroups: 
   - security.openshift.io

--- a/charts/loki-distributed/templates/rolebinding.yaml
+++ b/charts/loki-distributed/templates/rolebinding.yaml
@@ -1,4 +1,6 @@
-{{- if or .Values.rbac.pspEnabled .Values.rbac.sccEnabled }}
+{{- $usePSP := (eq (include "loki.rbac.usePodSecurityPolicy" .) "true") }}
+{{- $useSCC := (eq (include "loki.rbac.useSecurityContextConstraints" .) "true") }}
+{{- if or $usePSP $useSCC }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/loki-distributed/templates/securitycontextconstraints.yaml
+++ b/charts/loki-distributed/templates/securitycontextconstraints.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.sccEnabled }}
+{{- if eq (include "loki.rbac.useSecurityContextConstraints" .) "true" }}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:


### PR DESCRIPTION
…straints... This is to just change the way one selects if to use Pod Security Policy (psp) for GKE/EKS/AKS and other K8s distros that use Pod Security Policy or Security Context Constrains (scc) that is used for OpenShift.