### PR TITLE
[grafana] fix: also include extra ports for headless svc

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.50.0
+version: 6.50.1
 appVersion: 9.3.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/headless-service.yaml
+++ b/charts/grafana/templates/headless-service.yaml
@@ -1,5 +1,6 @@
 {{- $sts := list "sts" "StatefulSet" "statefulset" -}}
 {{- if or .Values.headlessService (and .Values.persistence.enabled (not .Values.persistence.existingClaim) (has .Values.persistence.type $sts)) }}
+{{- $root := . }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -20,4 +21,7 @@ spec:
   - protocol: TCP
     port: 3000
     targetPort: {{ .Values.service.targetPort }}
+    {{- with .Values.extraExposePorts }}
+    {{- tpl (toYaml . | nindent 2) $root }}
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
particularly useful when one want to set up unified alerting in HA mode, as the various grafana instances then use the gossip protocol to exchange alerting status/silences.
as this protocol runs on port 9094, we need a way to enable this port for the headless service

https://grafana.com/docs/grafana/latest/alerting/set-up/configure-high-availability/