### PR TITLE
[loki-distributed] Mount /var/loki to emptyDir in tableManager

### DIFF
--- a/charts/loki-distributed/templates/table-manager/deployment-table-manager.yaml
+++ b/charts/loki-distributed/templates/table-manager/deployment-table-manager.yaml
@@ -83,6 +83,8 @@ spec:
               mountPath: /etc/loki/config
             - name: runtime-config
               mountPath: /var/{{ include "loki.name" . }}-runtime
+            - name: data
+              mountPath: /var/loki
             {{- with .Values.tableManager.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -115,6 +117,8 @@ spec:
         - name: runtime-config
           configMap:
             name: {{ template "loki.fullname" . }}-runtime
+        - name: data
+          emptyDir: {}
         {{- with .Values.tableManager.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
Fix issue:
https://github.com/grafana/helm-charts/issues/737
