### PR TITLE
[promtail] changed condition for extraContainers

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.7.0
-version: 6.7.3
+version: 6.7.4
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 6.7.3](https://img.shields.io/badge/Version-6.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
+![Version: 6.7.4](https://img.shields.io/badge/Version-6.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/templates/_pod.tpl
+++ b/charts/promtail/templates/_pod.tpl
@@ -82,7 +82,7 @@ spec:
       resources:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- if .Values.deployment.enabled }}
+    {{- if .Values.extraContainers }}
     {{- range $name, $values := .Values.extraContainers }}
     - name: {{ $name }}
       {{ toYaml $values | nindent 6 }}


### PR DESCRIPTION
I have changed the condition for extraContainers, because previously it was working only if deployment type was enabled, usually promtail use daemonset instead of deployment. 
