### PR TITLE
[tempo] Introduce appProtocol, HTTPS for ServiceMonitor, and RemoteWrite headers

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 0.16.8
+version: 0.17.0
 appVersion: 1.5.0
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 0.16.8](https://img.shields.io/badge/Version-0.16.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 
@@ -36,10 +36,15 @@ Grafana Tempo Single Binary Mode
 | serviceAccount.imagePullSecrets | list | `[]` | Image pull secrets for the service account |
 | serviceAccount.labels | object | `{}` | Labels for the service account |
 | serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template |
-| serviceMonitor.additionalLabels | object | `{}` |  |
-| serviceMonitor.annotations | object | `{}` |  |
+| serviceMonitor.additionalLabels | object | `{}` | Additional ServiceMonitor labels |
+| serviceMonitor.annotations | object | `{}` | ServiceMonitor annotations |
+| serviceMonitor.appProtocol | string | `nil` | App protocol for the metrics port, required for Istio to work properly |
 | serviceMonitor.enabled | bool | `false` |  |
-| serviceMonitor.interval | string | `""` |  |
+| serviceMonitor.interval | string | `nil` | ServiceMonitor scrape interval in Go duration format (e.g. 15s) |
+| serviceMonitor.scheme | string | `nil` | ServiceMonitor will use http by default, but you can pick https as well |
+| serviceMonitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
+| serviceMonitor.targetLabels | list | `[]` | ServiceMonitor will add labels from the service to the Prometheus metric |
+| serviceMonitor.tlsConfig | string | `nil` | ServiceMonitor will use these tlsConfig settings when scheme is https |
 | tempo.extraArgs | object | `{}` |  |
 | tempo.extraEnv | list | `[]` | Environment variables to add |
 | tempo.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the ingester pods |
@@ -48,6 +53,7 @@ Grafana Tempo Single Binary Mode
 | tempo.ingester | object | `{}` | Configuration options for the ingester |
 | tempo.memBallastSizeMbs | int | `1024` |  |
 | tempo.metricsGenerator.enabled | bool | `false` | If true, enables Tempo's metrics generator (https://grafana.com/docs/tempo/next/metrics-generator/) |
+| tempo.metricsGenerator.remoteWriteHeaders | object | `{}` | Map of HTTP headers to include in remote write requests |
 | tempo.metricsGenerator.remoteWriteUrl | string | `"http://prometheus.monitoring:9090/api/v1/write"` |  |
 | tempo.multitenancyEnabled | bool | `false` |  |
 | tempo.overrides | object | `{}` |  |

--- a/charts/tempo/templates/service.yaml
+++ b/charts/tempo/templates/service.yaml
@@ -35,6 +35,9 @@ spec:
   - name: tempo-prom-metrics
     port: 3100
     targetPort: 3100
+    {{- with .Values.serviceMonitor.appProtocol }}
+    appProtocol: {{ . }}
+    {{- end }}
   {{- if .Values.tempoQuery.enabled }}
   - name: jaeger-metrics
     port: 16687

--- a/charts/tempo/templates/service.yaml
+++ b/charts/tempo/templates/service.yaml
@@ -42,6 +42,9 @@ spec:
   - name: jaeger-metrics
     port: 16687
     targetPort: 16687
+    {{- with .Values.serviceMonitor.appProtocol }}
+    appProtocol: {{ . }}
+    {{- end }}
   - name: tempo-query-jaeger-ui
     port: 16686
     targetPort: 16686

--- a/charts/tempo/templates/servicemonitor.yaml
+++ b/charts/tempo/templates/servicemonitor.yaml
@@ -1,40 +1,62 @@
-{{- if .Values.serviceMonitor.enabled }}
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "tempo.fullname" . }}
-  labels:
-    app: {{ template "tempo.name" . }}
-    chart: {{ template "tempo.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- if .Values.serviceMonitor.additionalLabels }}
-{{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
-    {{- end }}
-  {{- if .Values.serviceMonitor.annotations }}
+  name: {{ template "tempo.fullname" $ }}
+  {{- with .annotations }}
   annotations:
-{{ toYaml .Values.serviceMonitor.annotations | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
+  labels:
+    app: {{ template "tempo.name" $ }}
+    chart: {{ template "tempo.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+    {{- with .additionalLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
-      {{- include "tempo.labels" . | nindent 6 }}
+      {{- include "tempo.labels" $ | nindent 6 }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace | quote }}
+      - {{ $.Release.Namespace | quote }}
   endpoints:
     - port: tempo-prom-metrics
-      {{- if .Values.serviceMonitor.interval }}
-      interval: {{ .Values.serviceMonitor.interval }}
+      {{- with .interval }}
+      interval: {{ . }}
       {{- end }}
-      {{- if .Values.serviceMonitor.scrapeTimeout }}
-      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- with .scrapeTimeout }}
+      scrapeTimeout: {{ . }}
       {{- end }}
+      {{- with .scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- if $.Values.tempoQuery.enabled }}
     - port: jaeger-metrics
-      {{- if .Values.serviceMonitor.interval }}
-      interval: {{ .Values.serviceMonitor.interval }}
+      {{- with .interval }}
+      interval: {{ . }}
       {{- end }}
-      {{- if .Values.serviceMonitor.scrapeTimeout }}
-      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- with .scrapeTimeout }}
+      scrapeTimeout: {{ . }}
       {{- end }}
+      {{- with .scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+  {{- with .targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -40,6 +40,8 @@ tempo:
     # -- If true, enables Tempo's metrics generator (https://grafana.com/docs/tempo/next/metrics-generator/)
     enabled: false
     remoteWriteUrl: "http://prometheus.monitoring:9090/api/v1/write"
+    # -- Map of HTTP headers to include in remote write requests
+    remoteWriteHeaders: {}
   # -- Configuration options for the ingester
   ingester: {}
   # -- Configuration options for the querier
@@ -118,39 +120,57 @@ tempo:
 # -- Tempo configuration file contents
 # @default -- Dynamically generated tempo configmap
 config: |
-    multitenancy_enabled: {{ .Values.tempo.multitenancyEnabled }}
-    search_enabled: {{ .Values.tempo.searchEnabled }}
-    usage_report:
-      reporting_enabled: {{ .Values.tempo.reportingEnabled }}
-    metrics_generator_enabled: {{ .Values.tempo.metricsGenerator.enabled }}
-    compactor:
-      compaction:
-        block_retention: {{ .Values.tempo.retention }}
-    distributor:
-      receivers:
-        {{- toYaml .Values.tempo.receivers | nindent 8 }}
-    ingester:
-      {{- toYaml .Values.tempo.ingester | nindent 6 }}
-    server:
-      {{- toYaml .Values.tempo.server | nindent 6 }}
+  multitenancy_enabled: {{ .Values.tempo.multitenancyEnabled }}
+  search_enabled: {{ .Values.tempo.searchEnabled }}
+  usage_report:
+    reporting_enabled: {{ .Values.tempo.reportingEnabled }}
+  metrics_generator_enabled: {{ .Values.tempo.metricsGenerator.enabled }}
+  compactor:
+    compaction:
+      block_retention: {{ .Values.tempo.retention }}
+  distributor:
+    receivers:
+      {{- toYaml .Values.tempo.receivers | nindent 4 }}
+  {{- with .Values.tempo.ingester }}
+  ingester:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.tempo.server }}
+  server:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.tempo.storage }}
+  storage:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.tempo.querier }}
+  querier:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.tempo.queryFrontend }}
+  query_frontend:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- if or .Values.tempo.global_overrides .Values.tempo.metricsGenerator.enabled }}
+  overrides:
+    {{- with .Values.tempo.global_overrides }}
+    {{- toYaml . | nindent 2 }}
+    {{- end }}
+    {{- if .Values.tempo.metricsGenerator.enabled }}
+    metrics_generator_processors:
+      - 'service-graphs'
+      - 'span-metrics'
+  metrics_generator:
     storage:
-      {{- toYaml .Values.tempo.storage | nindent 6 }}
-    querier:
-      {{- toYaml .Values.tempo.querier | nindent 6 }}
-    query_frontend:
-      {{- toYaml .Values.tempo.queryFrontend | nindent 6 }}
-    overrides:
-      {{- toYaml .Values.tempo.global_overrides | nindent 6 }}
-      {{- if .Values.tempo.metricsGenerator.enabled }}
-          metrics_generator_processors:
-          - 'service-graphs'
-          - 'span-metrics'
-    metrics_generator:
-          storage:
-            path: "/tmp/tempo"
-            remote_write:
-              - url: {{ .Values.tempo.metricsGenerator.remoteWriteUrl }}
-      {{- end }}
+      path: "/tmp/tempo"
+      remote_write:
+        - url: {{ .Values.tempo.metricsGenerator.remoteWriteUrl }}
+          {{- with  .Values.tempo.metricsGenerator.remoteWriteHeaders }}
+          headers:
+            {{- . | toYaml | nindent 10 }}
+          {{- end }}
+    {{- end }}
+  {{- end }}
 
 tempoQuery:
   repository: grafana/tempo-query
@@ -210,10 +230,22 @@ service:
 
 serviceMonitor:
   enabled: false
-  interval: ""
+  # -- ServiceMonitor scrape interval in Go duration format (e.g. 15s)
+  interval: null
+  # -- ServiceMonitor scrape timeout in Go duration format (e.g. 15s)
+  scrapeTimeout: null
+  # -- ServiceMonitor will use http by default, but you can pick https as well
+  scheme: null
+  # -- ServiceMonitor will use these tlsConfig settings when scheme is https
+  tlsConfig: null
+  # -- Additional ServiceMonitor labels
   additionalLabels: {}
+  # -- ServiceMonitor annotations
   annotations: {}
-  # scrapeTimeout: 10s
+  # --ServiceMonitor will add labels from the service to the Prometheus metric
+  targetLabels: []
+  # -- App protocol for the metrics port, required for Istio to work properly
+  appProtocol: null
 
 persistence:
   enabled: false


### PR DESCRIPTION
This PR introduces changes that enable proper integration of the ServiceMonitor with the Istio service mesh.

* Introduce the `appProtocol` field on the Tempo metrics port. This should be set to `http` to allow Istio to automatically select the protocol for traffic.
* Introduce `scheme` and `tlsConfig` configuration options on the ServiceMonitor. These need to be set to HTTPS and provided with a valid certificate when Istio mTLS is in use.

Additionally, the default `tempo.config` value has been updated:
* The indentation has been fixed.
* Overrides block is now only shown if needed
* Remote Write HTTP headers may be set (this was required for our use-case where we remote write to Thanos and use an HTTP header to identify the tenancy).

This PR should be fully backwards compatible if none of the new values are enabled (beyond formatting of the configmap).