### PR TITLE
[tempo] block_retention instead of compacted_block_retention

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 0.16.3
+version: 0.16.4
 appVersion: 1.5.0
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 0.16.3](https://img.shields.io/badge/Version-0.16.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.16.4](https://img.shields.io/badge/Version-0.16.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -114,7 +114,7 @@ config: |
     metrics_generator_enabled: {{ .Values.tempo.metricsGenerator.enabled }}
     compactor:
       compaction:
-        compacted_block_retention: {{ .Values.tempo.retention }}
+        block_retention: {{ .Values.tempo.retention }}
     distributor:
       receivers:
         {{- toYaml .Values.tempo.receivers | nindent 8 }}


### PR DESCRIPTION
Tempo chart uses `compacted_block_retention` for the retention and tempo-distributed uses `block_retention`. I am updating the tempo chart to match the tempo-distributed.

We probably shouldn't update the `compacted_block_retention` as @joe-elliott mentioned here
https://github.com/grafana/tempo/issues/1884#issuecomment-1310295822

Fixes #1970