### PR TITLE
[grafana] Bump Grafana Version to 9.3.0

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.44.10
-appVersion: 9.2.5
+version: 6.44.11
+appVersion: 9.3.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net


### PR DESCRIPTION
In light of [CVE-2022-31097](https://grafana.com/blog/2022/11/29/grafana-security-release-new-versions-with-high-severity-security-fix-for-cve-2022-31097/) please can we bump the Grafana appVersion to 9.3.0 