### PR TITLE
[loki-distributed] Disable access_log for readinessProbe and livenessProbe in gateway

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.6.1
-version: 0.66.1
+version: 0.66.2
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.66.1](https://img.shields.io/badge/Version-0.66.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 0.66.2](https://img.shields.io/badge/Version-0.66.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -1032,6 +1032,7 @@ gateway:
           location = / {
             return 200 'OK';
             auth_basic off;
+            access_log off;
           }
 
           location = /api/prom/push {


### PR DESCRIPTION
Before:
```
kubectl logs -n loki loki-loki-distributed-gateway-86d46d55f7-hcsmv
/docker-entrypoint.sh: No files found in /docker-entrypoint.d/, skipping configuration
10.112.128.1 - - [28/Nov/2022:05:15:09 +0000]  200 "GET / HTTP/1.1" 2 "-" "kube-probe/1.22" "-"
10.112.128.1 - - [28/Nov/2022:05:15:19 +0000]  200 "GET / HTTP/1.1" 2 "-" "kube-probe/1.22" "-"
10.112.128.1 - - [28/Nov/2022:05:15:29 +0000]  200 "GET / HTTP/1.1" 2 "-" "kube-probe/1.22" "-"
10.112.128.1 - - [28/Nov/2022:05:15:29 +0000]  200 "GET / HTTP/1.1" 2 "-" "kube-probe/1.22" "-"
10.112.128.1 - - [28/Nov/2022:05:15:39 +0000]  200 "GET / HTTP/1.1" 2 "-" "kube-probe/1.22" "-"
10.112.128.1 - - [28/Nov/2022:05:15:39 +0000]  200 "GET / HTTP/1.1" 2 "-" "kube-probe/1.22" "-"
10.112.128.1 - - [28/Nov/2022:05:15:49 +0000]  200 "GET / HTTP/1.1" 2 "-" "kube-probe/1.22" "-"
10.112.128.1 - - [28/Nov/2022:05:15:49 +0000]  200 "GET / HTTP/1.1" 2 "-" "kube-probe/1.22" "-"
10.112.128.1 - - [28/Nov/2022:05:15:59 +0000]  200 "GET / HTTP/1.1" 2 "-" "kube-probe/1.22" "-"
10.112.128.1 - - [28/Nov/2022:05:15:59 +0000]  200 "GET / HTTP/1.1" 2 "-" "kube-probe/1.22" "-"
10.112.128.1 - - [28/Nov/2022:05:16:09 +0000]  200 "GET / HTTP/1.1" 2 "-" "kube-probe/1.22" "-"
10.112.128.1 - - [28/Nov/2022:05:16:09 +0000]  200 "GET / HTTP/1.1" 2 "-" "kube-probe/1.22" "-"
```

After:
```
kubectl logs -n loki loki-loki-distributed-gateway-86d46d55f7-hcsmv
/docker-entrypoint.sh: No files found in /docker-entrypoint.d/, skipping configuration
```

Signed-off-by: Anton Patsev <patsev.anton@gmail.com>