### PR TITLE
[tempo-distributed] Fix issue when render chart templates

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
-version: 0.27.1
+version: 0.27.2
 appVersion: 1.5.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
-version: 0.27.0
+version: 0.27.1
 appVersion: 1.5.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.27.1](https://img.shields.io/badge/Version-0.27.1-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.27.2](https://img.shields.io/badge/Version-0.27.2-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.27.0](https://img.shields.io/badge/Version-0.27.0-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.27.1](https://img.shields.io/badge/Version-0.27.1-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/gateway/ingress-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/ingress-gateway.yaml
@@ -42,7 +42,7 @@ spec:
             backend:
               {{- if $ingressApiIsStable }}
               service:
-                name: {{ include "tempo.resourceName" (dict "ctx" . "component" "gateway") }}
+                name: {{ include "tempo.resourceName" (dict "ctx" $ "component" "gateway") }}
                 port:
                   number: {{ $.Values.gateway.service.port }}
               {{- else }}

--- a/charts/tempo-distributed/templates/memcached/statefulset-memcached.yaml
+++ b/charts/tempo-distributed/templates/memcached/statefulset-memcached.yaml
@@ -75,7 +75,7 @@ spec:
         - args:
             - --memcached.address=localhost:11211
             - --web.listen-address=0.0.0.0:9150
-          image: {{ include "tempo.memcachedExporterImage" (dict "ctx" . "component" "memcached-exporter") }}
+          image: {{ include "tempo.imageReference" (dict "ctx" . "component" "memcached-exporter") }}
           imagePullPolicy: {{ .Values.memcachedExporter.image.pullPolicy }}
           name: exporter
           ports:

--- a/charts/tempo-distributed/templates/prometheusrule.yaml
+++ b/charts/tempo-distributed/templates/prometheusrule.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "tempo.labels" $ | nindent 4 }}
+    {{- include "tempo.labels" (dict "ctx" $) | nindent 4 }}
   {{- with .labels }}
   {{- toYaml . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
Re-procedure the issues:
```
$ helm pull grafana/tempo-distributed --untar --version 0.27.0
```
```
$ helm template --set memcachedExporter.enabled=true tempo-distributed
Error: template: tempo-distributed/templates/memcached/statefulset-memcached.yaml:78:20: executing "tempo-distributed/templates/memcached/statefulset-memcached.yaml" at <include "tempo.memcachedExporterImage" (dict "ctx" . "component" "memcached-exporter")>: error calling include: template: no template "tempo.memcachedExporterImage" associated with template "gotpl"
```
```
$ helm template --set gateway.enabled=true --set gateway.ingress.enabled=true tempo-distributed
Error: template: tempo-distributed/templates/gateway/ingress-gateway.yaml:45:25: executing "tempo-distributed/templates/gateway/ingress-gateway.yaml" at <include "tempo.resourceName" (dict "ctx" . "component" "gateway")>: error calling include: template: tempo-distributed/templates/_helpers.tpl:153:3: executing "tempo.resourceName" at <include "tempo.fullname" .ctx>: error calling include: template: tempo-distributed/templates/_helpers.tpl:15:14: executing "tempo.fullname" at <.Values.fullnameOverride>: nil pointer evaluating interface {}.fullnameOverride
```
```
$ helm template --set prometheusRule.enabled=true tempo-distributed
Error: template: tempo-distributed/templates/prometheusrule.yaml:15:8: executing "tempo-distributed/templates/prometheusrule.yaml" at <include "tempo.labels" $>: error calling include: template: tempo-distributed/templates/_helpers.tpl:69:35: executing "tempo.labels" at <.ctx.Release.Name>: nil pointer evaluating interface {}.Release
```
