### PR TITLE
[grafana] fix boolean pathType value

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.44.4
+version: 6.44.5
 appVersion: 9.2.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/ingress.yaml
+++ b/charts/grafana/templates/ingress.yaml
@@ -71,8 +71,8 @@ spec:
             {{- with $ingressPath }}
             path: {{ . }}
             {{- end }}
-            {{- with $ingressSupportsPathType }}
-            pathType: {{ . }}
+            {{- if $ingressSupportsPathType }}
+            pathType: {{ $ingressPathType }}
             {{- end }}
   {{- end -}}
 {{- end }}


### PR DESCRIPTION
In a recent refactor (45f71da2c9055f6de23761434a8fc2472559ca53), `path` based `Ingress` manifests [were broken](https://github.com/grafana/helm-charts/commit/45f71da2c9055f6de23761434a8fc2472559ca53#diff-3cc6b406041b4e16cbcfce60566d7931bd50051cd73290333657b94865ecca72L74-L75) in that they started providing boolean values for a string field. This PR reverts the broken refactor.

<img width="1533" alt="Screenshot 2022-11-18 at 10 59 27 AM" src="https://user-images.githubusercontent.com/981825/202774279-0450e60d-c14f-4930-9910-a0a5d44731dd.png">

