### PR TITLE
[grafana] fix alerting configmap

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.44.1
+version: 6.44.2
 appVersion: 9.2.4
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/configmap.yaml
+++ b/charts/grafana/templates/configmap.yaml
@@ -54,7 +54,7 @@ data:
 
   {{- range $key, $value := .Values.alerting }}
   {{- $key | nindent 2 }}: |
-    {{- tpl (toYaml $value | indent 4) $root }}
+    {{- tpl (toYaml $value | nindent 4) $root }}
   {{- end }}
 
   {{- range $key, $value := .Values.dashboardProviders }}


### PR DESCRIPTION
The Grafana ConfigMap cannot be rendered when an alerting value object is provided.