### PR TITLE
[grafana] fix broken interpolation for notifier searchNamespace in grafana chart

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.45.1
+version: 6.45.2
 appVersion: 9.3.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -562,7 +562,7 @@ containers:
       - name: UNIQUE_FILENAMES
         value: "{{ .Values.sidecar.enableUniqueFilenames }}"
       {{- end }}
-      {{- if .Values.sidecar.notifiers.searchNamespace }}
+      {{- with .Values.sidecar.notifiers.searchNamespace }}
       - name: NAMESPACE
         value: "{{ tpl (. | join ",") $root }}"
       {{- end }}


### PR DESCRIPTION
- fixes #2019 
- fixes #2044 

the condition for the `searchNamespaces` interpolation when enabling the `notifiers` sidecar was incorrect after the 6.44.0 migration.
hence, the  interpolation `{{ tpl (. | join ",") $root }}` did not succeed as `.` was the entire pod context.