### PR TITLE
[tempo-distributed] add appProtocol field to the memberlist, distributor, ingester, metricsGenerator, querier and the queryFrontend

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.27.3
+version: 0.27.4
 appVersion: 1.5.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -238,6 +238,8 @@ The memcached default args are removed and should be provided manually. The sett
 | config | string | See values.yaml | Config file contents for Tempo distributed. Passed through the `tpl` function to allow templating |
 | configStorageType | string | `"ConfigMap"` | Defines what kind of object stores the configuration, a ConfigMap or a Secret. In order to move sensitive information (such as credentials) from the ConfigMap/Secret to a more secure location (e.g. vault), it is possible to use [environment variables in the configuration](https://grafana.com/docs/mimir/latest/operators-guide/configuring/reference-configuration-parameters/#use-environment-variables-in-the-configuration). Such environment variables can be then stored in a separate Secret and injected via the global.extraEnvFrom value. For details about environment injection from a Secret please see [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/#use-case-as-container-environment-variables). |
 | distributor.affinity | string | Hard node and soft zone anti-affinity | Affinity for distributor pods. Passed through `tpl` and, thus, to be configured as string |
+| distributor.appProtocol | object | `{"grpc":null}` | Adds the appProtocol field to the distributor service. This allows distributor to work with istio protocol selection. |
+| distributor.appProtocol.grpc | string | `nil` | Set the optional grpc service protocol. Ex: "grpc", "http2" or "https" |
 | distributor.autoscaling.enabled | bool | `false` | Enable autoscaling for the distributor |
 | distributor.autoscaling.maxReplicas | int | `3` | Maximum autoscaling replicas for the distributor |
 | distributor.autoscaling.minReplicas | int | `1` | Minimum autoscaling replicas for the distributor |
@@ -365,6 +367,8 @@ The memcached default args are removed and should be provided manually. The sett
 | global_overrides.per_tenant_override_config | string | `"/conf/overrides.yaml"` |  |
 | ingester.affinity | string | Soft node and soft zone anti-affinity | Affinity for ingester pods. Passed through `tpl` and, thus, to be configured as string |
 | ingester.annotations | object | `{}` | Annotations for the ingester StatefulSet |
+| ingester.appProtocol | object | `{"grpc":null}` | Adds the appProtocol field to the ingester service. This allows ingester to work with istio protocol selection. |
+| ingester.appProtocol.grpc | string | `nil` | Set the optional grpc service protocol. Ex: "grpc", "http2" or "https" |
 | ingester.autoscaling.enabled | bool | `false` | Enable autoscaling for the ingester |
 | ingester.autoscaling.maxReplicas | int | `3` | Maximum autoscaling replicas for the ingester |
 | ingester.autoscaling.minReplicas | int | `1` | Minimum autoscaling replicas for the ingester |
@@ -456,6 +460,8 @@ The memcached default args are removed and should be provided manually. The sett
 | metaMonitoring.serviceMonitor.tlsConfig | string | `nil` | ServiceMonitor will use these tlsConfig settings to make the health check requests |
 | metricsGenerator.affinity | string | Hard node and soft zone anti-affinity | Affinity for metrics-generator pods. Passed through `tpl` and, thus, to be configured as string |
 | metricsGenerator.annotations | object | `{}` | Annotations for the metrics-generator StatefulSet |
+| metricsGenerator.appProtocol | object | `{"grpc":null}` | Adds the appProtocol field to the metricsGenerator service. This allows metricsGenerator to work with istio protocol selection. |
+| metricsGenerator.appProtocol.grpc | string | `nil` | Set the optional grpc service protocol. Ex: "grpc", "http2" or "https" |
 | metricsGenerator.config | object | `{"processor":{"service_graphs":{"dimensions":[],"histogram_buckets":[0.1,0.2,0.4,0.8,1.6,3.2,6.4,12.8],"max_items":10000,"wait":"10s","workers":10},"span_metrics":{"dimensions":[],"histogram_buckets":[0.002,0.004,0.008,0.016,0.032,0.064,0.128,0.256,0.512,1.02,2.05,4.1]}},"registry":{"collection_interval":"15s","external_labels":{},"stale_duration":"15m"},"storage":{"path":"/var/tempo/wal","remote_write":[],"remote_write_flush_deadline":"1m","wal":null}}` | More information on configuration: https://grafana.com/docs/tempo/latest/configuration/#metrics-generator |
 | metricsGenerator.config.processor.service_graphs.dimensions | list | `[]` | resource and span attributes and are added to the metrics if present. |
 | metricsGenerator.config.processor.span_metrics.dimensions | list | `[]` | Dimensions are searched for in the resource and span attributes and are added to the metrics if present. |
@@ -505,6 +511,8 @@ The memcached default args are removed and should be provided manually. The sett
 | prometheusRule.labels | object | `{}` | Additional PrometheusRule labels |
 | prometheusRule.namespace | string | `nil` | Alternative namespace for the PrometheusRule resource |
 | querier.affinity | string | Hard node and soft zone anti-affinity | Affinity for querier pods. Passed through `tpl` and, thus, to be configured as string |
+| querier.appProtocol | object | `{"grpc":null}` | Adds the appProtocol field to the querier service. This allows querier to work with istio protocol selection. |
+| querier.appProtocol.grpc | string | `nil` | Set the optional grpc service protocol. Ex: "grpc", "http2" or "https" |
 | querier.config.frontend_worker.grpc_client_config | object | `{}` | grpc client configuration |
 | querier.extraArgs | list | `[]` | Additional CLI args for the querier |
 | querier.extraEnv | list | `[]` | Environment variables to add to the querier pods |
@@ -524,6 +532,8 @@ The memcached default args are removed and should be provided manually. The sett
 | querier.terminationGracePeriodSeconds | int | `30` | Grace period to allow the querier to shutdown before it is killed |
 | querier.tolerations | list | `[]` | Tolerations for querier pods |
 | queryFrontend.affinity | string | Hard node and soft zone anti-affinity | Affinity for query-frontend pods. Passed through `tpl` and, thus, to be configured as string |
+| queryFrontend.appProtocol | object | `{"grpc":null}` | Adds the appProtocol field to the queriyFrontend service. This allows queriyFrontend to work with istio protocol selection. |
+| queryFrontend.appProtocol.grpc | string | `nil` | Set the optional grpc service protocol. Ex: "grpc", "http2" or "https" |
 | queryFrontend.autoscaling.enabled | bool | `false` | Enable autoscaling for the query-frontend |
 | queryFrontend.autoscaling.maxReplicas | int | `3` | Maximum autoscaling replicas for the query-frontend |
 | queryFrontend.autoscaling.minReplicas | int | `1` | Minimum autoscaling replicas for the query-frontend |
@@ -578,6 +588,8 @@ The memcached default args are removed and should be provided manually. The sett
 | tempo.image.registry | string | `"docker.io"` | The Docker registry |
 | tempo.image.repository | string | `"grafana/tempo"` | Docker image repository |
 | tempo.image.tag | string | `nil` | Overrides the image tag whose default is the chart's appVersion |
+| tempo.memberlist | object | `{"appProtocol":null}` | Memberlist service configuration. |
+| tempo.memberlist.appProtocol | string | `nil` | Adds the appProtocol field to the memberlist service. This allows memberlist to work with istio protocol selection. Set the optional service protocol. Ex: "tcp", "http" or "https". |
 | tempo.podAnnotations | object | `{}` | Common annotations for all pods |
 | tempo.podLabels | object | `{}` | Global labels for all tempo pods |
 | tempo.podSecurityContext | object | `{"fsGroup":1000}` | podSecurityContext holds pod-level security attributes and common container settings |

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.27.3](https://img.shields.io/badge/Version-0.27.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.27.4](https://img.shields.io/badge/Version-0.27.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/distributor/service-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/service-distributor.yaml
@@ -19,6 +19,9 @@ spec:
       port: 9095
       protocol: TCP
       targetPort: 9095
+      {{- if .Values.distributor.appProtocol.grpc }}
+      appProtocol: {{ .Values.distributor.appProtocol.grpc }}
+      {{- end }}
     {{- if .Values.traces.jaeger.thriftCompact.enabled }}
     - name: distributor-jaeger-thrift-compact
       port: 6831
@@ -42,6 +45,9 @@ spec:
       port: 14250
       protocol: TCP
       targetPort: grpc-jaeger
+      {{- if .Values.distributor.appProtocol.grpc }}
+      appProtocol: {{ .Values.distributor.appProtocol.grpc }}
+      {{- end }}
     {{- end }}
     {{- if .Values.traces.zipkin.enabled }}
     - name: distributor-zipkin
@@ -60,10 +66,16 @@ spec:
       port: 4317
       protocol: TCP
       targetPort: grpc-otlp
+      {{- if .Values.distributor.appProtocol.grpc }}
+      appProtocol: {{ .Values.distributor.appProtocol.grpc }}
+      {{- end }}
     - name: distributor-otlp-legacy
       port: 55680
       protocol: TCP
       targetPort: grpc-otlp
+      {{- if .Values.distributor.appProtocol.grpc }}
+      appProtocol: {{ .Values.distributor.appProtocol.grpc }}
+      {{- end }}
     {{- end }}
     {{- if .Values.traces.opencensus.enabled }}
     - name: distributor-opencensus

--- a/charts/tempo-distributed/templates/gossip-ring/service-gossip-ring.yaml
+++ b/charts/tempo-distributed/templates/gossip-ring/service-gossip-ring.yaml
@@ -13,6 +13,9 @@ spec:
       port: 7946
       protocol: TCP
       targetPort: http-memberlist
+      {{- if .Values.tempo.memberlist.appProtocol }}
+      appProtocol: {{ .Values.tempo.memberlist.appProtocol }}
+      {{- end }}
   publishNotReadyAddresses: true
   selector:
     {{- include "tempo.gossipRingSelectorLabels" (dict "ctx" .) | nindent 4 }}

--- a/charts/tempo-distributed/templates/ingester/service-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/service-ingester.yaml
@@ -19,5 +19,8 @@ spec:
       port: 9095
       protocol: TCP
       targetPort: 9095
+      {{- if .Values.ingester.appProtocol.grpc }}
+      appProtocol: {{ .Values.ingester.appProtocol.grpc }}
+      {{- end }}
   selector:
     {{- include "tempo.selectorLabels" (dict "ctx" . "component" "ingester") | nindent 4 }}

--- a/charts/tempo-distributed/templates/metrics-generator/service-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/service-metrics-generator.yaml
@@ -19,6 +19,9 @@ spec:
       port: {{ .port }}
       protocol: TCP
       targetPort: {{ .port }}
+      {{- if and (hasPrefix .name "grpc") ($.Values.metricsGenerator.appProtocol.grpc) }}
+      appProtocol: {{ $.Values.metricsGenerator.appProtocol.grpc }}
+      {{- end }}
     {{- end }}
     {{- end }}
   selector:

--- a/charts/tempo-distributed/templates/querier/service-querier.yaml
+++ b/charts/tempo-distributed/templates/querier/service-querier.yaml
@@ -19,5 +19,8 @@ spec:
       port: 9095
       protocol: TCP
       targetPort: 9095
+      {{- if .Values.querier.appProtocol.grpc }}
+      appProtocol: {{ .Values.querier.appProtocol.grpc }}
+      {{- end }}
   selector:
     {{- include "tempo.selectorLabels" (dict "ctx" . "component" "querier" "memberlist" true) | nindent 4 }}

--- a/charts/tempo-distributed/templates/query-frontend/service-query-frontend-discovery.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/service-query-frontend-discovery.yaml
@@ -20,10 +20,16 @@ spec:
       port: 9095
       protocol: TCP
       targetPort: 9095
+      {{- if .Values.queryFrontend.appProtocol.grpc }}
+      appProtocol: {{ .Values.queryFrontend.appProtocol.grpc }}
+      {{- end }}
     - name: grpclb
       port: 9096
       protocol: TCP
       targetPort: grpc
+      {{- if .Values.queryFrontend.appProtocol.grpc }}
+      appProtocol: {{ .Values.queryFrontend.appProtocol.grpc }}
+      {{- end }}
     {{- if .Values.queryFrontend.query.enabled }}
     - name: tempo-query-jaeger-ui
       port: 16686

--- a/charts/tempo-distributed/templates/query-frontend/service-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/service-query-frontend.yaml
@@ -19,6 +19,9 @@ spec:
       port: 9095
       protocol: TCP
       targetPort: 9095
+      {{- if .Values.queryFrontend.appProtocol.grpc }}
+      appProtocol: {{ .Values.queryFrontend.appProtocol.grpc }}
+      {{- end }}
     {{- if .Values.queryFrontend.query.enabled }}
     - name: tempo-query-jaeger-ui
       port: 16686

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -64,6 +64,10 @@ tempo:
     fsGroup: 1000
   # -- Structured tempo configuration
   structuredConfig: {}
+  # -- Memberlist service configuration.
+  memberlist:
+    # -- Adds the appProtocol field to the memberlist service. This allows memberlist to work with istio protocol selection. Set the optional service protocol. Ex: "tcp", "http" or "https".
+    appProtocol: null
 
 serviceAccount:
   # -- Specifies whether a ServiceAccount should be created
@@ -180,6 +184,10 @@ ingester:
   service:
     # -- Annotations for ingester service
     annotations: {}
+  # -- Adds the appProtocol field to the ingester service. This allows ingester to work with istio protocol selection.
+  appProtocol:
+    # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
+    grpc: null
 
 # Configuration for the metrics-generator
 metricsGenerator:
@@ -285,6 +293,10 @@ metricsGenerator:
   service:
     # -- Annotations for Metrics Generator service
     annotations: {}
+  # -- Adds the appProtocol field to the metricsGenerator service. This allows metricsGenerator to work with istio protocol selection.
+  appProtocol:
+    # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
+    grpc: null
 
 # Configuration for the distributor
 distributor:
@@ -370,6 +382,10 @@ distributor:
     extend_writes: null
     # -- List of tags that will not be extracted from trace data for search lookups
     search_tags_deny_list: []
+  # -- Adds the appProtocol field to the distributor service. This allows distributor to work with istio protocol selection.
+  appProtocol:
+    # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
+    grpc: null
 
 compactor:
   # -- Number of replicas for the compactor
@@ -471,6 +487,10 @@ querier:
   service:
     # -- Annotations for querier service
     annotations: {}
+  # -- Adds the appProtocol field to the querier service. This allows querier to work with istio protocol selection.
+  appProtocol:
+    # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
+    grpc: null
 
 # Configuration for the query-frontend
 queryFrontend:
@@ -570,6 +590,10 @@ queryFrontend:
   extraVolumeMounts: []
   # -- Extra volumes for query-frontend deployment
   extraVolumes: []
+  # -- Adds the appProtocol field to the queriyFrontend service. This allows queriyFrontend to work with istio protocol selection.
+  appProtocol:
+    # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
+    grpc: null
 
 search:
   # -- Enable Tempo search


### PR DESCRIPTION
When Istio is configured with `PeerAuthentication`-[policy](https://istio.io/latest/docs/concepts/security/#authentication-policies) mode set to STRICT, mutual TLS is enforced by default. Istio is relying on [protocol selection](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/) to proxy traffic. This pull request will introduce an optional `appProtocol`- and `appProtocol.grpc`-option for the memberlist-, ingester-, distributor-, querier-, metrics-generator- and query-frontend-service.

Feedback on the field names, `tempo.memberlist.appProtocol`, `<service>.appProtocol.grpc`, and documentation are welcome.

Istio doesn't work well when the gossip-ring / memberlist is of type `http`, I have to use `tcp`. That is why the optional `tempo.memberlist.appProtocol`-option is also part of this pull request.

This pull request is similar to the [loki-distributed 1697 PR](https://github.com/grafana/helm-charts/pull/1697).