### PR TITLE
[loki-distributed] wire-in memcached automatically when enabled, introduce memcached persistence

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.6.1
-version: 0.63.2
+version: 0.64.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.63.2](https://img.shields.io/badge/Version-0.63.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 0.64.0](https://img.shields.io/badge/Version-0.64.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 
@@ -305,6 +305,9 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | memcachedChunks.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to memcached-chunks pods |
 | memcachedChunks.maxUnavailable | string | `nil` | Pod Disruption Budget maxUnavailable |
 | memcachedChunks.nodeSelector | object | `{}` | Node selector for memcached-chunks pods |
+| memcachedChunks.persistence.enabled | bool | `false` | Enable creating PVCs which will persist cached data through restarts |
+| memcachedChunks.persistence.size | string | `"10Gi"` | Size of persistent or memory disk |
+| memcachedChunks.persistence.storageClass | string | `nil` | Storage class to be used. If defined, storageClassName: <storageClass>. If set to "-", storageClassName: "", which disables dynamic provisioning. If empty or set to null, no storageClassName spec is set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack). |
 | memcachedChunks.podAnnotations | object | `{}` | Annotations for memcached-chunks pods |
 | memcachedChunks.podLabels | object | `{}` | Labels for memcached-chunks pods |
 | memcachedChunks.priorityClassName | string | `nil` | The name of the PriorityClass for memcached-chunks pods |
@@ -329,6 +332,9 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | memcachedFrontend.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to memcached-frontend pods |
 | memcachedFrontend.maxUnavailable | int | `1` | Pod Disruption Budget maxUnavailable |
 | memcachedFrontend.nodeSelector | object | `{}` | Node selector for memcached-frontend pods |
+| memcachedFrontend.persistence.enabled | bool | `false` | Enable creating PVCs which will persist cached data through restarts |
+| memcachedFrontend.persistence.size | string | `"10Gi"` | Size of persistent or memory disk |
+| memcachedFrontend.persistence.storageClass | string | `nil` | Storage class to be used. If defined, storageClassName: <storageClass>. If set to "-", storageClassName: "", which disables dynamic provisioning. If empty or set to null, no storageClassName spec is set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack). |
 | memcachedFrontend.podAnnotations | object | `{}` | Annotations for memcached-frontend pods |
 | memcachedFrontend.podLabels | object | `{}` | Labels for memcached-frontend pods |
 | memcachedFrontend.priorityClassName | string | `nil` | The name of the PriorityClass for memcached-frontend pods |
@@ -345,6 +351,9 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | memcachedIndexQueries.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to memcached-index-queries pods |
 | memcachedIndexQueries.maxUnavailable | string | `nil` | Pod Disruption Budget maxUnavailable |
 | memcachedIndexQueries.nodeSelector | object | `{}` | Node selector for memcached-index-queries pods |
+| memcachedIndexQueries.persistence.enabled | bool | `false` | Enable creating PVCs which will persist cached data through restarts |
+| memcachedIndexQueries.persistence.size | string | `"10Gi"` | Size of persistent or memory disk |
+| memcachedIndexQueries.persistence.storageClass | string | `nil` | Storage class to be used. If defined, storageClassName: <storageClass>. If set to "-", storageClassName: "", which disables dynamic provisioning. If empty or set to null, no storageClassName spec is set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack). |
 | memcachedIndexQueries.podAnnotations | object | `{}` | Annotations for memcached-index-queries pods |
 | memcachedIndexQueries.podLabels | object | `{}` | Labels for memcached-index-queries pods |
 | memcachedIndexQueries.priorityClassName | string | `nil` | The name of the PriorityClass for memcached-index-queries pods |
@@ -361,6 +370,9 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | memcachedIndexWrites.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to memcached-index-writes pods |
 | memcachedIndexWrites.maxUnavailable | string | `nil` | Pod Disruption Budget maxUnavailable |
 | memcachedIndexWrites.nodeSelector | object | `{}` | Node selector for memcached-index-writes pods |
+| memcachedIndexWrites.persistence.enabled | bool | `false` | Enable creating PVCs which will persist cached data through restarts |
+| memcachedIndexWrites.persistence.size | string | `"10Gi"` | Size of persistent or memory disk |
+| memcachedIndexWrites.persistence.storageClass | string | `nil` | Storage class to be used. If defined, storageClassName: <storageClass>. If set to "-", storageClassName: "", which disables dynamic provisioning. If empty or set to null, no storageClassName spec is set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack). |
 | memcachedIndexWrites.podAnnotations | object | `{}` | Annotations for memcached-index-writes pods |
 | memcachedIndexWrites.podLabels | object | `{}` | Labels for memcached-index-writes pods |
 | memcachedIndexWrites.priorityClassName | string | `nil` | The name of the PriorityClass for memcached-index-writes pods |

--- a/charts/loki-distributed/templates/memcached-chunks/statefulset-memcached-chunks.yaml
+++ b/charts/loki-distributed/templates/memcached-chunks/statefulset-memcached-chunks.yaml
@@ -50,6 +50,17 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.memcachedChunks.terminationGracePeriodSeconds }}
       containers:
         - name: memcached
+          {{- if .Values.memcachedChunks.persistence.enabled }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - -ec
+                - |
+                  /usr/bin/pkill -10 memcached
+                  sleep 60s
+          {{- end }}
           image: {{ include "loki.memcachedImage" . }}
           imagePullPolicy: {{ .Values.memcached.image.pullPolicy }}
           {{- if or .Values.memcachedChunks.extraArgs .Values.memcachedChunks.persistence.enabled }}

--- a/charts/loki-distributed/templates/memcached-chunks/statefulset-memcached-chunks.yaml
+++ b/charts/loki-distributed/templates/memcached-chunks/statefulset-memcached-chunks.yaml
@@ -52,9 +52,14 @@ spec:
         - name: memcached
           image: {{ include "loki.memcachedImage" . }}
           imagePullPolicy: {{ .Values.memcached.image.pullPolicy }}
-          {{- with .Values.memcachedChunks.extraArgs }}
+          {{- if or .Values.memcachedChunks.extraArgs .Values.memcachedChunks.persistence.enabled }}
           args:
+          {{- if .Values.memcachedChunks.persistence.enabled }}
+            - --memory-file=/cache-state/memory_file
+          {{- end }}
+          {{- with .Values.memcachedChunks.extraArgs }}
             {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- end }}
           ports:
             - name: http
@@ -74,6 +79,11 @@ spec:
             {{- toYaml .Values.memcached.readinessProbe | nindent 12 }}
           livenessProbe:
             {{- toYaml .Values.memcached.livenessProbe | nindent 12 }}
+          {{- if .Values.memcachedChunks.persistence.enabled }}
+          volumeMounts:
+            - name: data
+              mountPath: /cache-state
+          {{- end }}
           resources:
             {{- toYaml .Values.memcachedChunks.resources | nindent 12 }}
         {{- if .Values.memcachedExporter.enabled }}
@@ -107,4 +117,18 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  {{- if .Values.memcachedChunks.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- with .Values.memcachedChunks.persistence.storageClass }}
+        storageClassName: {{ if (eq "-" .) }}""{{ else }}{{ . }}{{ end }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.memcachedChunks.persistence.size | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/memcached-frontend/statefulset-memcached-frontend.yaml
+++ b/charts/loki-distributed/templates/memcached-frontend/statefulset-memcached-frontend.yaml
@@ -52,9 +52,14 @@ spec:
         - name: memcached
           image: {{ include "loki.memcachedImage" . }}
           imagePullPolicy: {{ .Values.memcached.image.pullPolicy }}
-          {{- with .Values.memcachedFrontend.extraArgs }}
+          {{- if or .Values.memcachedFrontend.extraArgs .Values.memcachedFrontend.persistence.enabled }}
           args:
+          {{- if .Values.memcachedFrontend.persistence.enabled }}
+            - --memory-file=/cache-state/memory_file
+          {{- end }}
+          {{- with .Values.memcachedFrontend.extraArgs }}
             {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- end }}
           ports:
             - name: http
@@ -74,6 +79,11 @@ spec:
             {{- toYaml .Values.memcached.readinessProbe | nindent 12 }}
           livenessProbe:
             {{- toYaml .Values.memcached.livenessProbe | nindent 12 }}
+          {{- if .Values.memcachedFrontend.persistence.enabled }}
+          volumeMounts:
+            - name: data
+              mountPath: /cache-state
+          {{- end }}
           resources:
             {{- toYaml .Values.memcachedFrontend.resources | nindent 12 }}
         {{- if .Values.memcachedExporter.enabled }}
@@ -107,4 +117,18 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  {{- if .Values.memcachedFrontend.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- with .Values.memcachedFrontend.persistence.storageClass }}
+        storageClassName: {{ if (eq "-" .) }}""{{ else }}{{ . }}{{ end }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.memcachedFrontend.persistence.size | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/memcached-frontend/statefulset-memcached-frontend.yaml
+++ b/charts/loki-distributed/templates/memcached-frontend/statefulset-memcached-frontend.yaml
@@ -50,6 +50,17 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.memcachedFrontend.terminationGracePeriodSeconds }}
       containers:
         - name: memcached
+          {{- if .Values.memcachedFrontend.persistence.enabled }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - -ec
+                - |
+                  /usr/bin/pkill -10 memcached
+                  sleep 60s
+          {{- end }}
           image: {{ include "loki.memcachedImage" . }}
           imagePullPolicy: {{ .Values.memcached.image.pullPolicy }}
           {{- if or .Values.memcachedFrontend.extraArgs .Values.memcachedFrontend.persistence.enabled }}

--- a/charts/loki-distributed/templates/memcached-index-queries/statefulset-memcached-index-queries.yaml
+++ b/charts/loki-distributed/templates/memcached-index-queries/statefulset-memcached-index-queries.yaml
@@ -50,6 +50,17 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.memcachedIndexQueries.terminationGracePeriodSeconds }}
       containers:
         - name: memcached
+          {{- if .Values.memcachedIndexQueries.persistence.enabled }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - -ec
+                - |
+                  /usr/bin/pkill -10 memcached
+                  sleep 60s
+          {{- end }}
           image: {{ include "loki.memcachedImage" . }}
           imagePullPolicy: {{ .Values.memcached.image.pullPolicy }}
           {{- if or .Values.memcachedIndexQueries.extraArgs .Values.memcachedIndexQueries.persistence.enabled }}

--- a/charts/loki-distributed/templates/memcached-index-queries/statefulset-memcached-index-queries.yaml
+++ b/charts/loki-distributed/templates/memcached-index-queries/statefulset-memcached-index-queries.yaml
@@ -52,9 +52,14 @@ spec:
         - name: memcached
           image: {{ include "loki.memcachedImage" . }}
           imagePullPolicy: {{ .Values.memcached.image.pullPolicy }}
-          {{- with .Values.memcachedIndexQueries.extraArgs }}
+          {{- if or .Values.memcachedIndexQueries.extraArgs .Values.memcachedIndexQueries.persistence.enabled }}
           args:
+          {{- if .Values.memcachedIndexQueries.persistence.enabled }}
+            - --memory-file=/cache-state/memory_file
+          {{- end }}
+          {{- with .Values.memcachedIndexQueries.extraArgs }}
             {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- end }}
           ports:
             - name: http
@@ -74,6 +79,11 @@ spec:
             {{- toYaml .Values.memcached.readinessProbe | nindent 12 }}
           livenessProbe:
             {{- toYaml .Values.memcached.livenessProbe | nindent 12 }}
+          {{- if .Values.memcachedIndexQueries.persistence.enabled }}
+          volumeMounts:
+            - name: data
+              mountPath: /cache-state
+          {{- end }}
           resources:
             {{- toYaml .Values.memcachedIndexQueries.resources | nindent 12 }}
         {{- if .Values.memcachedExporter.enabled }}
@@ -107,4 +117,18 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  {{- if .Values.memcachedIndexQueries.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- with .Values.memcachedIndexQueries.persistence.storageClass }}
+        storageClassName: {{ if (eq "-" .) }}""{{ else }}{{ . }}{{ end }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.memcachedIndexQueries.persistence.size | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/memcached-index-writes/statefulset-memcached-index-writes.yaml
+++ b/charts/loki-distributed/templates/memcached-index-writes/statefulset-memcached-index-writes.yaml
@@ -50,6 +50,17 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.memcachedIndexWrites.terminationGracePeriodSeconds }}
       containers:
         - name: memcached
+          {{- if .Values.memcachedIndexWrites.persistence.enabled }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - -ec
+                - |
+                  /usr/bin/pkill -10 memcached
+                  sleep 60s
+          {{- end }}
           image: {{ include "loki.memcachedImage" . }}
           imagePullPolicy: {{ .Values.memcached.image.pullPolicy }}
           {{- if or .Values.memcachedIndexWrites.extraArgs .Values.memcachedIndexWrites.persistence.enabled }}

--- a/charts/loki-distributed/templates/memcached-index-writes/statefulset-memcached-index-writes.yaml
+++ b/charts/loki-distributed/templates/memcached-index-writes/statefulset-memcached-index-writes.yaml
@@ -52,9 +52,14 @@ spec:
         - name: memcached
           image: {{ include "loki.memcachedImage" . }}
           imagePullPolicy: {{ .Values.memcached.image.pullPolicy }}
-          {{- with .Values.memcachedIndexWrites.extraArgs }}
+          {{- if or .Values.memcachedIndexWrites.extraArgs .Values.memcachedIndexWrites.persistence.enabled }}
           args:
+          {{- if .Values.memcachedIndexWrites.persistence.enabled }}
+            - --memory-file=/cache-state/memory_file
+          {{- end }}
+          {{- with .Values.memcachedIndexWrites.extraArgs }}
             {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- end }}
           ports:
             - name: http
@@ -74,6 +79,11 @@ spec:
             {{- toYaml .Values.memcached.readinessProbe | nindent 12 }}
           livenessProbe:
             {{- toYaml .Values.memcached.livenessProbe | nindent 12 }}
+          {{- if .Values.memcachedIndexWrites.persistence.enabled }}
+          volumeMounts:
+            - name: data
+              mountPath: /cache-state
+          {{- end }}
           resources:
             {{- toYaml .Values.memcachedIndexWrites.resources | nindent 12 }}
         {{- if .Values.memcachedExporter.enabled }}
@@ -107,4 +117,18 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  {{- if .Values.memcachedIndexWrites.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- with .Values.memcachedIndexWrites.persistence.storageClass }}
+        storageClassName: {{ if (eq "-" .) }}""{{ else }}{{ . }}{{ end }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.memcachedIndexWrites.persistence.size | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -123,6 +123,12 @@ loki:
     {{- $_ := set .Values.loki.storageConfig.boltdb_shipper "index_gateway_client" $indexGatewayClient }}
     {{- end}}
     {{- toYaml .Values.loki.storageConfig | nindent 2}}
+    {{- if .Values.memcachedIndexQueries.enabled }}
+      index_queries_cache_config:
+        memcached_client:
+          addresses: dnssrv+_memcached-client._tcp.{{ include "loki.memcachedIndexQueriesFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+          consistent_hash: true
+    {{- end}}
     {{- end}}
 
     runtime_config:
@@ -130,6 +136,19 @@ loki:
 
     chunk_store_config:
       max_look_back_period: 0s
+      {{- if .Values.memcachedChunks.enabled }}
+      chunk_cache_config:
+        enable_fifocache: false
+        memcached_client:
+          consistent_hash: true
+          addresses: dnssrv+_memcached-client._tcp.{{ include "loki.memcachedChunksFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+      {{- end }}
+      {{- if .Values.memcachedIndexWrites.enabled }}
+      write_dedupe_cache_config:
+        memcached_client:
+          consistent_hash: true
+          addresses: dnssrv+_memcached-client._tcp.{{ include "loki.memcachedIndexWritesFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+      {{- end }}
 
     table_manager:
       retention_deletes_enabled: false
@@ -141,10 +160,16 @@ loki:
       cache_results: true
       results_cache:
         cache:
+          {{- if .Values.memcachedFrontend.enabled }}
+          memcached_client:
+            addresses: dnssrv+_memcached-client._tcp.{{ include "loki.memcachedFrontendFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+            consistent_hash: true
+          {{- else }}
           enable_fifocache: true
           fifocache:
             max_size_items: 1024
             ttl: 24h
+          {{- end }}
 
     frontend_worker:
       {{- if .Values.queryScheduler.enabled }}
@@ -1469,6 +1494,17 @@ memcachedChunks:
   nodeSelector: {}
   # -- Tolerations for memcached-chunks pods
   tolerations: []
+  persistence:
+    # -- Enable creating PVCs which will persist cached data through restarts
+    enabled: false
+    # -- Size of persistent or memory disk
+    size: 10Gi
+    # -- Storage class to be used.
+    # If defined, storageClassName: <storageClass>.
+    # If set to "-", storageClassName: "", which disables dynamic provisioning.
+    # If empty or set to null, no storageClassName spec is
+    # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
+    storageClass: null
 
 memcachedFrontend:
   # -- Specifies whether the Memcached frontend cache should be enabled
@@ -1518,6 +1554,17 @@ memcachedFrontend:
   nodeSelector: {}
   # -- Tolerations for memcached-frontend pods
   tolerations: []
+  persistence:
+    # -- Enable creating PVCs which will persist cached data through restarts
+    enabled: false
+    # -- Size of persistent or memory disk
+    size: 10Gi
+    # -- Storage class to be used.
+    # If defined, storageClassName: <storageClass>.
+    # If set to "-", storageClassName: "", which disables dynamic provisioning.
+    # If empty or set to null, no storageClassName spec is
+    # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
+    storageClass: null
 
 memcachedIndexQueries:
   # -- Specifies whether the Memcached index queries cache should be enabled
@@ -1567,6 +1614,17 @@ memcachedIndexQueries:
   nodeSelector: {}
   # -- Tolerations for memcached-index-queries pods
   tolerations: []
+  persistence:
+    # -- Enable creating PVCs which will persist cached data through restarts
+    enabled: false
+    # -- Size of persistent or memory disk
+    size: 10Gi
+    # -- Storage class to be used.
+    # If defined, storageClassName: <storageClass>.
+    # If set to "-", storageClassName: "", which disables dynamic provisioning.
+    # If empty or set to null, no storageClassName spec is
+    # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
+    storageClass: null
 
 memcachedIndexWrites:
   # -- Specifies whether the Memcached index writes cache should be enabled
@@ -1616,6 +1674,17 @@ memcachedIndexWrites:
   nodeSelector: {}
   # -- Tolerations for memcached-index-writes pods
   tolerations: []
+  persistence:
+    # -- Enable creating PVCs which will persist cached data through restarts
+    enabled: false
+    # -- Size of persistent or memory disk
+    size: 10Gi
+    # -- Storage class to be used.
+    # If defined, storageClassName: <storageClass>.
+    # If set to "-", storageClassName: "", which disables dynamic provisioning.
+    # If empty or set to null, no storageClassName spec is
+    # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
+    storageClass: null
 
 networkPolicy:
   # -- Specifies whether Network Policies should be created


### PR DESCRIPTION
## Memcached configuration
Currently if memcached is enabled through the `memcachedXXX` values, the infrastructure will be deployed, but Loki is not configured to use the created resources.

This PR adds new entries to the default `loki.config` value, which minimally configures each memcached component when enabled (solving #1386).

Additionally cache configuration can still be injected and overwritten using the `structuredConfig` value.

## Memcached persistence
This PR also adds the ability to configure optional persistence for the memcached stateful sets, meaning cache data will not be lost upon pod restart. This solves issue #1936.