### PR TITLE
[loki-distributed] update memcached usage documentation

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.6.1
-version: 0.62.0
+version: 0.63.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.62.0](https://img.shields.io/badge/Version-0.62.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 0.63.0](https://img.shields.io/badge/Version-0.63.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -729,7 +729,7 @@ loki:
         memcached_client:
           consistent_hash: true
           host: {{ include "loki.memcachedChunksFullname" . }}
-          service: http
+          service: memcached-client
 ```
 
 ### memcached-frontend
@@ -748,7 +748,7 @@ loki:
             consistent_hash: true
             host: {{ include "loki.memcachedFrontendFullname" . }}
             max_idle_conns: 16
-            service: http
+            service: memcached-client
             timeout: 500ms
             update_interval: 1m
 ```
@@ -769,7 +769,7 @@ loki:
         memcached_client:
           consistent_hash: true
           host: {{ include "loki.memcachedIndexQueriesFullname" . }}
-          service: http
+          service: memcached-client
 ```
 
 ### memcached-index-writes
@@ -790,7 +790,7 @@ loki:
         memcached_client:
           consistent_hash: true
           host: {{ include "loki.memcachedIndexWritesFullname" . }}
-          service: http
+          service: memcached-client
 ```
 
 ## Compactor

--- a/charts/loki-distributed/README.md.gotmpl
+++ b/charts/loki-distributed/README.md.gotmpl
@@ -241,7 +241,7 @@ loki:
         memcached_client:
           consistent_hash: true
           host: {{"{{"}} include "loki.memcachedChunksFullname" . {{"}}"}}
-          service: http
+          service: memcached-client
 ```
 
 ### memcached-frontend
@@ -260,7 +260,7 @@ loki:
             consistent_hash: true
             host: {{"{{"}} include "loki.memcachedFrontendFullname" . {{"}}"}}
             max_idle_conns: 16
-            service: http
+            service: memcached-client
             timeout: 500ms
             update_interval: 1m
 ```
@@ -281,7 +281,7 @@ loki:
         memcached_client:
           consistent_hash: true
           host: {{"{{"}} include "loki.memcachedIndexQueriesFullname" . {{"}}"}}
-          service: http
+          service: memcached-client
 ```
 
 ### memcached-index-writes
@@ -302,7 +302,7 @@ loki:
         memcached_client:
           consistent_hash: true
           host: {{"{{"}} include "loki.memcachedIndexWritesFullname" . {{"}}"}}
-          service: http
+          service: memcached-client
 ```
 
 ## Compactor


### PR DESCRIPTION
Hello dear Grafana helm chart maintainers

This PR updates the loki-distributed README.md to reflect the latest changes in memcached configuration introduced in https://github.com/grafana/helm-charts/pull/1765

