### PR TITLE
[tempo-distributed] Fix issue when render chart templates

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.27.16
+version: 0.27.17
 appVersion: 1.5.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.27.16](https://img.shields.io/badge/Version-0.27.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.27.17](https://img.shields.io/badge/Version-0.27.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/gateway/_helpers-gateway.tpl
+++ b/charts/tempo-distributed/templates/gateway/_helpers-gateway.tpl
@@ -18,6 +18,6 @@ gateway image
 gateway imagePullSecrets
 */}}
 {{- define "tempo.gatewayImagePullSecrets" -}}
-{{- $dict := dict "service" .Values.gateway.image "global" .Values.global.image "tempo" (dict) -}}
+{{- $dict := dict "component" .Values.gateway.image "global" .Values.global.image "tempo" (dict) -}}
 {{- include "tempo.imagePullSecrets" $dict -}}
 {{- end }}


### PR DESCRIPTION
Re-procedure the issues:
```
$ helm template --version 0.27.16 --set gateway.enabled=true grafana/tempo-distributed
Error: template: tempo-distributed/templates/gateway/deployment-gateway.yaml:47:10: executing "tempo-distributed/templates/gateway/deployment-gateway.yaml" at <include "tempo.gatewayImagePullSecrets" .>: error calling include: template: tempo-distributed/templates/gateway/_helpers-gateway.tpl:22:4: executing "tempo.gatewayImagePullSecrets" at <include "tempo.imagePullSecrets" $dict>: error calling include: template: tempo-distributed/templates/_helpers.tpl:41:64: executing "tempo.imagePullSecrets" at <.component.pullSecrets>: nil pointer evaluating interface {}.pullSecrets

Use --debug flag to render out invalid YAML
```