### PR TITLE
[locki-stack] Allow disabling of test_pod

### DIFF
--- a/charts/loki-stack/Chart.yaml
+++ b/charts/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 2.8.4
+version: 2.8.5
 appVersion: v2.6.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki-stack/templates/tests/loki-test-configmap.yaml
+++ b/charts/loki-stack/templates/tests/loki-test-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.loki.enabled }}
+{{- if and .Values.loki.enabled .Values.test_pod.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/loki-stack/templates/tests/loki-test-pod.yaml
+++ b/charts/loki-stack/templates/tests/loki-test-pod.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.loki.enabled }}
+{{- if and .Values.loki.enabled .Values.test_pod.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/charts/loki-stack/values.yaml
+++ b/charts/loki-stack/values.yaml
@@ -1,4 +1,5 @@
 test_pod:
+  enabled: true
   image: bats/bats:v1.1.0
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Hi there, we ran into a problem with the test_pod that's part of the loki-stack. Our production cluster is not able to reach the internet so we had to disable the pod entirely to avoid having a pod in a CrashLoopBackOff state forever. I think it's not a bad idea to have this option for such use cases.

PS: This is my first contribution, so I hope I didn't miss anything.

Signed-off-by: Niclas Behrendt <niclas.behrendt@nicl.dev>
