### PR TITLE
[grafana] bump grafana chart version

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.44.3
+version: 6.44.4
 appVersion: 9.2.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.


### PR DESCRIPTION
Due to https://github.com/grafana/helm-charts/pull/1980#issuecomment-1318724727 to trigger a new release build.
