### PR TITLE
[tempo-distributed] feat: Enable usage of private docker registry

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.27.15
+version: 0.27.16
 appVersion: 1.5.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.27.15](https://img.shields.io/badge/Version-0.27.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.27.16](https://img.shields.io/badge/Version-0.27.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -226,6 +226,7 @@ The memcached default args are removed and should be provided manually. The sett
 | compactor.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the compactor pods |
 | compactor.extraVolumeMounts | list | `[]` | Extra volumes for compactor pods |
 | compactor.extraVolumes | list | `[]` | Extra volumes for compactor deployment |
+| compactor.image.pullSecrets | list | `[]` | Optional list of imagePullSecrets. Overrides `tempo.image.pullSecrets` |
 | compactor.image.registry | string | `nil` | The Docker registry for the compactor image. Overrides `tempo.image.registry` |
 | compactor.image.repository | string | `nil` | Docker image repository for the compactor image. Overrides `tempo.image.repository` |
 | compactor.image.tag | string | `nil` | Docker image tag for the compactor image. Overrides `tempo.image.tag` |
@@ -257,6 +258,7 @@ The memcached default args are removed and should be provided manually. The sett
 | distributor.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the distributor pods |
 | distributor.extraVolumeMounts | list | `[]` | Extra volumes for distributor pods |
 | distributor.extraVolumes | list | `[]` | Extra volumes for distributor deployment |
+| distributor.image.pullSecrets | list | `[]` | Optional list of imagePullSecrets. Overrides `tempo.image.pullSecrets` |
 | distributor.image.registry | string | `nil` | The Docker registry for the ingester image. Overrides `tempo.image.registry` |
 | distributor.image.repository | string | `nil` | Docker image repository for the ingester image. Overrides `tempo.image.repository` |
 | distributor.image.tag | string | `nil` | Docker image tag for the ingester image. Overrides `tempo.image.tag` |
@@ -331,6 +333,7 @@ The memcached default args are removed and should be provided manually. The sett
 | gateway.extraVolumeMounts | list | `[]` | Volume mounts to add to the gateway pods |
 | gateway.extraVolumes | list | `[]` | Volumes to add to the gateway pods |
 | gateway.image.pullPolicy | string | `"IfNotPresent"` | The gateway image pull policy |
+| gateway.image.pullSecrets | list | `[]` | Optional list of imagePullSecrets. Overrides `global.image.pullSecrets` |
 | gateway.image.registry | string | `nil` | The Docker registry for the gateway image. Overrides `global.image.registry` |
 | gateway.image.repository | string | `"nginxinc/nginx-unprivileged"` | The gateway image repository |
 | gateway.image.tag | string | `"1.19-alpine"` | The gateway image tag |
@@ -367,6 +370,7 @@ The memcached default args are removed and should be provided manually. The sett
 | global.clusterDomain | string | `"cluster.local"` | configures cluster domain ("cluster.local" by default) |
 | global.dnsNamespace | string | `"kube-system"` | configures DNS service namespace |
 | global.dnsService | string | `"kube-dns"` | configures DNS service name |
+| global.image.pullSecrets | list | `[]` | Optional list of imagePullSecrets for all images, excluding enterprise. Names of existing secrets with private container registry credentials. Ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod Example: pullSecrets: [ my-dockerconfigjson-secret ] |
 | global.image.registry | string | `"docker.io"` | Overrides the Docker registry globally for all images, excluding enterprise. |
 | global.priorityClassName | string | `nil` | Overrides the priorityClassName for all pods |
 | global_overrides.per_tenant_override_config | string | `"/conf/overrides.yaml"` |  |
@@ -390,6 +394,7 @@ The memcached default args are removed and should be provided manually. The sett
 | ingester.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the ingester pods |
 | ingester.extraVolumeMounts | list | `[]` | Extra volumes for ingester pods |
 | ingester.extraVolumes | list | `[]` | Extra volumes for ingester deployment |
+| ingester.image.pullSecrets | list | `[]` | Optional list of imagePullSecrets. Overrides `tempo.image.pullSecrets` |
 | ingester.image.registry | string | `nil` | The Docker registry for the ingester image. Overrides `tempo.image.registry` |
 | ingester.image.repository | string | `nil` | Docker image repository for the ingester image. Overrides `tempo.image.repository` |
 | ingester.image.tag | string | `nil` | Docker image tag for the ingester image. Overrides `tempo.image.tag` |
@@ -417,6 +422,7 @@ The memcached default args are removed and should be provided manually. The sett
 | memcached.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to memcached pods |
 | memcached.host | string | `"memcached"` |  |
 | memcached.image.pullPolicy | string | `"IfNotPresent"` | Memcached Docker image pull policy |
+| memcached.image.pullSecrets | list | `[]` | Optional list of imagePullSecrets. Overrides `global.image.pullSecrets` |
 | memcached.image.registry | string | `nil` | The Docker registry for the Memcached image. Overrides `global.image.registry` |
 | memcached.image.repository | string | `"memcached"` | Memcached Docker image repository |
 | memcached.image.tag | string | `"1.5.17-alpine"` | Memcached Docker image tag |
@@ -427,6 +433,7 @@ The memcached default args are removed and should be provided manually. The sett
 | memcached.service.annotations | object | `{}` | Annotations for memcached service |
 | memcachedExporter.enabled | bool | `false` | Specifies whether the Memcached Exporter should be enabled |
 | memcachedExporter.image.pullPolicy | string | `"IfNotPresent"` | Memcached Exporter Docker image pull policy |
+| memcachedExporter.image.pullSecrets | list | `[]` | Optional list of imagePullSecrets. Overrides `global.image.pullSecrets` |
 | memcachedExporter.image.registry | string | `nil` | The Docker registry for the Memcached Exporter image. Overrides `global.image.registry` |
 | memcachedExporter.image.repository | string | `"prom/memcached-exporter"` | Memcached Exporter Docker image repository |
 | memcachedExporter.image.tag | string | `"v0.8.0"` | Memcached Exporter Docker image tag |
@@ -477,6 +484,7 @@ The memcached default args are removed and should be provided manually. The sett
 | metricsGenerator.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the metrics-generator pods |
 | metricsGenerator.extraVolumeMounts | list | `[]` | Extra volumes for metrics-generator pods |
 | metricsGenerator.extraVolumes | list | `[]` | Extra volumes for metrics-generator deployment |
+| metricsGenerator.image.pullSecrets | list | `[]` | Optional list of imagePullSecrets. Overrides `tempo.image.pullSecrets` |
 | metricsGenerator.image.registry | string | `nil` | The Docker registry for the metrics-generator image. Overrides `tempo.image.registry` |
 | metricsGenerator.image.repository | string | `nil` | Docker image repository for the metrics-generator image. Overrides `tempo.image.repository` |
 | metricsGenerator.image.tag | string | `nil` | Docker image tag for the metrics-generator image. Overrides `tempo.image.tag` |
@@ -529,6 +537,7 @@ The memcached default args are removed and should be provided manually. The sett
 | querier.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the querier pods |
 | querier.extraVolumeMounts | list | `[]` | Extra volumes for querier pods |
 | querier.extraVolumes | list | `[]` | Extra volumes for querier deployment |
+| querier.image.pullSecrets | list | `[]` | Optional list of imagePullSecrets. Overrides `tempo.image.pullSecrets` |
 | querier.image.registry | string | `nil` | The Docker registry for the querier image. Overrides `tempo.image.registry` |
 | querier.image.repository | string | `nil` | Docker image repository for the querier image. Overrides `tempo.image.repository` |
 | querier.image.tag | string | `nil` | Docker image tag for the querier image. Overrides `tempo.image.tag` |
@@ -554,6 +563,7 @@ The memcached default args are removed and should be provided manually. The sett
 | queryFrontend.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the query-frontend pods |
 | queryFrontend.extraVolumeMounts | list | `[]` | Extra volumes for query-frontend pods |
 | queryFrontend.extraVolumes | list | `[]` | Extra volumes for query-frontend deployment |
+| queryFrontend.image.pullSecrets | list | `[]` | Optional list of imagePullSecrets. Overrides `tempo.image.pullSecrets` |
 | queryFrontend.image.registry | string | `nil` | The Docker registry for the query-frontend image. Overrides `tempo.image.registry` |
 | queryFrontend.image.repository | string | `nil` | Docker image repository for the query-frontend image. Overrides `tempo.image.repository` |
 | queryFrontend.image.tag | string | `nil` | Docker image tag for the query-frontend image. Overrides `tempo.image.tag` |
@@ -568,6 +578,7 @@ The memcached default args are removed and should be provided manually. The sett
 | queryFrontend.query.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the tempo-query pods |
 | queryFrontend.query.extraVolumeMounts | list | `[]` | Extra volumes for tempo-query pods |
 | queryFrontend.query.extraVolumes | list | `[]` | Extra volumes for tempo-query deployment |
+| queryFrontend.query.image.pullSecrets | list | `[]` | Optional list of imagePullSecrets. Overrides `tempo.image.pullSecrets` |
 | queryFrontend.query.image.registry | string | `nil` | The Docker registry for the query-frontend image. Overrides `tempo.image.registry` |
 | queryFrontend.query.image.repository | string | `"grafana/tempo-query"` | Docker image repository for the query-frontend image. Overrides `tempo.image.repository` |
 | queryFrontend.query.image.tag | string | `nil` | Docker image tag for the query-frontend image. Overrides `tempo.image.tag` |
@@ -595,6 +606,7 @@ The memcached default args are removed and should be provided manually. The sett
 | serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template |
 | storage.trace.backend | string | `"local"` | The supported storage backends are gcs, s3 and azure, as specified in https://grafana.com/docs/tempo/latest/configuration/#storage |
 | tempo.image.pullPolicy | string | `"IfNotPresent"` |  |
+| tempo.image.pullSecrets | list | `[]` | Optional list of imagePullSecrets. Overrides `global.image.pullSecrets` |
 | tempo.image.registry | string | `"docker.io"` | The Docker registry |
 | tempo.image.repository | string | `"grafana/tempo"` | Docker image repository |
 | tempo.image.tag | string | `nil` | Overrides the image tag whose default is the chart's appVersion |

--- a/charts/tempo-distributed/templates/_helpers.tpl
+++ b/charts/tempo-distributed/templates/_helpers.tpl
@@ -35,6 +35,19 @@ Docker image selector for Tempo. Hierachy based on global, component, and tempo 
 {{- end -}}
 
 {{/*
+Optional list of imagePullSecrets for Tempo docker images
+*/}}
+{{- define "tempo.imagePullSecrets" -}}
+{{- $imagePullSecrets := coalesce .global.pullSecrets .component.pullSecrets .tempo.pullSecrets -}}
+{{- if $imagePullSecrets  -}}
+imagePullSecrets:
+{{- range $imagePullSecrets }}
+  - name: {{ . }}
+{{ end }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "tempo.chart" -}}

--- a/charts/tempo-distributed/templates/compactor/_helpers-compactor.tpl
+++ b/charts/tempo-distributed/templates/compactor/_helpers-compactor.tpl
@@ -1,0 +1,7 @@
+{{/*
+compactor imagePullSecrets
+*/}}
+{{- define "tempo.compactorImagePullSecrets" -}}
+{{- $dict := dict "tempo" .Values.tempo.image "component" .Values.compactor.image "global" .Values.global.image -}}
+{{- include "tempo.imagePullSecrets" $dict -}}
+{{- end }}

--- a/charts/tempo-distributed/templates/compactor/deployment-compactor.yaml
+++ b/charts/tempo-distributed/templates/compactor/deployment-compactor.yaml
@@ -49,6 +49,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       enableServiceLinks: false
+      {{- include "tempo.compactorImagePullSecrets" . | nindent 6 -}}
       containers:
         - args:
             - -target=compactor

--- a/charts/tempo-distributed/templates/distributor/_helpers-distributor.tpl
+++ b/charts/tempo-distributed/templates/distributor/_helpers-distributor.tpl
@@ -1,0 +1,7 @@
+{{/*
+distributor imagePullSecrets
+*/}}
+{{- define "tempo.distributorImagePullSecrets" -}}
+{{- $dict := dict "tempo" .Values.tempo.image "component" .Values.distributor.image "global" .Values.global.image -}}
+{{- include "tempo.imagePullSecrets" $dict -}}
+{{- end }}

--- a/charts/tempo-distributed/templates/distributor/deployment-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/deployment-distributor.yaml
@@ -47,6 +47,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       enableServiceLinks: false
+      {{- include "tempo.distributorImagePullSecrets" . | nindent 6 -}}
       containers:
         - args:
             - -target=distributor

--- a/charts/tempo-distributed/templates/gateway/_helpers-gateway.tpl
+++ b/charts/tempo-distributed/templates/gateway/_helpers-gateway.tpl
@@ -13,3 +13,11 @@ gateway image
 {{- $dict := dict "tempo" (dict) "service" .Values.gateway.image "global" .Values.global.image -}}
 {{- include "tempo.tempoImage" $dict -}}
 {{- end }}
+
+{{/*
+gateway imagePullSecrets
+*/}}
+{{- define "tempo.gatewayImagePullSecrets" -}}
+{{- $dict := dict "service" .Values.gateway.image "global" .Values.global.image "tempo" (dict) -}}
+{{- include "tempo.imagePullSecrets" $dict -}}
+{{- end }}

--- a/charts/tempo-distributed/templates/gateway/deployment-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/deployment-gateway.yaml
@@ -44,6 +44,7 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.gateway.terminationGracePeriodSeconds }}
       enableServiceLinks: false
+      {{- include "tempo.gatewayImagePullSecrets" . | nindent 6 -}}
       containers:
         - name: nginx
           image: "{{ include "tempo.imageReference" $dict }}"

--- a/charts/tempo-distributed/templates/ingester/_helpers-ingester.tpl
+++ b/charts/tempo-distributed/templates/ingester/_helpers-ingester.tpl
@@ -1,0 +1,7 @@
+{{/*
+ingester imagePullSecrets
+*/}}
+{{- define "tempo.ingesterImagePullSecrets" -}}
+{{- $dict := dict "tempo" .Values.tempo.image "component" .Values.ingester.image "global" .Values.global.image -}}
+{{- include "tempo.imagePullSecrets" $dict -}}
+{{- end }}

--- a/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
@@ -50,6 +50,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       enableServiceLinks: false
+      {{- include "tempo.ingesterImagePullSecrets" . | nindent 6 -}}
       containers:
         - args:
             - -target=ingester

--- a/charts/tempo-distributed/templates/memcached/_helpers-memcached.tpl
+++ b/charts/tempo-distributed/templates/memcached/_helpers-memcached.tpl
@@ -1,0 +1,7 @@
+{{/*
+memcachedExporter imagePullSecrets
+*/}}
+{{- define "tempo.memcachedExporterImagePullSecrets" -}}
+{{- $dict := dict "component" .Values.memcachedExporter.image "global" .Values.global.image "tempo" (dict) -}}
+{{- include "tempo.imagePullSecrets" $dict -}}
+{{- end }}

--- a/charts/tempo-distributed/templates/memcached/statefulset-memcached.yaml
+++ b/charts/tempo-distributed/templates/memcached/statefulset-memcached.yaml
@@ -46,6 +46,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       enableServiceLinks: false
+      {{- include "tempo.memcachedExporterImagePullSecrets" . | nindent 6 -}}
       containers:
         - image: {{ include "tempo.imageReference" $dict }}
           imagePullPolicy: {{ .Values.memcached.image.pullPolicy }}

--- a/charts/tempo-distributed/templates/metrics-generator/_helpers-metrics-generator.tpl
+++ b/charts/tempo-distributed/templates/metrics-generator/_helpers-metrics-generator.tpl
@@ -1,0 +1,7 @@
+{{/*
+metrics-generator imagePullSecrets
+*/}}
+{{- define "tempo.metricsGeneratorImagePullSecrets" -}}
+{{- $dict := dict "tempo" .Values.tempo.image "component" .Values.metricsGenerator.image "global" .Values.global.image -}}
+{{- include "tempo.imagePullSecrets" $dict -}}
+{{- end }}

--- a/charts/tempo-distributed/templates/metrics-generator/deployment-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/deployment-metrics-generator.yaml
@@ -43,6 +43,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       enableServiceLinks: false
+      {{- include "tempo.metricsGeneratorImagePullSecrets" . | nindent 6 -}}
       containers:
         - args:
             - -target=metrics-generator

--- a/charts/tempo-distributed/templates/querier/_helpers-querier.tpl
+++ b/charts/tempo-distributed/templates/querier/_helpers-querier.tpl
@@ -1,0 +1,7 @@
+{{/*
+querier imagePullSecrets
+*/}}
+{{- define "tempo.querierImagePullSecrets" -}}
+{{- $dict := dict "tempo" .Values.tempo.image "component" .Values.querier.image "global" .Values.global.image -}}
+{{- include "tempo.imagePullSecrets" $dict -}}
+{{- end }}

--- a/charts/tempo-distributed/templates/querier/deployment-querier.yaml
+++ b/charts/tempo-distributed/templates/querier/deployment-querier.yaml
@@ -51,6 +51,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       enableServiceLinks: false
+      {{- include "tempo.querierImagePullSecrets" . | nindent 6 -}}
       containers:
         - args:
             - -target=querier

--- a/charts/tempo-distributed/templates/query-frontend/_helpers-query-frontend.tpl
+++ b/charts/tempo-distributed/templates/query-frontend/_helpers-query-frontend.tpl
@@ -5,3 +5,19 @@ query image
 {{- $dict := dict "tempo" .Values.tempo.image "component" .Values.queryFrontend.query.image "global" .Values.global.image "defaultVersion" .Chart.AppVersion -}}
 {{- include "tempo.tempoImage" $dict -}}
 {{- end }}
+
+{{/*
+queryFrontend imagePullSecrets
+*/}}
+{{- define "tempo.queryFrontendImagePullSecrets" -}}
+{{- $dict := dict "tempo" .Values.tempo.image "component" .Values.queryFrontend.image "global" .Values.global.image -}}
+{{- include "tempo.imagePullSecrets" $dict -}}
+{{- end }}
+
+{{/*
+query imagePullSecrets
+*/}}
+{{- define "tempo.queryImagePullSecrets" -}}
+{{- $dict := dict "tempo" .Values.tempo.image "component" .Values.queryFrontend.query.image "global" .Values.global.image -}}
+{{- include "tempo.imagePullSecrets" $dict -}}
+{{- end }}

--- a/charts/tempo-distributed/templates/query-frontend/deployment-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/deployment-query-frontend.yaml
@@ -51,6 +51,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       enableServiceLinks: false
+      {{- include "tempo.queryImagePullSecrets" . | nindent 6 -}}
       containers:
         - args:
             - -target=query-frontend

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -2,6 +2,12 @@ global:
   image:
     # -- Overrides the Docker registry globally for all images, excluding enterprise.
     registry: docker.io
+    # -- Optional list of imagePullSecrets for all images, excluding enterprise.
+    # Names of existing secrets with private container registry credentials.
+    # Ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+    # Example:
+    # pullSecrets: [ my-dockerconfigjson-secret ]
+    pullSecrets: []
   # -- Overrides the priorityClassName for all pods
   priorityClassName: null
   # -- configures cluster domain ("cluster.local" by default)
@@ -34,6 +40,8 @@ tempo:
   image:
     # -- The Docker registry
     registry: docker.io
+    # -- Optional list of imagePullSecrets. Overrides `global.image.pullSecrets`
+    pullSecrets: []
     # -- Docker image repository
     repository: grafana/tempo
     # -- Overrides the image tag whose default is the chart's appVersion
@@ -106,6 +114,8 @@ ingester:
   image:
     # -- The Docker registry for the ingester image. Overrides `tempo.image.registry`
     registry: null
+    # -- Optional list of imagePullSecrets. Overrides `tempo.image.pullSecrets`
+    pullSecrets: []
     # -- Docker image repository for the ingester image. Overrides `tempo.image.repository`
     repository: null
     # -- Docker image tag for the ingester image. Overrides `tempo.image.tag`
@@ -200,6 +210,8 @@ metricsGenerator:
   image:
     # -- The Docker registry for the metrics-generator image. Overrides `tempo.image.registry`
     registry: null
+    # -- Optional list of imagePullSecrets. Overrides `tempo.image.pullSecrets`
+    pullSecrets: []
     # -- Docker image repository for the metrics-generator image. Overrides `tempo.image.repository`
     repository: null
     # -- Docker image tag for the metrics-generator image. Overrides `tempo.image.tag`
@@ -316,6 +328,8 @@ distributor:
   image:
     # -- The Docker registry for the ingester image. Overrides `tempo.image.registry`
     registry: null
+    # -- Optional list of imagePullSecrets. Overrides `tempo.image.pullSecrets`
+    pullSecrets: []
     # -- Docker image repository for the ingester image. Overrides `tempo.image.repository`
     repository: null
     # -- Docker image tag for the ingester image. Overrides `tempo.image.tag`
@@ -393,6 +407,8 @@ compactor:
   image:
     # -- The Docker registry for the compactor image. Overrides `tempo.image.registry`
     registry: null
+    # -- Optional list of imagePullSecrets. Overrides `tempo.image.pullSecrets`
+    pullSecrets: []
     # -- Docker image repository for the compactor image. Overrides `tempo.image.repository`
     repository: null
     # -- Docker image tag for the compactor image. Overrides `tempo.image.tag`
@@ -453,6 +469,8 @@ querier:
   image:
     # -- The Docker registry for the querier image. Overrides `tempo.image.registry`
     registry: null
+    # -- Optional list of imagePullSecrets. Overrides `tempo.image.pullSecrets`
+    pullSecrets: []
     # -- Docker image repository for the querier image. Overrides `tempo.image.repository`
     repository: null
     # -- Docker image tag for the querier image. Overrides `tempo.image.tag`
@@ -517,6 +535,8 @@ queryFrontend:
     image:
       # -- The Docker registry for the query-frontend image. Overrides `tempo.image.registry`
       registry: null
+      # -- Optional list of imagePullSecrets. Overrides `tempo.image.pullSecrets`
+      pullSecrets: []
       # -- Docker image repository for the query-frontend image. Overrides `tempo.image.repository`
       repository: grafana/tempo-query
       # -- Docker image tag for the query-frontend image. Overrides `tempo.image.tag`
@@ -551,6 +571,8 @@ queryFrontend:
   image:
     # -- The Docker registry for the query-frontend image. Overrides `tempo.image.registry`
     registry: null
+    # -- Optional list of imagePullSecrets. Overrides `tempo.image.pullSecrets`
+    pullSecrets: []
     # -- Docker image repository for the query-frontend image. Overrides `tempo.image.repository`
     repository: null
     # -- Docker image tag for the query-frontend image. Overrides `tempo.image.tag`
@@ -924,6 +946,8 @@ memcached:
   image:
     # -- The Docker registry for the Memcached image. Overrides `global.image.registry`
     registry: null
+    # -- Optional list of imagePullSecrets. Overrides `global.image.pullSecrets`
+    pullSecrets: []
     # -- Memcached Docker image repository
     repository: memcached
     # -- Memcached Docker image tag
@@ -971,6 +995,8 @@ memcachedExporter:
   image:
     # -- The Docker registry for the Memcached Exporter image. Overrides `global.image.registry`
     registry: null
+    # -- Optional list of imagePullSecrets. Overrides `global.image.pullSecrets`
+    pullSecrets: []
     # -- Memcached Exporter Docker image repository
     repository: prom/memcached-exporter
     # -- Memcached Exporter Docker image tag
@@ -1154,6 +1180,8 @@ gateway:
   image:
     # -- The Docker registry for the gateway image. Overrides `global.image.registry`
     registry: null
+    # -- Optional list of imagePullSecrets. Overrides `global.image.pullSecrets`
+    pullSecrets: []
     # -- The gateway image repository
     repository: nginxinc/nginx-unprivileged
     # -- The gateway image tag


### PR DESCRIPTION
There are many reasons to not use docker.io public registry, e.g.:
- docker.io pull rate limit is really low and this release usually pulls 10 or more images. Ref: https://www.docker.com/increase-rate-limits/
- to use modified images from private registry

This can be enabled by simply adding imagePullSecrets

ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod