### PR TITLE
[loki-distributed] Do not create PDBs if maxUnavailable value is not set

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.6.1
-version: 0.66.3
+version: 0.66.4
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.6.1
-version: 0.66.2
+version: 0.66.3
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.66.3](https://img.shields.io/badge/Version-0.66.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 0.66.4](https://img.shields.io/badge/Version-0.66.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
+++ b/charts/loki-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
@@ -1,4 +1,7 @@
-{{- if and (gt (int .Values.distributor.replicas) 1) .Values.distributor.maxUnavailable }}
+{{- if gt (int .Values.distributor.replicas) 1 }}
+{{- if not .Values.distributor.maxUnavailable }}
+{{- fail "`.Values.distributor.maxUnavailable` must be set when `.Values.distributor.replicas` is greater than 1." }}
+{{- else }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -12,4 +15,5 @@ spec:
   {{- with .Values.distributor.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
+++ b/charts/loki-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
@@ -1,4 +1,4 @@
-{{- if gt (int .Values.distributor.replicas) 1 }}
+{{- if and (gt (int .Values.distributor.replicas) 1) .Values.distributor.maxUnavailable }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/loki-distributed/templates/gateway/poddisruptionbudget-gateway.yaml
+++ b/charts/loki-distributed/templates/gateway/poddisruptionbudget-gateway.yaml
@@ -1,4 +1,7 @@
-{{- if and .Values.gateway.enabled (gt (int .Values.gateway.replicas) 1) .Values.gateway.maxUnavailable }}
+{{- if and .Values.gateway.enabled (gt (int .Values.gateway.replicas) 1) }}
+{{- if not .Values.gateway.maxUnavailable }}
+{{- fail "`.Values.gateway.maxUnavailable` must be set when `.Values.gateway.replicas` is greater than 1." }}
+{{- else }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -12,4 +15,5 @@ spec:
   {{- with .Values.gateway.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/gateway/poddisruptionbudget-gateway.yaml
+++ b/charts/loki-distributed/templates/gateway/poddisruptionbudget-gateway.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.gateway.enabled (gt (int .Values.gateway.replicas) 1) }}
+{{- if and .Values.gateway.enabled (gt (int .Values.gateway.replicas) 1) .Values.gateway.maxUnavailable }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/loki-distributed/templates/index-gateway/poddisruptionbudget-index-gateway.yaml
+++ b/charts/loki-distributed/templates/index-gateway/poddisruptionbudget-index-gateway.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.indexGateway.enabled (gt (int .Values.indexGateway.replicas) 1) }}
+{{- if and .Values.indexGateway.enabled (gt (int .Values.indexGateway.replicas) 1) .Values.indexGateway.maxUnavailable }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/loki-distributed/templates/index-gateway/poddisruptionbudget-index-gateway.yaml
+++ b/charts/loki-distributed/templates/index-gateway/poddisruptionbudget-index-gateway.yaml
@@ -1,4 +1,7 @@
-{{- if and .Values.indexGateway.enabled (gt (int .Values.indexGateway.replicas) 1) .Values.indexGateway.maxUnavailable }}
+{{- if and .Values.indexGateway.enabled (gt (int .Values.indexGateway.replicas) 1) }}
+{{- if not .Values.indexGateway.maxUnavailable }}
+{{- fail "`.Values.indexGateway.maxUnavailable` must be set when `.Values.indexGateway.replicas` is greater than 1." }}
+{{- else }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -12,4 +15,5 @@ spec:
   {{- with .Values.indexGateway.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
@@ -1,4 +1,4 @@
-{{- if gt (int .Values.ingester.replicas) 1 }}
+{{- if and (gt (int .Values.ingester.replicas) 1) .Values.ingester.maxUnavailable }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/loki-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
@@ -1,4 +1,7 @@
-{{- if and (gt (int .Values.ingester.replicas) 1) .Values.ingester.maxUnavailable }}
+{{- if gt (int .Values.ingester.replicas) 1 }}
+{{- if not .Values.ingester.maxUnavailable }}
+{{- fail "`.Values.ingester.maxUnavailable` must be set when `.Values.ingester.replicas` is greater than 1." }}
+{{- else }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -12,4 +15,5 @@ spec:
   {{- with .Values.ingester.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/memcached-chunks/poddisruptionbudget-memcached-chunks.yaml
+++ b/charts/loki-distributed/templates/memcached-chunks/poddisruptionbudget-memcached-chunks.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.memcachedChunks.enabled (gt (int .Values.memcachedChunks.replicas) 1) }}
+{{- if and .Values.memcachedChunks.enabled (gt (int .Values.memcachedChunks.replicas) 1) .Values.memcachedChunks.maxUnavailable }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/loki-distributed/templates/memcached-chunks/poddisruptionbudget-memcached-chunks.yaml
+++ b/charts/loki-distributed/templates/memcached-chunks/poddisruptionbudget-memcached-chunks.yaml
@@ -1,4 +1,7 @@
-{{- if and .Values.memcachedChunks.enabled (gt (int .Values.memcachedChunks.replicas) 1) .Values.memcachedChunks.maxUnavailable }}
+{{- if and .Values.memcachedChunks.enabled (gt (int .Values.memcachedChunks.replicas) 1) }}
+{{- if not .Values.memcachedChunks.maxUnavailable }}
+{{- fail "`.Values.memcachedChunks.maxUnavailable` must be set when `.Values.memcachedChunks.replicas` is greater than 1." }}
+{{- else }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -12,4 +15,5 @@ spec:
   {{- with .Values.memcachedChunks.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/memcached-frontend/poddisruptionbudget-memcached-frontend.yaml
+++ b/charts/loki-distributed/templates/memcached-frontend/poddisruptionbudget-memcached-frontend.yaml
@@ -1,4 +1,7 @@
-{{- if and .Values.memcachedFrontend.enabled (gt (int .Values.memcachedFrontend.replicas) 1) .Values.memcachedFrontend.maxUnavailable }}
+{{- if and .Values.memcachedFrontend.enabled (gt (int .Values.memcachedFrontend.replicas) 1) }}
+{{- if not .Values.memcachedFrontend.maxUnavailable }}
+{{- fail "`.Values.memcachedFrontend.maxUnavailable` must be set when `.Values.memcachedFrontend.replicas` is greater than 1." }}
+{{- else }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -12,4 +15,5 @@ spec:
   {{- with .Values.memcachedFrontend.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/memcached-frontend/poddisruptionbudget-memcached-frontend.yaml
+++ b/charts/loki-distributed/templates/memcached-frontend/poddisruptionbudget-memcached-frontend.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.memcachedFrontend.enabled (gt (int .Values.memcachedFrontend.replicas) 1) }}
+{{- if and .Values.memcachedFrontend.enabled (gt (int .Values.memcachedFrontend.replicas) 1) .Values.memcachedFrontend.maxUnavailable }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/loki-distributed/templates/memcached-index-queries/poddisruptionbudget-memcached-index-queries.yaml
+++ b/charts/loki-distributed/templates/memcached-index-queries/poddisruptionbudget-memcached-index-queries.yaml
@@ -1,4 +1,7 @@
-{{- if and .Values.memcachedIndexQueries.enabled (gt (int .Values.memcachedIndexQueries.replicas) 1) .Values.memcachedIndexQueries.maxUnavailable }}
+{{- if and .Values.memcachedIndexQueries.enabled (gt (int .Values.memcachedIndexQueries.replicas) 1) }}
+{{- if not .Values.memcachedIndexQueries.maxUnavailable }}
+{{- fail "`.Values.memcachedIndexQueries.maxUnavailable` must be set when `.Values.memcachedIndexQueries.replicas` is greater than 1." }}
+{{- else }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -12,4 +15,5 @@ spec:
   {{- with .Values.memcachedIndexQueries.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/memcached-index-queries/poddisruptionbudget-memcached-index-queries.yaml
+++ b/charts/loki-distributed/templates/memcached-index-queries/poddisruptionbudget-memcached-index-queries.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.memcachedIndexQueries.enabled (gt (int .Values.memcachedIndexQueries.replicas) 1) }}
+{{- if and .Values.memcachedIndexQueries.enabled (gt (int .Values.memcachedIndexQueries.replicas) 1) .Values.memcachedIndexQueries.maxUnavailable }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/loki-distributed/templates/memcached-index-writes/poddisruptionbudget-memcached-index-writes.yaml
+++ b/charts/loki-distributed/templates/memcached-index-writes/poddisruptionbudget-memcached-index-writes.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.memcachedIndexWrites.enabled (gt (int .Values.memcachedIndexWrites.replicas) 1) }}
+{{- if and .Values.memcachedIndexWrites.enabled (gt (int .Values.memcachedIndexWrites.replicas) 1) .Values.memcachedIndexWrites.maxUnavailable }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/loki-distributed/templates/memcached-index-writes/poddisruptionbudget-memcached-index-writes.yaml
+++ b/charts/loki-distributed/templates/memcached-index-writes/poddisruptionbudget-memcached-index-writes.yaml
@@ -1,4 +1,7 @@
-{{- if and .Values.memcachedIndexWrites.enabled (gt (int .Values.memcachedIndexWrites.replicas) 1) .Values.memcachedIndexWrites.maxUnavailable }}
+{{- if and .Values.memcachedIndexWrites.enabled (gt (int .Values.memcachedIndexWrites.replicas) 1) }}
+{{- if not .Values.memcachedIndexWrites.maxUnavailable }}
+{{- fail "`.Values.memcachedIndexWrites.maxUnavailable` must be set when `.Values.memcachedIndexWrites.replicas` is greater than 1." }}
+{{- else }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -12,4 +15,5 @@ spec:
   {{- with .Values.memcachedIndexWrites.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/querier/poddisruptionbudget-querier.yaml
+++ b/charts/loki-distributed/templates/querier/poddisruptionbudget-querier.yaml
@@ -1,4 +1,7 @@
-{{- if and (gt (int .Values.querier.replicas) 1) .Values.querier.maxUnavailable }}
+{{- if gt (int .Values.querier.replicas) 1 }}
+{{- if not .Values.querier.maxUnavailable }}
+{{- fail "`.Values.querier.maxUnavailable` must be set when `.Values.querier.replicas` is greater than 1." }}
+{{- else }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -12,4 +15,5 @@ spec:
   {{- with .Values.querier.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/querier/poddisruptionbudget-querier.yaml
+++ b/charts/loki-distributed/templates/querier/poddisruptionbudget-querier.yaml
@@ -1,4 +1,4 @@
-{{- if gt (int .Values.querier.replicas) 1 }}
+{{- if and (gt (int .Values.querier.replicas) 1) .Values.querier.maxUnavailable }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/loki-distributed/templates/query-frontend/poddisruptionbudget-query-frontent.yaml
+++ b/charts/loki-distributed/templates/query-frontend/poddisruptionbudget-query-frontent.yaml
@@ -1,4 +1,7 @@
-{{- if and (gt (int .Values.queryFrontend.replicas) 1) .Values.queryFrontend.maxUnavailable }}
+{{- if gt (int .Values.queryFrontend.replicas) 1 }}
+{{- if not .Values.queryFrontend.maxUnavailable }}
+{{- fail "`.Values.queryFrontend.maxUnavailable` must be set when `.Values.queryFrontend.replicas` is greater than 1." }}
+{{- else }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -12,4 +15,5 @@ spec:
   {{- with .Values.queryFrontend.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/query-frontend/poddisruptionbudget-query-frontent.yaml
+++ b/charts/loki-distributed/templates/query-frontend/poddisruptionbudget-query-frontent.yaml
@@ -1,4 +1,4 @@
-{{- if gt (int .Values.queryFrontend.replicas) 1 }}
+{{- if and (gt (int .Values.queryFrontend.replicas) 1) .Values.queryFrontend.maxUnavailable }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/loki-distributed/templates/query-scheduler/poddisruptionbudget-query-scheduler.yaml
+++ b/charts/loki-distributed/templates/query-scheduler/poddisruptionbudget-query-scheduler.yaml
@@ -1,4 +1,7 @@
-{{- if and .Values.queryScheduler.enabled (gt (int .Values.queryScheduler.replicas) 1) .Values.queryScheduler.maxUnavailable }}
+{{- if and .Values.queryScheduler.enabled (gt (int .Values.queryScheduler.replicas) 1) }}
+{{- if not .Values.queryScheduler.maxUnavailable }}
+{{- fail "`.Values.queryScheduler.maxUnavailable` must be set when `.Values.queryScheduler.replicas` is greater than 1." }}
+{{- else }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -12,4 +15,5 @@ spec:
   {{- with .Values.queryScheduler.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/query-scheduler/poddisruptionbudget-query-scheduler.yaml
+++ b/charts/loki-distributed/templates/query-scheduler/poddisruptionbudget-query-scheduler.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.queryScheduler.enabled (gt (int .Values.queryScheduler.replicas) 1) }}
+{{- if and .Values.queryScheduler.enabled (gt (int .Values.queryScheduler.replicas) 1) .Values.queryScheduler.maxUnavailable }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/loki-distributed/templates/ruler/poddisruptionbudget-ruler.yaml
+++ b/charts/loki-distributed/templates/ruler/poddisruptionbudget-ruler.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ruler.enabled (gt (int .Values.ruler.replicas) 1) }}
+{{- if and .Values.ruler.enabled (gt (int .Values.ruler.replicas) 1) .Values.ruler.maxUnavailable }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/loki-distributed/templates/ruler/poddisruptionbudget-ruler.yaml
+++ b/charts/loki-distributed/templates/ruler/poddisruptionbudget-ruler.yaml
@@ -1,4 +1,7 @@
-{{- if and .Values.ruler.enabled (gt (int .Values.ruler.replicas) 1) .Values.ruler.maxUnavailable }}
+{{- if and .Values.ruler.enabled (gt (int .Values.ruler.replicas) 1) }}
+{{- if not .Values.ruler.maxUnavailable }}
+{{- fail "`.Values.ruler.maxUnavailable` must be set when `.Values.ruler.replicas` is greater than 1." }}
+{{- else }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -12,4 +15,5 @@ spec:
   {{- with .Values.ruler.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Currently the chart creates `PodDisruptionBudget` for enabled components even if `maxUnavailable` value is not set. This results in resources which look like this:
```yaml
---
# Source: loki-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: dimunech-loki-loki-distributed-distributor
  labels:
    helm.sh/chart: loki-distributed-0.66.2
    app.kubernetes.io/name: loki-distributed
    app.kubernetes.io/instance: dimunech-loki
    app.kubernetes.io/version: "2.6.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: distributor
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: loki-distributed
      app.kubernetes.io/instance: dimunech-loki
      app.kubernetes.io/component: distributor

```
Such PDBs have neither `minAvailable` nor `maxUnavailable` defined, effectively functioning as if no disruptions are allowed. One effect of this is that it prevents `cluster-autoscaler` from evicting loki pods when trying to scale the cluster down.

This PR changes the conditions for creating `PodDisruptionBudget` resources, so that they are not created, unless `maxUnavailable` value for a component is set.