### PR TITLE
[grafana] ability to set container security context for image-renderer

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.40.4
+version: 6.42.0
 appVersion: 9.1.7
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/image-renderer-deployment.yaml
+++ b/charts/grafana/templates/image-renderer-deployment.yaml
@@ -6,37 +6,36 @@ metadata:
   namespace: {{ template "grafana.namespace" . }}
   labels:
     {{- include "grafana.imageRenderer.labels" . | nindent 4 }}
-{{- if .Values.imageRenderer.labels }}
-{{ toYaml .Values.imageRenderer.labels | indent 4 }}
-{{- end }}
-{{- with .Values.imageRenderer.annotations }}
+    {{- if .Values.imageRenderer.labels }}
+    {{ toYaml .Values.imageRenderer.labels | indent 4 }}
+    {{- end }}
+  {{- with .Values.imageRenderer.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.imageRenderer.replicas }}
   revisionHistoryLimit: {{ .Values.imageRenderer.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "grafana.imageRenderer.selectorLabels" . | nindent 6 }}
-{{- with .Values.imageRenderer.deploymentStrategy }}
+  {{- with .Values.imageRenderer.deploymentStrategy }}
   strategy:
-{{ toYaml . | trim | indent 4 }}
-{{- end }}
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:
         {{- include "grafana.imageRenderer.selectorLabels" . | nindent 8 }}
-{{- with .Values.imageRenderer.podLabels }}
-{{ toYaml . | indent 8 }}
-{{- end }}
+        {{- with .Values.imageRenderer.podLabels }}
+        {{ toYaml . | indent 8 }}
+        {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-{{- with .Values.imageRenderer.podAnnotations }}
-{{ toYaml . | indent 8 }}
-{{- end }}
+        {{- with .Values.imageRenderer.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
-
       {{- if .Values.imageRenderer.schedulerName }}
       schedulerName: "{{ .Values.imageRenderer.schedulerName }}"
       {{- end }}
@@ -90,29 +89,29 @@ spec:
             - name: {{ $key | quote }}
               value: {{ $value | quote }}
           {{- end }}
-      {{- with .Values.imageRenderer.containerSecurityContext }}
+          {{- with .Values.imageRenderer.containerSecurityContext }}
           securityContext:
-{{ toYaml . | nindent 12 }}
-      {{- end }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /tmp
               name: image-renderer-tmpfs
-      {{- with .Values.imageRenderer.resources }}
+          {{- with .Values.imageRenderer.resources }}
           resources:
-{{ toYaml . | indent 12 }}
-      {{- end }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.imageRenderer.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- $root := . }}
       {{- with .Values.imageRenderer.affinity }}
       affinity:
-{{ tpl (toYaml .) $root | indent 8 }}
+        {{- tpl (toYaml .) $root | nindent 8 }}
       {{- end }}
       {{- with .Values.imageRenderer.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
         - name: image-renderer-tmpfs

--- a/charts/grafana/templates/image-renderer-deployment.yaml
+++ b/charts/grafana/templates/image-renderer-deployment.yaml
@@ -90,11 +90,9 @@ spec:
             - name: {{ $key | quote }}
               value: {{ $value | quote }}
           {{- end }}
+      {{- with .Values.imageRenderer.containerSecurityContext }}
           securityContext:
-            capabilities:
-              drop: ['all']
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+{{ toYaml . | nindent 12 }}
           volumeMounts:
             - mountPath: /tmp
               name: image-renderer-tmpfs

--- a/charts/grafana/templates/image-renderer-deployment.yaml
+++ b/charts/grafana/templates/image-renderer-deployment.yaml
@@ -29,7 +29,7 @@ spec:
       labels:
         {{- include "grafana.imageRenderer.selectorLabels" . | nindent 8 }}
         {{- with .Values.imageRenderer.podLabels }}
-        {{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}

--- a/charts/grafana/templates/image-renderer-deployment.yaml
+++ b/charts/grafana/templates/image-renderer-deployment.yaml
@@ -19,9 +19,10 @@ spec:
   selector:
     matchLabels:
       {{- include "grafana.imageRenderer.selectorLabels" . | nindent 6 }}
+
   {{- with .Values.imageRenderer.deploymentStrategy }}
   strategy:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml . | trim | nindent 4 }}
   {{- end }}
   template:
     metadata:

--- a/charts/grafana/templates/image-renderer-deployment.yaml
+++ b/charts/grafana/templates/image-renderer-deployment.yaml
@@ -93,6 +93,7 @@ spec:
       {{- with .Values.imageRenderer.containerSecurityContext }}
           securityContext:
 {{ toYaml . | nindent 12 }}
+      {{- end }}
           volumeMounts:
             - mountPath: /tmp
               name: image-renderer-tmpfs

--- a/charts/grafana/templates/image-renderer-deployment.yaml
+++ b/charts/grafana/templates/image-renderer-deployment.yaml
@@ -21,7 +21,7 @@ spec:
       {{- include "grafana.imageRenderer.selectorLabels" . | nindent 6 }}
   {{- with .Values.imageRenderer.deploymentStrategy }}
   strategy:
-    {{- toYaml . | trim | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   template:
     metadata:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1014,10 +1014,10 @@ imageRenderer:
   securityContext: {}
   # image-renderer deployment container securityContext
   containerSecurityContext:
-      capabilities:
-        drop: ['all']
-      allowPrivilegeEscalation: false
-      readOnlyRootFilesystem: true
+    capabilities:
+      drop: ['all']
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
   # image-renderer deployment Host Aliases
   hostAliases: []
   # image-renderer deployment priority class

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1015,7 +1015,7 @@ imageRenderer:
   # image-renderer deployment container securityContext
   containerSecurityContext:
       capabilities:
-        drop: [ 'all' ]
+        drop: ['all']
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true
   # image-renderer deployment Host Aliases

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -990,8 +990,7 @@ revisionHistoryLimit: 10
 
 ## Add a seperate remote image renderer deployment/service
 imageRenderer:
-  deploymentStrategy:
-    type: RollingUpdate
+  deploymentStrategy: {}
   # Enable the image-renderer deployment & service
   enabled: true
   replicas: 1

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -990,6 +990,7 @@ revisionHistoryLimit: 10
 
 ## Add a seperate remote image renderer deployment/service
 imageRenderer:
+  deploymentStrategy: {}
   # Enable the image-renderer deployment & service
   enabled: false
   replicas: 1

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1009,6 +1009,12 @@ imageRenderer:
   serviceAccountName: ""
   # image-renderer deployment securityContext
   securityContext: {}
+  # image-renderer deployment container securityContext
+  containerSecurityContext:
+      capabilities:
+        drop: [ 'all' ]
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
   # image-renderer deployment Host Aliases
   hostAliases: []
   # image-renderer deployment priority class

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -990,9 +990,10 @@ revisionHistoryLimit: 10
 
 ## Add a seperate remote image renderer deployment/service
 imageRenderer:
-  deploymentStrategy: {}
+  deploymentStrategy:
+    type: RollingUpdate
   # Enable the image-renderer deployment & service
-  enabled: false
+  enabled: true
   replicas: 1
   image:
     # image-renderer Image repository


### PR DESCRIPTION
Signed-off-by: ybelMekk <youssef.bel.mekki@nav.no>

Stumbled in to this then configuring kyverno and Pod security standard: [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/)

I found that i could not control the container security context in values.yaml

added this PR to add that.

Cheers.