### PR TITLE
[loki-distributed] Added support for IPv6 only clusters

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.8.2
-version: 0.69.16
+version: 0.69.17
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.69.16](https://img.shields.io/badge/Version-0.69.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
+![Version: 0.69.17](https://img.shields.io/badge/Version-0.69.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 
@@ -173,6 +173,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | gateway.nginxConfig.httpSnippet | string | `""` | Allows appending custom configuration to the http block |
 | gateway.nginxConfig.logFormat | string | See values.yaml | NGINX log format |
 | gateway.nginxConfig.resolver | string | `""` | Allows overriding the DNS resolver address nginx will use. |
+| gateway.nginxConfig.serverListens | string | `"listen             8080;"` | Configure the server listener(s), this needs to be customised for IPv6 only clusters |
 | gateway.nginxConfig.serverSnippet | string | `""` | Allows appending custom configuration to the server block |
 | gateway.nodeSelector | object | `{}` | Node selector for gateway pods |
 | gateway.podAnnotations | object | `{}` | Annotations for gateway pods |

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -1030,6 +1030,9 @@ gateway:
       main '$remote_addr - $remote_user [$time_local]  $status '
               '"$request" $body_bytes_sent "$http_referer" '
               '"$http_user_agent" "$http_x_forwarded_for"';
+    # -- Configure the server listener(s), this needs to be customised for IPv6 only clusters
+    serverListens: |-
+      listen             8080;
     # -- Allows appending custom configuration to the server block
     serverSnippet: ""
     # -- Allows appending custom configuration to the http block
@@ -1084,7 +1087,7 @@ gateway:
         {{- end }}
 
         server {
-          listen             8080;
+          {{- .Values.gateway.nginxConfig.serverListens | nindent 4 }}
 
           {{- if .Values.gateway.basicAuth.enabled }}
           auth_basic           "Loki";


### PR DESCRIPTION
This PR enables the modification of the Loki Gateway Nginx listener without needing to duplicate and maintain the whole `gateway.nginxConfig.file` value; this functionality is required to use Loki in an EKS IPv6 cluster. Unless you change `gateway.nginxConfig.serverListens` this change should be a no-op.