### PR TITLE
Disable helm chart signing and provenance

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,18 +24,6 @@ jobs:
         with:
           version: v3.5.2
 
-      - name: Prepare GPG key
-        run: |
-          gpg_dir=.cr-gpg
-          mkdir "$gpg_dir"
-
-          keyring="$gpg_dir/secring.gpg"
-          base64 -d <<< "$GPG_KEY_BASE64" > "$keyring"
-
-          echo "CR_KEYRING=$keyring" >> "$GITHUB_ENV"
-        env:
-          GPG_KEY_BASE64: "${{ secrets.GPG_KEY_BASE64 }}"
-
       - name: Add dependency chart repos
         run: |
           helm repo add elastic https://helm.elastic.co

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,2 +1,1 @@
-sign: true
-key: Grafana Loki
+sign: false


### PR DESCRIPTION
There are a few reasons for this:

* The GPG key being used was potentially compromised related to a recent security incident in another CI tool which had this GPG private key as a secret
* We consider these "public" helm charts, we don't want the existence of a signature to indicate a level of scrutiny or security that doesn't exist.
* The public key was never published to a key server as far as we can tell and as such we doubt anyone is actually using this as it it's extremely difficult right now to find the public key
* You should always verify changes made when updating a chart as both good operational and security practice.

In short: at best this signing provides little value, at worst a false sense of security.

Signed-off-by: Edward Welch <edward.welch@grafana.com>