### PR TITLE
[loki-canary] Introduce volumes and volume mounts to containers

### DIFF
--- a/charts/loki-canary/Chart.yaml
+++ b/charts/loki-canary/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-canary
 description: Helm chart for Grafana Loki Canary
 type: application
 appVersion: 2.6.1
-version: 0.9.2
+version: 0.10.0
 home: https://github.com/grafana/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-canary/README.md
+++ b/charts/loki-canary/README.md
@@ -1,6 +1,6 @@
 # loki-canary
 
-![Version: 0.9.2](https://img.shields.io/badge/Version-0.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki Canary
 
@@ -30,6 +30,8 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | extraArgs | list | `["-labelname=pod","-labelvalue=$(POD_NAME)"]` | Additional CLI args for the canary |
 | extraEnv | list | `[]` | Environment variables to add to the canary pods |
 | extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the canary pods |
+| extraVolumeMounts | list | `[]` | Volume mounts to add to the containers |
+| extraVolumes | list | `[]` | Volumes to add to the containers |
 | fullnameOverride | string | `""` | Overrides the chart's computed fullname |
 | image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | image.repository | string | `"docker.io/grafana/loki-canary"` | Docker image repository |

--- a/charts/loki-canary/templates/daemonset.yaml
+++ b/charts/loki-canary/templates/daemonset.yaml
@@ -82,11 +82,19 @@ spec:
             timeoutSeconds: 1
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.extraVolumes }}
+      volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/loki-canary/values.yaml
+++ b/charts/loki-canary/values.yaml
@@ -86,6 +86,11 @@ nodeSelector: {}
 # -- Tolerations for canary pods
 tolerations: []
 
+# -- Volume mounts to add to the containers
+extraVolumeMounts: []
+# -- Volumes to add to the containers
+extraVolumes: []
+
 # -- The Loki server URL:Port, e.g. loki:3100
 lokiAddress: null
 


### PR DESCRIPTION
This change introduces templating for volume mounts and volumes

Tested with 

```
helm  template --dry-run --debug -f ci/without-basic-auth-values.yaml .
helm  template --dry-run --debug -f ci/with-basic-auth-values.yaml .
```

Also created a file with the additional values and ran `helm  template --dry-run --debug -f tmp/with-basic-volume-values.yaml`
```
lokiAddress: loki:3100

basicAuth:
  enabled: true
  username: user
  password: pass

extraVolumes:
   - name: tmp-test
     emptyDir: {}
extraVolumeMounts:
  - name: tmp-test
    mountPath: /tmp-test
```

Output
```
---
# Source: loki-canary/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: release-name-loki-canary
  labels:
    helm.sh/chart: loki-canary-0.9.2
    app.kubernetes.io/name: loki-canary
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "2.6.1"
    app.kubernetes.io/managed-by: Helm
automountServiceAccountToken: true
---
# Source: loki-canary/templates/secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: release-name-loki-canary
  labels:
    helm.sh/chart: loki-canary-0.9.2
    app.kubernetes.io/name: loki-canary
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "2.6.1"
    app.kubernetes.io/managed-by: Helm
stringData:
  username: user
  password: pass
---
# Source: loki-canary/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: release-name-loki-canary
  labels:
    helm.sh/chart: loki-canary-0.9.2
    app.kubernetes.io/name: loki-canary
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "2.6.1"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  ports:
    - name: http
      port: 3500
      targetPort: http
      protocol: TCP
  selector:
    app.kubernetes.io/name: loki-canary
    app.kubernetes.io/instance: release-name
---
# Source: loki-canary/templates/daemonset.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: release-name-loki-canary
  labels:
    helm.sh/chart: loki-canary-0.9.2
    app.kubernetes.io/name: loki-canary
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "2.6.1"
    app.kubernetes.io/managed-by: Helm
spec:
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app.kubernetes.io/name: loki-canary
      app.kubernetes.io/instance: release-name
  template:
    metadata:
      annotations:
      labels:
        app.kubernetes.io/name: loki-canary
        app.kubernetes.io/instance: release-name
    spec:
      serviceAccountName: release-name-loki-canary
      securityContext:
        fsGroup: 10001
        runAsGroup: 10001
        runAsNonRoot: true
        runAsUser: 10001
      containers:
        - name: loki
          image: "docker.io/grafana/loki-canary:2.6.1"
          imagePullPolicy: IfNotPresent
          args:
            - -addr=loki:3100
            - -user=$(USER)
            - -pass=$(PASS)
            - -labelname=pod
            - -labelvalue=$(POD_NAME)
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
          ports:
            - name: http
              containerPort: 3500
              protocol: TCP
          env:
            - name: POD_NAME
              valueFrom:
                fieldRef:
                  fieldPath: metadata.name
            - name: USER
              valueFrom:
                secretKeyRef:
                  name: release-name-loki-canary
                  key: username
            - name: PASS
              valueFrom:
                secretKeyRef:
                  name: release-name-loki-canary
                  key: password
          readinessProbe:
            httpGet:
              path: /metrics
              port: http
            initialDelaySeconds: 15
            timeoutSeconds: 1
          resources:
            {}
          volumeMounts:
            - mountPath: /tmp-test
              name: tmp-test
      volumes:
        - emptyDir: {}
          name: tmp-test
```