### PR TITLE
[promtail] Allow to Configure Promtail Namespace

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.7.0
-version: 6.7.4
+version: 6.8.0
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 6.7.4](https://img.shields.io/badge/Version-6.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
+![Version: 6.8.0](https://img.shields.io/badge/Version-6.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 
@@ -111,6 +111,7 @@ The new release which will pick up again from the existing `positions.yaml`.
 | initContainer | list | `[]` |  |
 | livenessProbe | object | `{}` | Liveness probe |
 | nameOverride | string | `nil` | Overrides the chart's name |
+| namespace.name | string | `nil` | The name of the Namespace to deploy If not set, `.Release.Namespace` is used |
 | networkPolicy.enabled | bool | `false` | Specifies whether Network Policies should be created |
 | networkPolicy.k8sApi.cidrs | list | `[]` | Specifies specific network CIDRs you want to limit access to |
 | networkPolicy.k8sApi.port | int | `8443` | Specify the k8s API endpoint port |

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -111,7 +111,7 @@ The new release which will pick up again from the existing `positions.yaml`.
 | initContainer | list | `[]` |  |
 | livenessProbe | object | `{}` | Liveness probe |
 | nameOverride | string | `nil` | Overrides the chart's name |
-| namespace.name | string | `nil` | The name of the Namespace to deploy If not set, `.Release.Namespace` is used |
+| namespace | string | `nil` | The name of the Namespace to deploy If not set, `.Release.Namespace` is used |
 | networkPolicy.enabled | bool | `false` | Specifies whether Network Policies should be created |
 | networkPolicy.k8sApi.cidrs | list | `[]` | Specifies specific network CIDRs you want to limit access to |
 | networkPolicy.k8sApi.port | int | `8443` | Specify the k8s API endpoint port |

--- a/charts/promtail/templates/_helpers.tpl
+++ b/charts/promtail/templates/_helpers.tpl
@@ -54,7 +54,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the namespace
 */}}
 {{- define "promtail.namespaceName" -}}
-{{- default .Release.Namespace .Values.namespace.name }}
+{{- default .Release.Namespace .Values.namespace }}
 {{- end }}
 
 {{/*

--- a/charts/promtail/templates/_helpers.tpl
+++ b/charts/promtail/templates/_helpers.tpl
@@ -51,6 +51,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Create the name of the namespace
+*/}}
+{{- define "promtail.namespaceName" -}}
+{{- default .Release.Namespace .Values.namespace.name }}
+{{- end }}
+
+{{/*
 Create the name of the service account
 */}}
 {{- define "promtail.serviceAccountName" -}}

--- a/charts/promtail/templates/clusterrolebinding.yaml
+++ b/charts/promtail/templates/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ include "promtail.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "promtail.namespaceName" . }}
 roleRef:
   kind: ClusterRole
   name: {{ include "promtail.fullname" . }}

--- a/charts/promtail/templates/configmap.yaml
+++ b/charts/promtail/templates/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "promtail.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "promtail.namespaceName" . }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
 data:

--- a/charts/promtail/templates/daemonset.yaml
+++ b/charts/promtail/templates/daemonset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "promtail.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "promtail.namespaceName" . }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
   {{- with .Values.annotations }}

--- a/charts/promtail/templates/deployment.yaml
+++ b/charts/promtail/templates/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "promtail.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "promtail.namespaceName" . }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
   {{- with .Values.annotations }}

--- a/charts/promtail/templates/hpa.yaml
+++ b/charts/promtail/templates/hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "promtail.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "promtail.namespaceName" . }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
 spec:

--- a/charts/promtail/templates/networkpolicy.yaml
+++ b/charts/promtail/templates/networkpolicy.yaml
@@ -4,7 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ template "promtail.name" . }}-namespace-only
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "promtail.namespaceName" . }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
 spec:
@@ -23,7 +23,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ template "promtail.name" . }}-egress-dns
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "promtail.namespaceName" . }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
 spec:
@@ -43,7 +43,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ template "promtail.name" . }}-egress-k8s-api
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "promtail.namespaceName" . }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
 spec:
@@ -69,7 +69,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ template "promtail.name" . }}-ingress-metrics
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "promtail.namespaceName" . }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
 spec:
@@ -104,7 +104,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ template "promtail.name" . }}-egress-extra-ports
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "promtail.namespaceName" . }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
 spec:

--- a/charts/promtail/templates/role.yaml
+++ b/charts/promtail/templates/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "promtail.fullname" . }}-psp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "promtail.namespaceName" . }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
 rules:

--- a/charts/promtail/templates/rolebinding.yaml
+++ b/charts/promtail/templates/rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "promtail.fullname" . }}-psp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "promtail.namespaceName" . }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
 roleRef:

--- a/charts/promtail/templates/secret.yaml
+++ b/charts/promtail/templates/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "promtail.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "promtail.namespaceName" . }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
     {{- with .Values.secret.labels }}

--- a/charts/promtail/templates/service-extra.yaml
+++ b/charts/promtail/templates/service-extra.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "promtail.fullname" $ }}-{{ $key | lower }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "promtail.namespaceName" $ }}
   labels:
     {{- include "promtail.labels" $ | nindent 4 }}
     {{- with .labels }}

--- a/charts/promtail/templates/service-metrics.yaml
+++ b/charts/promtail/templates/service-metrics.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "promtail.fullname" . }}-metrics
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "promtail.namespaceName" . }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
 spec:

--- a/charts/promtail/templates/serviceaccount.yaml
+++ b/charts/promtail/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "promtail.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "promtail.namespaceName" . }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -118,10 +118,9 @@ rbac:
   # -- Specifies whether a PodSecurityPolicy is to be created
   pspEnabled: false
 
-namespace:
-  # -- The name of the Namespace to deploy
-  # If not set, `.Release.Namespace` is used
-  name: null
+# -- The name of the Namespace to deploy
+# If not set, `.Release.Namespace` is used
+namespace: null
 
 serviceAccount:
   # -- Specifies whether a ServiceAccount should be created

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -118,6 +118,11 @@ rbac:
   # -- Specifies whether a PodSecurityPolicy is to be created
   pspEnabled: false
 
+namespace:
+  # -- The name of the Namespace to deploy
+  # If not set, `.Release.Namespace` is used
+  name: null
+
 serviceAccount:
   # -- Specifies whether a ServiceAccount should be created
   create: true


### PR DESCRIPTION
This pull request makes it possible to configure the namespace the promtail to deploy outsides `.Release.Namespace`. It is useful if the user wrap all logging helm charts as an umbrella chart and want to deploy promtail into a different namespace.

Signed-off-by: Kirchen99 <latias_latios@126.com>