### PR TITLE
[loki-distributed] statefulset-ingester - do not set replicas if autoscaling is enabled

### DIFF
--- a/charts/loki-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/statefulset-ingester.yaml
@@ -11,7 +11,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- if not .Values.ingester.autoscaling.enabled }}
   replicas: {{ .Values.ingester.replicas }}
+{{- end }}
   podManagementPolicy: Parallel
   updateStrategy:
     rollingUpdate:


### PR DESCRIPTION
We should not set the number of replicas for Ingester StatefulSet if the autoscaling is not enabled.