### PR TITLE
[loki-stack] Bumb Grafana to 9.2

### DIFF
--- a/charts/loki-stack/Chart.yaml
+++ b/charts/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 2.8.3
+version: 2.8.4
 appVersion: v2.6.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki-stack/requirements.yaml
+++ b/charts/loki-stack/requirements.yaml
@@ -13,7 +13,7 @@ dependencies:
   version: "^2.3.0"
 - name: "grafana"
   condition: grafana.enabled
-  version: "~6.24.1"
+  version: "~6.43.0"
   repository:  "https://grafana.github.io/helm-charts"
 - name: "prometheus"
   condition: prometheus.enabled


### PR DESCRIPTION
To address 2 points:
a) Grafana has UI issues with latest Chrome like https://github.com/grafana/grafana/issues/54722
b) Need to specify appProtocol for loki-grafna service and this is available in Grafana helm chart since https://github.com/grafana/helm-charts/commit/ce087048ecc833876c63826b9ec2157083ce55be