### PR TITLE
[tempo-distributed] add headless services for ingester and metrics-generator

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.27.4
+version: 0.27.5
 appVersion: 1.5.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.27.4](https://img.shields.io/badge/Version-0.27.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.27.5](https://img.shields.io/badge/Version-0.27.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/ingester/service-ingester-discovery.yaml
+++ b/charts/tempo-distributed/templates/ingester/service-ingester-discovery.yaml
@@ -1,10 +1,11 @@
+{{- $dict := dict "ctx" . "component" "ingester" true }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "tempo.resourceName" (dict "ctx" . "component" "ingester") }}-discovery
+  name: {{ template "tempo.resourceName" $dict }}-discovery
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "tempo.labels" (dict "ctx" . "component" "ingester") | nindent 4 }}
+    {{- include "tempo.labels" $dict | nindent 4 }}
     prometheus.io/service-monitor: "false"
   {{- with .Values.ingester.service.annotations }}
   annotations:
@@ -26,4 +27,4 @@ spec:
       appProtocol: {{ .Values.ingester.appProtocol.grpc }}
       {{- end }}
   selector:
-    {{- include "tempo.selectorLabels" (dict "ctx" . "component" "ingester") | nindent 4 }}
+    {{- include "tempo.selectorLabels" $dict | nindent 4 }}

--- a/charts/tempo-distributed/templates/ingester/service-ingester-discovery.yaml
+++ b/charts/tempo-distributed/templates/ingester/service-ingester-discovery.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "tempo.resourceName" (dict "ctx" . "component" "ingester") }}-discovery
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tempo.labels" (dict "ctx" . "component" "ingester") | nindent 4 }}
+    prometheus.io/service-monitor: "false"
+  {{- with .Values.ingester.service.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http-metrics
+      port: 3100
+      protocol: TCP
+      targetPort: 3100
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: 9095
+      {{- if .Values.ingester.appProtocol.grpc }}
+      appProtocol: {{ .Values.ingester.appProtocol.grpc }}
+      {{- end }}
+  selector:
+    {{- include "tempo.selectorLabels" (dict "ctx" . "component" "ingester") | nindent 4 }}

--- a/charts/tempo-distributed/templates/ingester/service-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/service-ingester.yaml
@@ -1,10 +1,11 @@
+{{- $dict := dict "ctx" . "component" "ingester" true }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "tempo.resourceName" (dict "ctx" . "component" "ingester") }}
+  name: {{ template "tempo.resourceName" $dict }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "tempo.labels" (dict "ctx" . "component" "ingester") | nindent 4 }}
+    {{- include "tempo.labels" $dict | nindent 4 }}
   {{- with .Values.ingester.service.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
@@ -23,4 +24,4 @@ spec:
       appProtocol: {{ .Values.ingester.appProtocol.grpc }}
       {{- end }}
   selector:
-    {{- include "tempo.selectorLabels" (dict "ctx" . "component" "ingester") | nindent 4 }}
+    {{- include "tempo.selectorLabels" $dict | nindent 4 }}

--- a/charts/tempo-distributed/templates/metrics-generator/service-metrics-generator-discovery.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/service-metrics-generator-discovery.yaml
@@ -28,5 +28,5 @@ spec:
     {{- end }}
     {{- end }}
   selector:
-    {{- include "tempo.selectorLabels" (dict "ctx" . "component" "metrics-generator") | nindent 4 }}
+    {{- include "tempo.selectorLabels" $dict | nindent 4 }}
 {{- end }}

--- a/charts/tempo-distributed/templates/metrics-generator/service-metrics-generator-discovery.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/service-metrics-generator-discovery.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.metricsGenerator.enabled }}
+{{- $dict := dict "ctx" . "component" "metrics-generator" "memberlist" true }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "tempo.resourceName" $dict }}-discovery
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tempo.labels" $dict | nindent 4 }}
+    prometheus.io/service-monitor: "false"
+  {{- with .Values.metricsGenerator.service.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    {{- range .Values.metricsGenerator.ports }}
+    {{- if .service }}
+    - name: {{ .name | quote }}
+      port: {{ .port }}
+      protocol: TCP
+      targetPort: {{ .port }}
+      {{- if and (hasPrefix .name "grpc") ($.Values.metricsGenerator.appProtocol.grpc) }}
+      appProtocol: {{ $.Values.metricsGenerator.appProtocol.grpc }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
+  selector:
+    {{- include "tempo.selectorLabels" (dict "ctx" . "component" "metrics-generator") | nindent 4 }}
+{{- end }}

--- a/charts/tempo-distributed/templates/metrics-generator/service-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/service-metrics-generator.yaml
@@ -25,5 +25,5 @@ spec:
     {{- end }}
     {{- end }}
   selector:
-    {{- include "tempo.selectorLabels" (dict "ctx" . "component" "metrics-generator") | nindent 4 }}
+    {{- include "tempo.selectorLabels" $dict | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
This pull request will add [headless services](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services) for the `ingester` and `metrics-generator`. The `query-frontend` already has a headless service. Tried to follow the same name convention as the `query-frontend` and named the new headless services with the suffix *-discovery*.

Headless services for the `ingester` and the `metrics-generator` are required when used with service-mesh solutions such as [Istio](https://istio.io/). The gRPC connections are established with internal Kubernetes endpoint IP's which Istio are not aware of and will therefore block those connections. Adding headless services will resolve this Istio issue.

**This pull request include the optional `appProtocol` option and should therefore be merged after pull request** https://github.com/grafana/helm-charts/pull/1884 **!**

```
{{- if .Values.ingester.appProtocol.grpc }}
appProtocol: {{ .Values.ingester.appProtocol.grpc }}
{{- end }}
 ```