### PR TITLE
[grafana] Fix drop ALL capitalization

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.43.1
+version: 6.43.2
 appVersion: 9.2.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1020,7 +1020,7 @@ imageRenderer:
   # image-renderer deployment container securityContext
   containerSecurityContext:
     capabilities:
-      drop: ['all']
+      drop: ['ALL']
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
   # image-renderer deployment Host Aliases


### PR DESCRIPTION
Changes:
* drop `ALL` (caps) instead of `all` to match spec, k8s implementation, and kyverno policy implementation.
* bump chart patch version

Fixes #1938 