### PR TITLE
[grafana] Fix broken extraLabels parameter due to missing line break

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.44.6
+version: 6.44.7
 appVersion: 9.2.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_helpers.tpl
+++ b/charts/grafana/templates/_helpers.tpl
@@ -72,7 +72,7 @@ app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | qu
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- with .Values.extraLabels }}
-{{- toYaml . }}
+{{ toYaml . }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
Signed-off-by: toVersus <toversus2357@gmail.com>

Fixes: #2003

After this patch, we can properly render the manifests:

```console
❯ helm template grafana -n monitoring .
---
# Source: grafana/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  labels:
    helm.sh/chart: grafana-6.44.7
    app.kubernetes.io/name: grafana
    app.kubernetes.io/instance: grafana
    app.kubernetes.io/version: "9.2.5"
    app.kubernetes.io/managed-by: Helm
    foo: bar
  name: grafana
  namespace: monitoring
(...)
```