### PR TITLE
[tempo-distributed] fix wrong context on ingress-gateway

### DIFF
--- a/charts/tempo-distributed/templates/gateway/ingress-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/ingress-gateway.yaml
@@ -3,12 +3,13 @@
 {{- $ingressApiIsStable := eq (include "tempo.ingress.isStable" .) "true" -}}
 {{- $ingressSupportsIngressClassName := eq (include "tempo.ingress.supportsIngressClassName" .) "true" -}}
 {{- $ingressSupportsPathType := eq (include "tempo.ingress.supportsPathType" .) "true" -}}
+{{- $dict := dict "ctx" . "component" "gateway" -}}
 apiVersion: {{ include "tempo.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: {{ include "tempo.resourceName" (dict "ctx" . "component" "gateway") }}
+  name: {{ include "tempo.resourceName" $dict }}
   labels:
-    {{- include "tempo.labels" (dict "ctx" . "component" "gateway") | nindent 4 }}
+    {{- include "tempo.labels" $dict | nindent 4 }}
   {{- with .Values.gateway.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -42,11 +43,11 @@ spec:
             backend:
               {{- if $ingressApiIsStable }}
               service:
-                name: {{ include "tempo.resourceName" (dict "ctx" . "component" "gateway") }}
+                name: {{ include "tempo.resourceName" $dict }}
                 port:
                   number: {{ $.Values.gateway.service.port }}
               {{- else }}
-              serviceName: {{ include "tempo.resourceName" (dict "ctx" . "component" "gateway") }}
+              serviceName: {{ include "tempo.resourceName" $dict }}
               servicePort: {{ $.Values.gateway.service.port }}
               {{- end }}
           {{- end }}


### PR DESCRIPTION
I was having the following error during the chart render.

```
template: tempo-distributed/templates/gateway/ingress-gateway.yaml:45:25: executing "tempo-distributed/templates/gateway/ingress-gateway.yaml" at <include "tempo.resourceName" (dict "ctx" . "component" "gateway")>: error calling include: template: tempo-distributed/templates/_helpers.tpl:153:3: executing "tempo.resourceName" at <include "tempo.fullname" .ctx>: error calling include: template: tempo-distributed/templates/_helpers.tpl:15:14: executing "tempo.fullname" at <.Values.fullnameOverride>: nil pointer evaluating interface {}.fullnameOverride
```

It is caused by a missing context due to the `range` in [ingress-gateway.yaml:37](https://github.com/grafana/helm-charts/blob/main/charts/tempo-distributed/templates/gateway/ingress-gateway.yaml#L37). I've followed the same pattern seen on other templates here and defined a `$dict` on top which is then passed as context.