### PR TITLE
[grafana] bump default grafana image tag to 9.2.5

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.44.2
-appVersion: 9.2.4
+version: 6.44.3
+appVersion: 9.2.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net


### PR DESCRIPTION
See: [https://github.com/grafana/grafana/releases/tag/v9.2.5](https://github.com/grafana/grafana/releases/tag/v9.2.5)