### PR TITLE
[promtail] Update ServiceMonitor template and introduce config as ConfigMap option

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.6.1
-version: 6.5.1
+version: 6.6.0
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -35,7 +35,7 @@ A major chart version change indicates that there is an incompatible breaking ch
 * The default scrape configs have been updated to take new and old labels into consideration
 * The config file must be specified as string which can be templated.
   See below for details
-* The config file is now stored in a Secret and no longer in a ConfigMap because it may contain sensitive data, such as basic auth credentials
+* The config file is now stored in a Secret and no longer in a ConfigMap because it may contain sensitive data, such as basic auth credentials. You can still choose to generate config as a ConfigMap by setting `configmap.enabled` to `true`. If you need secrets in your config, consider injecting them through environment variables using `extraEnvFrom` and setting `extraArgs: ["-config.expand-env=true"]`.
 
 Due to the label changes, an existing installation cannot be upgraded without manual interaction.
 There are basically two options:

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -35,7 +35,7 @@ A major chart version change indicates that there is an incompatible breaking ch
 * The default scrape configs have been updated to take new and old labels into consideration
 * The config file must be specified as string which can be templated.
   See below for details
-* The config file is now stored in a Secret and no longer in a ConfigMap because it may contain sensitive data, such as basic auth credentials. You can still choose to generate config as a ConfigMap by setting `configmap.enabled` to `true`. If you need secrets in your config, consider injecting them through environment variables using `extraEnvFrom` and setting `extraArgs: ["-config.expand-env=true"]`.
+* The config file is now stored in a Secret and no longer in a ConfigMap because it may contain sensitive data, such as basic auth credentials
 
 Due to the label changes, an existing installation cannot be upgraded without manual interaction.
 There are basically two options:

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 6.5.1](https://img.shields.io/badge/Version-6.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 6.6.0](https://img.shields.io/badge/Version-6.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 
@@ -80,6 +80,7 @@ The new release which will pick up again from the existing `positions.yaml`.
 | config.snippets.extraRelabelConfigs | list | `[]` | You can put here any additional relabel_configs to "kubernetes-pods" job |
 | config.snippets.extraScrapeConfigs | string | empty | You can put here any additional scrape configs you want to add to the config file. |
 | config.snippets.extraServerConfigs | string | empty | You can put here any keys that will be directly added to the config file's 'server' block. |
+| configmap.enabled | bool | `true` | If enabled, promtail config will be created as a ConfigMap instead of a secret |
 | containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The security context for containers |
 | daemonset.enabled | bool | `true` | Deploys Promtail as a DaemonSet |
 | defaultVolumeMounts | list | See `values.yaml` | Default volume mounts. Corresponds to `volumes`. |
@@ -136,7 +137,10 @@ The new release which will pick up again from the existing `positions.yaml`.
 | serviceMonitor.namespace | string | `nil` | Alternative namespace for ServiceMonitor resources |
 | serviceMonitor.namespaceSelector | object | `{}` | Namespace selector for ServiceMonitor resources |
 | serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig (defines `relabel_configs`) |
+| serviceMonitor.scheme | string | `"http"` | ServiceMonitor will use http by default, but you can pick https as well |
 | serviceMonitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
+| serviceMonitor.targetLabels | list | `[]` | ServiceMonitor will add labels from the service to the Prometheus metric https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitorspec |
+| serviceMonitor.tlsConfig | string | `nil` | ServiceMonitor will use these tlsConfig settings to make the health check requests |
 | tolerations | list | `[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane","operator":"Exists"}]` | Tolerations for pods. By default, pods will be scheduled on master/control-plane nodes. |
 | updateStrategy | object | `{}` | The update strategy for the DaemonSet |
 

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -35,7 +35,7 @@ A major chart version change indicates that there is an incompatible breaking ch
 * The default scrape configs have been updated to take new and old labels into consideration
 * The config file must be specified as string which can be templated.
   See below for details
-* The config file is now stored in a Secret and no longer in a ConfigMap because it may contain sensitive data, such as basic auth credentials. You can still choose to generate config as a ConfigMap by setting `configmap.enabled` to `true`. If you need secrets in your config, consider injecting them through environment variables using `extraEnvFrom` and setting `extraArgs: ["-config.expand-env=true"]`.
+* The config file is now stored in a Secret and no longer in a ConfigMap because it may contain sensitive data, such as basic auth credentials
 
 Due to the label changes, an existing installation cannot be upgraded without manual interaction.
 There are basically two options:
@@ -80,7 +80,7 @@ The new release which will pick up again from the existing `positions.yaml`.
 | config.snippets.extraRelabelConfigs | list | `[]` | You can put here any additional relabel_configs to "kubernetes-pods" job |
 | config.snippets.extraScrapeConfigs | string | empty | You can put here any additional scrape configs you want to add to the config file. |
 | config.snippets.extraServerConfigs | string | empty | You can put here any keys that will be directly added to the config file's 'server' block. |
-| configmap.enabled | bool | `true` | If enabled, promtail config will be created as a ConfigMap instead of a secret |
+| configmap.enabled | bool | `false` | If enabled, promtail config will be created as a ConfigMap instead of a secret |
 | containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The security context for containers |
 | daemonset.enabled | bool | `true` | Deploys Promtail as a DaemonSet |
 | defaultVolumeMounts | list | See `values.yaml` | Default volume mounts. Corresponds to `volumes`. |

--- a/charts/promtail/templates/_pod.tpl
+++ b/charts/promtail/templates/_pod.tpl
@@ -101,8 +101,13 @@ Pod template used in Daemonset and Deployment
       {{- end }}
       volumes:
         - name: config
+          {{- if .Values.configmap.enabled }}
+          configMap:
+            name: {{ include "promtail.fullname" . }}
+          {{- else }}
           secret:
             secretName: {{ include "promtail.fullname" . }}
+          {{- end }}
         {{- with .Values.defaultVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/promtail/templates/configmap.yaml
+++ b/charts/promtail/templates/configmap.yaml
@@ -1,12 +1,12 @@
-{{- if not .Values.configmap.enabled }}
+{{- if .Values.configmap.enabled }}
 apiVersion: v1
-kind: Secret
+kind: ConfigMap
 metadata:
   name: {{ include "promtail.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
-stringData:
+data:
   promtail.yaml: |
     {{- tpl .Values.config.file . | nindent 4 }}
 {{- end }}

--- a/charts/promtail/templates/servicemonitor.yaml
+++ b/charts/promtail/templates/servicemonitor.yaml
@@ -1,44 +1,55 @@
-{{- if .Values.serviceMonitor.enabled }}
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "promtail.fullname" $ }}
-  {{- if .Values.serviceMonitor.namespace }}
-  namespace: {{ .Values.serviceMonitor.namespace }}
-  {{- else }}
-  namespace: {{ .Release.Namespace }}
+  {{- with .namespace }}
+  namespace: {{ . }}
   {{- end }}
-  {{- with .Values.serviceMonitor.annotations }}
+  {{- with .annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
     {{- include "promtail.labels" $ | nindent 4 }}
-    {{- with .Values.serviceMonitor.labels }}
+    {{- with .labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- with .Values.serviceMonitor.namespaceSelector }}
+  {{- with .namespaceSelector }}
   namespaceSelector:
   {{- toYaml . | nindent 4 }}
   {{- end }}
   selector:
     matchLabels:
-      {{- include "promtail.selectorLabels" . | nindent 6 }}
+      {{- include "promtail.selectorLabels" $ | nindent 6 }}
   endpoints:
     - port: http-metrics
-      {{- with .Values.serviceMonitor.interval }}
+      {{- with .interval }}
       interval: {{ . }}
       {{- end }}
-      {{- with .Values.serviceMonitor.scrapeTimeout }}
+      {{- with .scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
-      {{- with .Values.serviceMonitor.relabelings }}
+      {{- with .relabelings }}
       relabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.serviceMonitor.metricRelabelings }}
+      {{- with .metricRelabelings }}
       metricRelabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- with .targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -22,7 +22,7 @@ deployment:
 
 configmap:
   # -- If enabled, promtail config will be created as a ConfigMap instead of a secret
-  enabled: true
+  enabled: false
 
 initContainer: []
   # # -- Specifies whether the init container for setting inotify max user instances is to be enabled

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -20,6 +20,10 @@ deployment:
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage:
 
+configmap:
+  # -- If enabled, promtail config will be created as a ConfigMap instead of a secret
+  enabled: true
+
 initContainer: []
   # # -- Specifies whether the init container for setting inotify max user instances is to be enabled
   # - name: init
@@ -203,6 +207,13 @@ serviceMonitor:
   # https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
   # (defines `metric_relabel_configs`)
   metricRelabelings: []
+  # --ServiceMonitor will add labels from the service to the Prometheus metric
+  # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitorspec
+  targetLabels: []
+  # -- ServiceMonitor will use http by default, but you can pick https as well
+  scheme: http
+  # -- ServiceMonitor will use these tlsConfig settings to make the health check requests
+  tlsConfig: null
 
 # Extra containers created as part of a Promtail Deployment resource
 # - spec for Container:


### PR DESCRIPTION
This pull request solves issues #1915 and #1916.

 - The Promtail config can now optionally be generated as a ConfigMap instead of a secret. This makes hacking with `kubectl` much less of a chore. If you still need secrets in your config, consider injecting them through environment variables using `extraEnvFrom` chart value and setting `extraArgs: ["-config.expand-env=true"]`.
 - ServiceMonitor was missing some crucial settings, in particular `tlsConfig`. The ServiceMonitor template has now been updated to match that used for the `loki-distributed` chart.