### PR TITLE
[grafana] Added support for ServiceAccount labels

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.42.4
-appVersion: 9.2.2
+version: 6.42.5
+appVersion: 9.2.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.42.3
+version: 6.42.4
 appVersion: 9.2.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -206,6 +206,7 @@ This version requires Helm >= 3.1.0.
 | `serviceAccount.autoMount`                | Automount the service account token in the pod| `true`                                                  |
 | `serviceAccount.annotations`              | ServiceAccount annotations                    |                                                         |
 | `serviceAccount.create`                   | Create service account                        | `true`                                                  |
+| `serviceAccount.labels`                   | ServiceAccount labels                         | `{}`                                                    |
 | `serviceAccount.name`                     | Service account name to use, when empty will be set to created account if `serviceAccount.create` is set else to `default` | `` |
 | `serviceAccount.nameTest`                 | Service account name to use for test, when empty will be set to created account if `serviceAccount.create` is set else to `default` | `nil` |
 | `rbac.create`                             | Create and use RBAC resources                 | `true`                                                  |

--- a/charts/grafana/templates/serviceaccount.yaml
+++ b/charts/grafana/templates/serviceaccount.yaml
@@ -4,6 +4,9 @@ kind: ServiceAccount
 metadata:
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- $root := . }}
 {{- with .Values.serviceAccount.annotations }}
   annotations:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -17,6 +17,8 @@ serviceAccount:
   create: true
   name:
   nameTest:
+  ## ServiceAccount labels.
+  labels: {}
 ## Service account annotations. Can be templated.
 #  annotations:
 #    eks.amazonaws.com/role-arn: arn:aws:iam::123456789000:role/iam-role-name-here


### PR DESCRIPTION
This PR adds support for adding labels to the Grafana Service Account which is required for the new [Azure Workload Identity](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview) functionality.