### PR TITLE
[tempo-distributed] fix wrong context on gateway with basicAuth enabled

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.27.7
+version: 0.27.8
 appVersion: 1.5.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.27.7](https://img.shields.io/badge/Version-0.27.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.27.8](https://img.shields.io/badge/Version-0.27.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/gateway/_helpers-gateway.tpl
+++ b/charts/tempo-distributed/templates/gateway/_helpers-gateway.tpl
@@ -2,7 +2,7 @@
 gateway auth secret name
 */}}
 {{- define "tempo.gatewayAuthSecret" -}}
-{{ .Values.gateway.basicAuth.existingSecret | default (include "tempo.gatewayFullname" . ) }}
+{{ .Values.gateway.basicAuth.existingSecret | default (include "tempo.resourceName" (dict "ctx" . "component" "gateway")) }}
 {{- end }}
 
 

--- a/charts/tempo-distributed/templates/gateway/secret-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/secret-gateway.yaml
@@ -1,13 +1,14 @@
+{{- $dict := dict "ctx" . "component" "gateway" -}}
 {{- with .Values.gateway }}
 {{- if and .enabled .basicAuth.enabled (not .basicAuth.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "tempo.resourceName" (dict "ctx" . "component" "gateway") }}
+  name: {{ include "tempo.resourceName" $dict }}
   labels:
-    {{- include "tempo.labels" (dict "ctx" . "component" "gateway") | nindent 4 }}
+    {{- include "tempo.labels" $dict | nindent 4 }}
 stringData:
   .htpasswd: |
-    {{- tpl .basicAuth.htpasswd $ | nindent 4 }}
+    {{- tpl .basicAuth.htpasswd $dict.ctx | nindent 4 }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The following template fails on the latest version of tempo-distributed.

```sh
$ helm template tempo grafana/tempo-distributed \
  --set gateway.enabled=true \
  --set gateway.ingress.enabled=true \
  --set fullnameOverride=tempo \
  --set gateway.basicAuth.enabled=true \
  --version 0.27.7 >/dev/null
Error: template: tempo-distributed/templates/gateway/secret-gateway.yaml:6:11: executing "tempo-distributed/templates/gateway/secret-gateway.yaml" at <include "tempo.resourceName" (dict "ctx" . "component" "gateway")>: error calling include: template: tempo-distributed/templates/_helpers.tpl:153:3: executing "tempo.resourceName" at <include "tempo.fullname" .ctx>: error calling include: template: tempo-distributed/templates/_helpers.tpl:15:14: executing "tempo.fullname" at <.Values.fullnameOverride>: nil pointer evaluating interface {}.fullnameOverride

Use --debug flag to render out invalid YAML
```

This fixes #1934. Where wrong context is passed to the secret-gateway template when basicAuth is enabled.