### PR TITLE
[grafana] Add support for global imagePullSecrets values

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.44.11
+version: 6.45.0
 appVersion: 9.3.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -135,6 +135,7 @@ This version requires Helm >= 3.1.0.
 | `dashboards`                              | Dashboards to import                          | `{}`                                                    |
 | `dashboardsConfigMaps`                    | ConfigMaps reference that contains dashboards | `{}`                                                    |
 | `grafana.ini`                             | Grafana's primary configuration               | `{}`                                                    |
+| `global.imagePullSecrets`                 | Global image pull secrets (can be templated). Allows either an array of {name: pullSecret} maps (k8s-style), or an array of strings (more common helm-style).  | `[]`                                                    |
 | `ldap.enabled`                            | Enable LDAP authentication                    | `false`                                                 |
 | `ldap.existingSecret`                     | The name of an existing secret containing the `ldap.toml` file, this must have the key `ldap-toml`. | `""` |
 | `ldap.config`                             | Grafana's LDAP configuration                  | `""`                                                    |

--- a/charts/grafana/templates/_helpers.tpl
+++ b/charts/grafana/templates/_helpers.tpl
@@ -174,14 +174,15 @@ Return if ingress supports pathType.
 {{- end }}
 
 {{/*
-Formats imagePullSecrets. Input is (dict "Values" .Values "imagePullSecrets" .{specific imagePullSecrets})
+Formats imagePullSecrets. Input is (dict "root" . "imagePullSecrets" .{specific imagePullSecrets})
 */}}
 {{- define "grafana.imagePullSecrets" -}}
-{{- range (concat .Values.global.imagePullSecrets .imagePullSecrets) }}
+{{- $root := .root -}}
+{{- range (concat .root.Values.global.imagePullSecrets .imagePullSecrets) }}
   {{- if eq (typeOf .) "map[string]interface {}" }}
-- {{ toYaml . | trim }}
+- {{ toYaml (tpl .name $root) | trim }}
   {{- else }}
-- name: {{ . }}
+- name: {{ tpl . $root }}
   {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/grafana/templates/_helpers.tpl
+++ b/charts/grafana/templates/_helpers.tpl
@@ -177,12 +177,12 @@ Return if ingress supports pathType.
 Formats imagePullSecrets. Input is (dict "root" . "imagePullSecrets" .{specific imagePullSecrets})
 */}}
 {{- define "grafana.imagePullSecrets" -}}
-{{- $root := .root -}}
+{{- $root := .root }}
 {{- range (concat .root.Values.global.imagePullSecrets .imagePullSecrets) }}
-  {{- if eq (typeOf .) "map[string]interface {}" }}
+{{- if eq (typeOf .) "map[string]interface {}" }}
 - {{ toYaml (dict "name" (tpl .name $root)) | trim }}
-  {{- else }}
+{{- else }}
 - name: {{ tpl . $root }}
-  {{- end }}
 {{- end }}
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/charts/grafana/templates/_helpers.tpl
+++ b/charts/grafana/templates/_helpers.tpl
@@ -172,3 +172,16 @@ Return if ingress supports pathType.
 {{- define "grafana.ingress.supportsPathType" -}}
 {{- or (eq (include "grafana.ingress.isStable" .) "true") (and (eq (include "grafana.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) }}
 {{- end }}
+
+{{/*
+Formats imagePullSecrets. Input is (dict "Values" .Values "imagePullSecrets" .{specific imagePullSecrets})
+*/}}
+{{- define "grafana.imagePullSecrets" -}}
+{{- range (concat .Values.global.imagePullSecrets .imagePullSecrets) }}
+  {{- if eq (typeOf .) "map[string]interface {}" }}
+- {{ toYaml . | trim }}
+  {{- else }}
+- name: {{ . }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/grafana/templates/_helpers.tpl
+++ b/charts/grafana/templates/_helpers.tpl
@@ -180,7 +180,7 @@ Formats imagePullSecrets. Input is (dict "root" . "imagePullSecrets" .{specific 
 {{- $root := .root -}}
 {{- range (concat .root.Values.global.imagePullSecrets .imagePullSecrets) }}
   {{- if eq (typeOf .) "map[string]interface {}" }}
-- {{ toYaml (tpl .name $root) | trim }}
+- {{ toYaml (dict "name" (tpl .name $root)) | trim }}
   {{- else }}
 - name: {{ tpl . $root }}
   {{- end }}

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -222,7 +222,7 @@ initContainers:
 {{- end }}
 {{- if or .Values.image.pullSecrets .Values.global.imagePullSecrets }}
 imagePullSecrets:
-  {{- include "grafana.imagePullSecrets" (dict "root" $root "imagePullSecrets" .Values.image.pullSecrets) | indent 2 }}
+  {{- include "grafana.imagePullSecrets" (dict "root" $root "imagePullSecrets" .Values.image.pullSecrets) | nindent 2 }}
 {{- end }}
 {{- if not .Values.enableKubeBackwardCompatibility }}
 enableServiceLinks: {{ .Values.enableServiceLinks }}

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -220,11 +220,9 @@ initContainers:
 {{- with .Values.extraInitContainers }}
   {{- tpl (toYaml .) $root | nindent 2 }}
 {{- end }}
-{{- with .Values.image.pullSecrets }}
+{{- if or .Values.image.pullSecrets .Values.global.imagePullSecrets }}
 imagePullSecrets:
-  {{- range . }}
-  - name: {{ tpl . $root }}
-  {{- end}}
+  {{- include "grafana.imagePullSecrets" (dict "Values" .Values "imagePullSecrets" .Values.image.pullSecrets) | indent 2 }}
 {{- end }}
 {{- if not .Values.enableKubeBackwardCompatibility }}
 enableServiceLinks: {{ .Values.enableServiceLinks }}

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -222,7 +222,7 @@ initContainers:
 {{- end }}
 {{- if or .Values.image.pullSecrets .Values.global.imagePullSecrets }}
 imagePullSecrets:
-  {{- include "grafana.imagePullSecrets" (dict "Values" .Values "imagePullSecrets" .Values.image.pullSecrets) | indent 2 }}
+  {{- include "grafana.imagePullSecrets" (dict "root" $root "imagePullSecrets" .Values.image.pullSecrets) | indent 2 }}
 {{- end }}
 {{- if not .Values.enableKubeBackwardCompatibility }}
 enableServiceLinks: {{ .Values.enableServiceLinks }}

--- a/charts/grafana/templates/tests/test.yaml
+++ b/charts/grafana/templates/tests/test.yaml
@@ -16,11 +16,9 @@ spec:
   securityContext:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .Values.image.pullSecrets }}
+  {{- if or .Values.image.pullSecrets .Values.global.imagePullSecrets }}
   imagePullSecrets:
-    {{- range . }}
-    - name: {{ tpl . $root }}
-    {{- end}}
+    {{- include "grafana.imagePullSecrets" (dict "Values" .Values "imagePullSecrets" .Values.image.pullSecrets) | indent 4 }}
   {{- end }}
   {{- with .Values.nodeSelector }}
   nodeSelector:

--- a/charts/grafana/templates/tests/test.yaml
+++ b/charts/grafana/templates/tests/test.yaml
@@ -18,7 +18,7 @@ spec:
   {{- end }}
   {{- if or .Values.image.pullSecrets .Values.global.imagePullSecrets }}
   imagePullSecrets:
-    {{- include "grafana.imagePullSecrets" (dict "root" $root "imagePullSecrets" .Values.image.pullSecrets) | indent 4 }}
+    {{- include "grafana.imagePullSecrets" (dict "root" $root "imagePullSecrets" .Values.image.pullSecrets) | nindent 4 }}
   {{- end }}
   {{- with .Values.nodeSelector }}
   nodeSelector:

--- a/charts/grafana/templates/tests/test.yaml
+++ b/charts/grafana/templates/tests/test.yaml
@@ -18,7 +18,7 @@ spec:
   {{- end }}
   {{- if or .Values.image.pullSecrets .Values.global.imagePullSecrets }}
   imagePullSecrets:
-    {{- include "grafana.imagePullSecrets" (dict "Values" .Values "imagePullSecrets" .Values.image.pullSecrets) | indent 4 }}
+    {{- include "grafana.imagePullSecrets" (dict "root" $root "imagePullSecrets" .Values.image.pullSecrets) | indent 4 }}
   {{- end }}
   {{- with .Values.nodeSelector }}
   nodeSelector:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1,3 +1,17 @@
+global:
+  # To help compatibility with other charts which use global.imagePullSecrets.
+  # Allow either an array of {name: pullSecret} maps (k8s-style), or an array of strings (more common helm-style).
+  # global:
+  #   imagePullSecrets:
+  #   - name: pullSecret1
+  #   - name: pullSecret2
+  # or
+  # global:
+  #   imagePullSecrets:
+  #   - pullSecret1
+  #   - pullSecret2
+  imagePullSecrets: []
+
 rbac:
   create: true
   ## Use an existing ClusterRole/Role (depending on rbac.namespaced false/true)

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1,6 +1,7 @@
 global:
   # To help compatibility with other charts which use global.imagePullSecrets.
   # Allow either an array of {name: pullSecret} maps (k8s-style), or an array of strings (more common helm-style).
+  # Can be tempalted.
   # global:
   #   imagePullSecrets:
   #   - name: pullSecret1


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Some parent charts of grafana have global values. As a user it is confusing when global values aren't consistently used across charts.

#### Which issue this PR fixes
This PR adds support for global `imagePullSecrets`. This makes it easier for users of charts such as kube-prometheus-stack to configure custom pull secrets.

#### Special notes for your reviewer
This is my first PR to Grafana. Any feedback is greatly appreciated.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
