### PR TITLE
[tempo-distributed] fix(docs): typo on compactor.config.compaction.max_time_per_tenant flag

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.27.14
+version: 0.27.15
 appVersion: 1.5.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.27.13
+version: 0.27.14
 appVersion: 1.5.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.27.14](https://img.shields.io/badge/Version-0.27.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.27.15](https://img.shields.io/badge/Version-0.27.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.27.13](https://img.shields.io/badge/Version-0.27.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.27.14](https://img.shields.io/badge/Version-0.27.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -220,7 +220,7 @@ The memcached default args are removed and should be provided manually. The sett
 | compactor.config.compaction.block_retention | string | `"48h"` | Duration to keep blocks |
 | compactor.config.compaction.compaction_cycle | string | `"30s"` | The time between compaction cycles |
 | compactor.config.compaction.iterator_buffer_size | int | `1000` | Number of traces to buffer in memory during compaction |
-| compactor.config.compaction.max_time_per_tenant | string | `"5m"` | tenant before moving to the next |
+| compactor.config.compaction.max_time_per_tenant | string | `"5m"` | The maximum amount of time to spend compacting a single tenant before moving to the next |
 | compactor.extraArgs | list | `[]` | Additional CLI args for the compactor |
 | compactor.extraEnv | list | `[]` | Environment variables to add to the compactor pods |
 | compactor.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the compactor pods |

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -427,8 +427,7 @@ compactor:
       block_retention: 48h
       # -- Number of traces to buffer in memory during compaction
       iterator_buffer_size: 1000
-      # -- The maximum amount of time to spend compacting a single
-      # -- tenant before moving to the next
+      # -- The maximum amount of time to spend compacting a single tenant before moving to the next
       max_time_per_tenant: 5m
       # -- The time between compaction cycles
       compaction_cycle: 30s


### PR DESCRIPTION
This is a followup from my earlier MR: https://github.com/grafana/helm-charts/pull/2086

I accidentally omitted part of the documentation for the `compactor.config.compaction.max_time_per_tenant` flag

Checklist

 - [x] DCO signed
 - [x] Chart Version bumped
 - [x] Title of the PR starts with chart name (e.g. [tempo-distributed])