### PR TITLE
[grafana] Fix image.pullSecret nil pointer and fix persistence.type missing "statefulset" type

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.45.0
+version: 6.45.1
 appVersion: 9.3.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -1,4 +1,5 @@
 {{- define "grafana.pod" -}}
+{{- $sts := list "sts" "StatefulSet" "statefulset" -}}
 {{- $root := . -}}
 {{- with .Values.schedulerName }}
 schedulerName: "{{ . }}"
@@ -1013,8 +1014,8 @@ volumes:
   - name: storage
     persistentVolumeClaim:
       claimName: {{ tpl (.Values.persistence.existingClaim | default (include "grafana.fullname" .)) . }}
-  {{- else if and .Values.persistence.enabled (eq .Values.persistence.type "statefulset") }}
-  # nothing
+  {{- else if and .Values.persistence.enabled (has .Values.persistence.type $sts) }}
+  {{/* nothing */}}
   {{- else }}
   - name: storage
     {{- if .Values.persistence.inMemory.enabled }}

--- a/charts/grafana/templates/headless-service.yaml
+++ b/charts/grafana/templates/headless-service.yaml
@@ -1,4 +1,4 @@
-{{- $sts := list "sts" "StatefulSet" -}}
+{{- $sts := list "sts" "StatefulSet" "statefulset" -}}
 {{- if or .Values.headlessService (and .Values.persistence.enabled (not .Values.persistence.existingClaim) (has .Values.persistence.type $sts)) }}
 apiVersion: v1
 kind: Service

--- a/charts/grafana/templates/hpa.yaml
+++ b/charts/grafana/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- $sts := list "sts" "StatefulSet" -}}
+{{- $sts := list "sts" "StatefulSet" "statefulset" -}}
 {{- if .Values.autoscaling.enabled }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler

--- a/charts/grafana/templates/statefulset.yaml
+++ b/charts/grafana/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-{{- $sts := list "sts" "StatefulSet" -}}
+{{- $sts := list "sts" "StatefulSet" "statefulset" -}}
 {{- if (or (.Values.useStatefulSet) (and .Values.persistence.enabled (not .Values.persistence.existingClaim) (has .Values.persistence.type $sts)))}}
 apiVersion: apps/v1
 kind: StatefulSet

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -101,7 +101,7 @@ image:
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   ## Can be templated.
   ##
-  # pullSecrets:
+  pullSecrets: []
   #   - myRegistrKeySecretName
 
 testFramework:


### PR DESCRIPTION
In PR https://github.com/grafana/helm-charts/pull/1971 a change was made that converted "statefulset" to a list of "sts" and "StatefulSet". This was a breaking change, since if you supplied "statefulset" it was no longer recognized. 
This PR also fixes a nil pointer when supplying a `global.imagePullSecrets`, but not a `image.pullSecrets` that was introduced in https://github.com/grafana/helm-charts/pull/2035