### PR TITLE
[loki-distributed] Add HPA support for k8s >=1.25-0

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.6.1
-version: 0.66.5
+version: 0.66.6
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.6.1
-version: 0.65.0
+version: 0.65.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.66.5](https://img.shields.io/badge/Version-0.66.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 0.66.6](https://img.shields.io/badge/Version-0.66.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.65.0](https://img.shields.io/badge/Version-0.65.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 0.65.1](https://img.shields.io/badge/Version-0.65.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/templates/_helpers.tpl
+++ b/charts/loki-distributed/templates/_helpers.tpl
@@ -141,6 +141,17 @@ Return the appropriate apiVersion for PodDisruptionBudget.
   {{- end -}}
 {{- end -}}
 
+{{/*
+Return the appropriate apiVersion for HorizontalPodAutoscaler.
+*/}}
+{{- define "loki.hpa.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "autoscaling/v2") (semverCompare ">=1.25-0" .Capabilities.KubeVersion.Version) -}}
+    {{- print "autoscaling/v2" -}}
+  {{- else -}}
+    {{- print "autoscaling/v2beta1" -}}
+  {{- end -}}
+{{- end -}}
+
 {{- define "loki.ingester.readinessProbe" -}}
 {{- with .Values.ingester.readinessProbe }}  
 readinessProbe:

--- a/charts/loki-distributed/templates/distributor/hpa.yaml
+++ b/charts/loki-distributed/templates/distributor/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.distributor.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ include "loki.hpa.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.distributorFullname" . }}

--- a/charts/loki-distributed/templates/gateway/hpa.yaml
+++ b/charts/loki-distributed/templates/gateway/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.gateway.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ include "loki.hpa.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.gatewayFullname" . }}

--- a/charts/loki-distributed/templates/ingester/hpa.yaml
+++ b/charts/loki-distributed/templates/ingester/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingester.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ include "loki.hpa.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.ingesterFullname" . }}

--- a/charts/loki-distributed/templates/querier/hpa.yaml
+++ b/charts/loki-distributed/templates/querier/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.indexGateway.enabled .Values.querier.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ include "loki.hpa.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.querierFullname" . }}

--- a/charts/loki-distributed/templates/query-frontend/hpa.yaml
+++ b/charts/loki-distributed/templates/query-frontend/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.queryFrontend.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ include "loki.hpa.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.queryFrontendFullname" . }}


### PR DESCRIPTION
Hi, we migraded from loki-stack to loki-distributed helm chart, but our k8s cluster is running on 1.25.x version already. 

I ran into an issue with an unsupported apiVersion for HorizontalPodAutoscaler in loki-distributed helm chart, so I decided to add support for the autoscaling/v2 apiVersion.

Signed-off-by: Tomáš Novák <tomas.novak@bcas.cz>