### PR TITLE
[grafana] Explicit volumeClaimTemplate kind/apiVersion

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.50.0
+version: 6.50.1
 appVersion: 9.3.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/statefulset.yaml
+++ b/charts/grafana/templates/statefulset.yaml
@@ -38,7 +38,9 @@ spec:
       {{- include "grafana.pod" . | nindent 6 }}
   {{- if .Values.persistence.enabled}}
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
       name: storage
     spec:
       accessModes: {{ .Values.persistence.accessModes }}


### PR DESCRIPTION
Otherwise, I'm having a diff in ArgoCD:

```diff
     type: RollingUpdate
   volumeClaimTemplates:
-    - apiVersion: v1
-      kind: PersistentVolumeClaim
-      metadata:
+    - metadata:
        creationTimestamp: null
        name: storage
```