### PR TITLE
[grafana] bump default grafana image tag to 9.2.2

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.43.0
-appVersion: 9.2.1
+version: 6.43.1
+appVersion: 9.2.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net


### PR DESCRIPTION
See: https://github.com/grafana/grafana/releases/tag/v9.2.2