### PR TITLE
[grafana] bump default grafana image tag to 9.2.0

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.40.4
-appVersion: 9.1.7
+version: 6.40.5
+appVersion: 9.2.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net


### PR DESCRIPTION
Signed-off-by: Roman Verenich <roman.verenich@gmail.com>