### PR TITLE
[grafana] Allow to configure HPA scaling behavior and add autoscaling for grafana-image-renderer

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.49.0
+version: 6.50.0
 appVersion: 9.3.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_helpers.tpl
+++ b/charts/grafana/templates/_helpers.tpl
@@ -145,10 +145,12 @@ Return the appropriate apiVersion for ingress.
 Return the appropriate apiVersion for Horizontal Pod Autoscaler.
 */}}
 {{- define "grafana.hpa.apiVersion" -}}
-{{- if semverCompare "<1.23-0" .Capabilities.KubeVersion.Version }}
-{{- print "autoscaling/v2beta1" }}
-{{- else }}
+{{- if $.Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler" }}
 {{- print "autoscaling/v2" }}
+{{- else if $.Capabilities.APIVersions.Has "autoscaling/v2beta2/HorizontalPodAutoscaler" }}
+{{- print "autoscaling/v2beta2" }}
+{{- else }}
+{{- print "autoscaling/v2beta1" }}
 {{- end }}
 {{- end }}
 

--- a/charts/grafana/templates/hpa.yaml
+++ b/charts/grafana/templates/hpa.yaml
@@ -26,7 +26,7 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" .Capabilities.KubeVersion.Version }}
+        {{- if eq (include "grafana.hpa.apiVersion" .) "autoscaling/v2beta1" }}
         targetAverageUtilization: {{ .Values.autoscaling.targetMemory }}
         {{- else }}
         target:
@@ -38,7 +38,7 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" .Capabilities.KubeVersion.Version }}
+        {{- if eq (include "grafana.hpa.apiVersion" .) "autoscaling/v2beta1" }}
         targetAverageUtilization: {{ .Values.autoscaling.targetCPU }}
         {{- else }}
         target:

--- a/charts/grafana/templates/hpa.yaml
+++ b/charts/grafana/templates/hpa.yaml
@@ -46,4 +46,7 @@ spec:
           averageUtilization: {{ .Values.autoscaling.targetCPU }}
         {{- end }}
     {{- end }}
+  {{- if .Values.autoscaling.behavior }}
+  behavior: {{ toYaml .Values.autoscaling.behavior | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/grafana/templates/image-renderer-deployment.yaml
+++ b/charts/grafana/templates/image-renderer-deployment.yaml
@@ -15,7 +15,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if and (not .Values.imageRenderer.autoscaling.enabled) (.Values.imageRenderer.replicas) }}
   replicas: {{ .Values.imageRenderer.replicas }}
+  {{- end }}
   revisionHistoryLimit: {{ .Values.imageRenderer.revisionHistoryLimit }}
   selector:
     matchLabels:

--- a/charts/grafana/templates/image-renderer-hpa.yaml
+++ b/charts/grafana/templates/image-renderer-hpa.yaml
@@ -1,0 +1,47 @@
+{{- if and .Values.imageRenderer.enabled .Values.imageRenderer.autoscaling.enabled }}
+apiVersion: {{ include "grafana.hpa.apiVersion" . }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "grafana.fullname" . }}-image-renderer
+  namespace: {{ include "grafana.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "grafana.name" . }}-image-renderer
+    helm.sh/chart: {{ include "grafana.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "grafana.fullname" . }}-image-renderer
+  minReplicas: {{ .Values.imageRenderer.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.imageRenderer.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.imageRenderer.autoscaling.targetMemory }}
+    - type: Resource
+      resource:
+        name: memory
+        {{- if eq (include "grafana.hpa.apiVersion" .) "autoscaling/v2beta1" }}
+        targetAverageUtilization: {{ .Values.imageRenderer.autoscaling.targetMemory }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.imageRenderer.autoscaling.targetMemory }}
+        {{- end }}
+    {{- end }}
+    {{- if .Values.imageRenderer.autoscaling.targetCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        {{- if eq (include "grafana.hpa.apiVersion" .) "autoscaling/v2beta1" }}
+        targetAverageUtilization: {{ .Values.imageRenderer.autoscaling.targetCPU }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.imageRenderer.autoscaling.targetCPU }}
+        {{- end }}
+    {{- end }}
+  {{- if .Values.imageRenderer.autoscaling.behavior }}
+  behavior: {{ toYaml .Values.imageRenderer.autoscaling.behavior | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1009,6 +1009,13 @@ imageRenderer:
   # Enable the image-renderer deployment & service
   enabled: false
   replicas: 1
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPU: "60"
+    targetMemory: ""
+    behavior: {}
   image:
     # image-renderer Image repository
     repository: grafana/grafana-image-renderer

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -52,6 +52,7 @@ autoscaling:
   maxReplicas: 5
   targetCPU: "60"
   targetMemory: ""
+  behavior: {}
 
 ## See `kubectl explain poddisruptionbudget.spec` for more
 ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/


### PR DESCRIPTION
* Update the `grafana.hpa.apiVersion` helper to support the `autoscaling/v2beta2` API
* Update the Grafana HPA to allow configuring scaling behavior
* Add optional autoscaling for the `grafana-image-renderer`deployment