### PR TITLE
[loki-stack] Make it possible to disable the loki test_pod.

### DIFF
--- a/charts/loki-stack/Chart.yaml
+++ b/charts/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 2.8.9
+version: 2.9.9
 appVersion: v2.6.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki-stack/templates/tests/loki-test-configmap.yaml
+++ b/charts/loki-stack/templates/tests/loki-test-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.loki.enabled }}
+{{- if (and .Values.test_pod.enabled .Values.loki.enabled) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/loki-stack/templates/tests/loki-test-pod.yaml
+++ b/charts/loki-stack/templates/tests/loki-test-pod.yaml
@@ -1,4 +1,4 @@
-{{- if (and .Values.test_pod.enabled .Values.loki.enabled) }}
+{{- if .Values.loki.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/charts/loki-stack/templates/tests/loki-test-pod.yaml
+++ b/charts/loki-stack/templates/tests/loki-test-pod.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.loki.enabled }}
+{{- if (and .Values.test_pod.enabled .Values.loki.enabled) }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/charts/loki-stack/values.yaml
+++ b/charts/loki-stack/values.yaml
@@ -1,4 +1,5 @@
 test_pod:
+  enabled: true
   image: bats/bats:v1.1.0
   pullPolicy: IfNotPresent
 

--- a/charts/loki-stack/values.yaml
+++ b/charts/loki-stack/values.yaml
@@ -1,5 +1,4 @@
 test_pod:
-  enabled: true
   image: bats/bats:v1.1.0
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
In some enterprise environments it's forbidden to let everything communicate with the internet. In such cases we need an option to disable components that want to do that to not have a broken pod in the cluster. That's why I added the option to disable the test_pod even if loki itself is enabled, expanding [#1835](https://github.com/grafana/helm-charts/pull/1835).