### PR TITLE
[loki-stack] Use grafana.sidecar.datasources.{label,labelValue} for datasources cm metadata

### DIFF
--- a/charts/loki-stack/Chart.yaml
+++ b/charts/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 2.8.4
+version: 2.8.5
 appVersion: v2.6.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki-stack/Chart.yaml
+++ b/charts/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 2.8.5
+version: 2.8.6
 appVersion: v2.6.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki-stack/templates/datasources.yaml
+++ b/charts/loki-stack/templates/datasources.yaml
@@ -9,7 +9,11 @@ metadata:
     chart: {{ template "loki-stack.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.grafana.sidecar.datasources.label }}
+    {{ .Values.grafana.sidecar.datasources.label }}: {{ .Values.grafana.sidecar.datasources.labelValue | quote }}
+    {{- else }}
     grafana_datasource: "1"
+    {{- end }}
 data:
   loki-stack-datasource.yaml: |-
     apiVersion: 1


### PR DESCRIPTION
When using multiple releases of the loki-stack chart, the datasources of the wrong release can be imported into grafana by the sidecar as the grafana_datasource label is the same.

the datasource configmap should instead use the key/value pair defined in the values of the grafana sub-chart if specified: https://github.com/grafana/helm-charts/blob/d7d211d3b8e5d134afcdbbd40d6cd36be73443f2/charts/grafana/values.yaml#L873 and https://github.com/grafana/helm-charts/blob/d7d211d3b8e5d134afcdbbd40d6cd36be73443f2/charts/grafana/values.yaml#L875

Any feedback or suggestions are appreciated :) 