### PR TITLE
[loki-distributed] Fix compactor address without protocol schema

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.7.1
-version: 0.69.1
+version: 0.69.2
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.69.1](https://img.shields.io/badge/Version-0.69.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.1](https://img.shields.io/badge/AppVersion-2.7.1-informational?style=flat-square)
+![Version: 0.69.2](https://img.shields.io/badge/Version-0.69.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.1](https://img.shields.io/badge/AppVersion-2.7.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -83,7 +83,7 @@ loki:
       http_listen_port: 3100
 
     common:
-      compactor_address: {{ include "loki.compactorFullname" . }}:3100
+      compactor_address: http://{{ include "loki.compactorFullname" . }}:3100
 
     distributor:
       ring:


### PR DESCRIPTION
The previous version of loki [included](https://github.com/grafana/helm-charts/blob/5ec00d6923c3045e3c387f8367ed90193998a70c/charts/loki-distributed/values.yaml#L86) a wrong compactor address, which caused the following errors from other components:
```
level=error ts=2023-01-13T09:47:29.06565832Z caller=http.go:131 msg="error getting cache gen numbers from the store" err="Get \"loki-distributed-qa-compactor:3100\": unsupported protocol scheme \"loki-distributed-qa-compactor\""
```

This changes fix compactor address by adding `http://` protocol schema.

Related comment: https://github.com/grafana/loki/pull/3109#discussion_r551354841

Signed-off-by: junwei.liang <junwei.liang@mintegral.com>