### PR TITLE
[tempo-distributed] feat: add flags for compaction configs

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.27.11
+version: 0.27.12
 appVersion: 1.5.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.27.11](https://img.shields.io/badge/Version-0.27.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.27.12](https://img.shields.io/badge/Version-0.27.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -218,6 +218,9 @@ The memcached default args are removed and should be provided manually. The sett
 | adminApi.terminationGracePeriodSeconds | int | `60` |  |
 | adminApi.tolerations | list | `[]` |  |
 | compactor.config.compaction.block_retention | string | `"48h"` | Duration to keep blocks |
+| compactor.config.compaction.compaction_cycle | string | `"30s"` | The time between compaction cycles |
+| compactor.config.compaction.iterator_buffer_size | int | `1000` | Number of traces to buffer in memory during compaction |
+| compactor.config.compaction.max_time_per_tenant | string | `"5m"` | tenant before moving to the next |
 | compactor.extraArgs | list | `[]` | Additional CLI args for the compactor |
 | compactor.extraEnv | list | `[]` | Environment variables to add to the compactor pods |
 | compactor.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the compactor pods |

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -425,6 +425,13 @@ compactor:
     compaction:
       # -- Duration to keep blocks
       block_retention: 48h
+      # -- Number of traces to buffer in memory during compaction
+      iterator_buffer_size: 1000
+      # -- The maximum amount of time to spend compacting a single
+      # -- tenant before moving to the next
+      max_time_per_tenant: 5m
+      # -- The time between compaction cycles
+      compaction_cycle: 30s
   service:
     # -- Annotations for compactor service
     annotations: {}
@@ -714,6 +721,9 @@ config: |
   compactor:
     compaction:
       block_retention: {{ .Values.compactor.config.compaction.block_retention }}
+      iterator_buffer_size: {{ .Values.compactor.config.compaction.iterator_buffer_size }}
+      max_time_per_tenant: {{ .Values.compactor.config.compaction.max_time_per_tenant }}
+      compaction_cycle: {{ .Values.compactor.config.compaction.compaction_cycle }}
     ring:
       kvstore:
         store: memberlist


### PR DESCRIPTION
The Tempo compactor offers several flags to customize the compactor's behavior: https://grafana.com/docs/tempo/latest/configuration/#compactor

This PR allows us to pass these flags into the `values.yaml` file so that we can override the flags as needed.

Checklist

 - [x] DCO signed
 - [x] Chart Version bumped
 - [x] Title of the PR starts with chart name (e.g. [tempo-distributed])
