### PR TITLE
[grafana] bump default grafana image tag to 9.2.4 for critical security update

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.43.4
-appVersion: 9.2.3
+version: 6.43.5
+appVersion: 9.2.4
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net


### PR DESCRIPTION
A new version of Grafana has been released [fixing a critical vulnerability](https://grafana.com/blog/2022/11/08/security-release-new-versions-of-grafana-with-critical-and-moderate-fixes-for-cve-2022-39328-cve-2022-39307-and-cve-2022-39306/) and more. This fix should be available to everyone installing Grafana via Helm Chart quickly.