### PR TITLE
[loki-distributed] Update HPAs to support autoscaling/v2 schema

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.6.1
-version: 0.67.0
+version: 0.67.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.67.0](https://img.shields.io/badge/Version-0.67.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 0.67.1](https://img.shields.io/badge/Version-0.67.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/templates/distributor/hpa.yaml
+++ b/charts/loki-distributed/templates/distributor/hpa.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.distributor.autoscaling.enabled }}
-apiVersion: {{ include "loki.hpa.apiVersion" . }}
+{{- $apiVersion := include "loki.hpa.apiVersion" . -}}
+apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.distributorFullname" . }}
@@ -17,12 +18,24 @@ spec:
     - type: Resource
       resource:
         name: memory
+        {{- if (eq $apiVersion "autoscaling/v2") }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
         targetAverageUtilization: {{ . }}
+        {{- end }}
   {{- end }}
   {{- with .Values.distributor.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
+        {{- if (eq $apiVersion "autoscaling/v2") }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
         targetAverageUtilization: {{ . }}
+        {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/gateway/hpa.yaml
+++ b/charts/loki-distributed/templates/gateway/hpa.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.gateway.autoscaling.enabled }}
-apiVersion: {{ include "loki.hpa.apiVersion" . }}
+{{- $apiVersion := include "loki.hpa.apiVersion" . -}}
+apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.gatewayFullname" . }}
@@ -17,12 +18,24 @@ spec:
     - type: Resource
       resource:
         name: memory
+        {{- if (eq $apiVersion "autoscaling/v2") }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
         targetAverageUtilization: {{ . }}
+        {{- end }}
   {{- end }}
   {{- with .Values.gateway.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
+        {{- if (eq $apiVersion "autoscaling/v2") }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
         targetAverageUtilization: {{ . }}
+        {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/ingester/hpa.yaml
+++ b/charts/loki-distributed/templates/ingester/hpa.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingester.autoscaling.enabled }}
-apiVersion: {{ include "loki.hpa.apiVersion" . }}
+{{- $apiVersion := include "loki.hpa.apiVersion" . -}}
+apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.ingesterFullname" . }}
@@ -17,12 +18,24 @@ spec:
     - type: Resource
       resource:
         name: memory
+        {{- if (eq $apiVersion "autoscaling/v2") }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
         targetAverageUtilization: {{ . }}
+        {{- end }}
   {{- end }}
   {{- with .Values.ingester.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
+        {{- if (eq $apiVersion "autoscaling/v2") }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
         targetAverageUtilization: {{ . }}
+        {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/querier/hpa.yaml
+++ b/charts/loki-distributed/templates/querier/hpa.yaml
@@ -1,5 +1,6 @@
 {{- if and .Values.indexGateway.enabled .Values.querier.autoscaling.enabled }}
-apiVersion: {{ include "loki.hpa.apiVersion" . }}
+{{- $apiVersion := include "loki.hpa.apiVersion" . -}}
+apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.querierFullname" . }}
@@ -17,12 +18,24 @@ spec:
     - type: Resource
       resource:
         name: memory
+        {{- if (eq $apiVersion "autoscaling/v2") }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
         targetAverageUtilization: {{ . }}
+        {{- end }}
   {{- end }}
   {{- with .Values.querier.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
+        {{- if (eq $apiVersion "autoscaling/v2") }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
         targetAverageUtilization: {{ . }}
+        {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/query-frontend/hpa.yaml
+++ b/charts/loki-distributed/templates/query-frontend/hpa.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.queryFrontend.autoscaling.enabled }}
-apiVersion: {{ include "loki.hpa.apiVersion" . }}
+{{- $apiVersion := include "loki.hpa.apiVersion" . -}}
+apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.queryFrontendFullname" . }}
@@ -17,12 +18,24 @@ spec:
     - type: Resource
       resource:
         name: memory
+        {{- if (eq $apiVersion "autoscaling/v2") }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
         targetAverageUtilization: {{ . }}
+        {{- end }}
   {{- end }}
   {{- with .Values.queryFrontend.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
+        {{- if (eq $apiVersion "autoscaling/v2") }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
         targetAverageUtilization: {{ . }}
+        {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Followup to https://github.com/grafana/helm-charts/pull/2038

I forgot that there were schema changes between `autoscaling/v2beta1` and `autoscaling/v2`. Updated HPA templates to support old and new API version. Otherwise rendering of chart with any `...autoscaling.enabled=true` will fail with
```
Failed to render chart: exit status 1: Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: [ValidationError(HorizontalPodAutoscaler.spec.metrics[0].resource): unknown field "targetAverageUtilization" in io.k8s.api.autoscaling.v2.ResourceMetricSource, ValidationError(HorizontalPodAutoscaler.spec.metrics[0].resource): missing required field "target" in io.k8s.api.autoscaling.v2.ResourceMetricSource]
```

Signed-off-by: Ihor Urazov <iurazov@healthjoy.com>