### PR TITLE
[tempo-distributed] Ensure that Admin Client is configured with relevant details.

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: 2.0.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -626,6 +626,7 @@ The memcached default args are removed and should be provided manually. The sett
 | serviceAccount.create | bool | `true` | Specifies whether a ServiceAccount should be created |
 | serviceAccount.imagePullSecrets | list | `[]` | Image pull secrets for the service account |
 | serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template |
+| storage.admin.backend | string | `"filesystem"` | The supported storage backends are gcs, s3 and azure, as specified in https://grafana.com/docs/enterprise-traces/latest/config/reference/#admin_client_config |
 | storage.trace.backend | string | `"local"` | The supported storage backends are gcs, s3 and azure, as specified in https://grafana.com/docs/tempo/latest/configuration/#storage |
 | tempo.image.pullPolicy | string | `"IfNotPresent"` |  |
 | tempo.image.pullSecrets | list | `[]` | Optional list of imagePullSecrets. Overrides `global.image.pullSecrets` |

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -958,27 +958,9 @@ config: |
   storage:
     trace:
       backend: {{.Values.storage.trace.backend}}
-      {{- if .Values.minio.enabled }}
-      backend: s3
-      s3:
-        access_key: {{ .Values.minio.rootUser }}
-        {{- if .Values.enterprise.enabled }}
-        {{with (index .Values.minio.buckets 1) }}
-        bucket: {{ .name }}
-        {{- end }}
-        {{ else }}
-        {{with (index .Values.minio.buckets 0) }}
-        bucket: {{ .name }}
-        {{- end }}
-        {{- end }}
-        endpoint: {{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000
-        insecure: true
-        secret_key: {{ .Values.minio.rootPassword }}
-      {{ else }}
       {{- if eq .Values.storage.trace.backend "s3"}}
       s3:
         {{- toYaml .Values.storage.trace.s3 | nindent 6}}
-      {{- end }}
       {{- end }}
       {{- if eq .Values.storage.trace.backend "gcs"}}
       gcs:

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -1029,7 +1029,7 @@ storage:
   # Settings for the Admin client storage backend and buckets. Only valid is enterprise.enabled is true.
   admin:
     # -- The supported storage backends are gcs, s3 and azure, as specified in https://grafana.com/docs/enterprise-traces/latest/config/reference/#admin_client_config
-    backend: local
+    backend: filesystem
 
 # Global overrides
 global_overrides:

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -765,22 +765,10 @@ config: |
 
   admin_client:
     storage:
-      type: {{.Values.storage.admin.backend}}
-      {{- if .Values.minio.enabled }}
-      type: s3
-      s3:
-        access_key_id: {{ .Values.minio.rootUser }}
-        {{with (index .Values.minio.buckets 2) }}
-        bucket_name: {{ .name }}
-        {{- end}}
-        endpoint: {{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000
-        insecure: true
-        secret_access_key: {{ .Values.minio.rootPassword }}
-      {{ else }}
+      backend: {{.Values.storage.admin.backend}}
       {{- if eq .Values.storage.admin.backend "s3"}}
       s3:
         {{- toYaml .Values.storage.admin.s3 | nindent 6}}
-      {{- end}}
       {{- end}}
       {{- if eq .Values.storage.admin.backend "gcs"}}
       gcs:
@@ -789,6 +777,14 @@ config: |
       {{- if eq .Values.storage.admin.backend "azure"}}
       azure:
         {{- toYaml .Values.storage.admin.azure | nindent 6}}
+      {{- end}}
+      {{- if eq .Values.storage.admin.backend "swift"}}
+      swift:
+        {{- toYaml .Values.storage.admin.swift | nindent 6}}
+      {{- end}}
+      {{- if eq .Values.storage.admin.backend "filesystem"}}
+      filesystem:
+        {{- toYaml .Values.storage.admin.filesystem | nindent 6}}
       {{- end}}
   {{- end }}
 

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -758,17 +758,38 @@ config: |
         kvstore:
           store: "memberlist"
 
-  {{- if .Values.minio.enabled }}
+  auth:
+    type: enterprise
+
+  http_api_prefix: {{get .Values.tempo.structuredConfig "http_api_prefix"}}
+
   admin_client:
     storage:
-      backend: s3
+      type: {{.Values.storage.admin.backend}}
+      {{- if .Values.minio.enabled }}
+      type: s3
       s3:
         access_key_id: {{ .Values.minio.rootUser }}
-        bucket_name: enterprise-traces-admin
+        {{with (index .Values.minio.buckets 2) }}
+        bucket_name: {{ .name }}
+        {{- end}}
         endpoint: {{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000
         insecure: true
         secret_access_key: {{ .Values.minio.rootPassword }}
-    {{- end }}
+      {{ else }}
+      {{- if eq .Values.storage.admin.backend "s3"}}
+      s3:
+        {{- toYaml .Values.storage.admin.s3 | nindent 6}}
+      {{- end}}
+      {{- end}}
+      {{- if eq .Values.storage.admin.backend "gcs"}}
+      gcs:
+        {{- toYaml .Values.storage.admin.gcs | nindent 6}}
+      {{- end}}
+      {{- if eq .Values.storage.admin.backend "azure"}}
+      azure:
+        {{- toYaml .Values.storage.admin.azure | nindent 6}}
+      {{- end}}
   {{- end }}
 
   {{- if and .Values.enterprise.enabled .Values.enterpriseGateway.useDefaultProxyURLs }}
@@ -941,18 +962,36 @@ config: |
   storage:
     trace:
       backend: {{.Values.storage.trace.backend}}
-      {{- if eq .Values.storage.trace.backend "gcs"}}
-      gcs:
-        {{- toYaml .Values.storage.trace.gcs | nindent 6}}
-      {{- end}}
+      {{- if .Values.minio.enabled }}
+      backend: s3
+      s3:
+        access_key: {{ .Values.minio.rootUser }}
+        {{- if .Values.enterprise.enabled }}
+        {{with (index .Values.minio.buckets 1) }}
+        bucket: {{ .name }}
+        {{- end }}
+        {{ else }}
+        {{with (index .Values.minio.buckets 0) }}
+        bucket: {{ .name }}
+        {{- end }}
+        {{- end }}
+        endpoint: {{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000
+        insecure: true
+        secret_key: {{ .Values.minio.rootPassword }}
+      {{ else }}
       {{- if eq .Values.storage.trace.backend "s3"}}
       s3:
         {{- toYaml .Values.storage.trace.s3 | nindent 6}}
-      {{- end}}
+      {{- end }}
+      {{- end }}
+      {{- if eq .Values.storage.trace.backend "gcs"}}
+      gcs:
+        {{- toYaml .Values.storage.trace.gcs | nindent 6}}
+      {{- end }}
       {{- if eq .Values.storage.trace.backend "azure"}}
       azure:
         {{- toYaml .Values.storage.trace.azure | nindent 6}}
-      {{- end}}
+      {{- end }}
       blocklist_poll: 5m
       local:
         path: /var/tempo/traces
@@ -990,6 +1029,10 @@ server:
 storage:
   trace:
     # -- The supported storage backends are gcs, s3 and azure, as specified in https://grafana.com/docs/tempo/latest/configuration/#storage
+    backend: local
+  # Settings for the Admin client storage backend and buckets. Only valid is enterprise.enabled is true.
+  admin:
+    # -- The supported storage backends are gcs, s3 and azure, as specified in https://grafana.com/docs/enterprise-traces/latest/config/reference/#admin_client_config
     backend: local
 
 # Global overrides
@@ -1211,12 +1254,15 @@ minio:
   rootUser: grafana-tempo
   rootPassword: supersecret
   buckets:
+    # Default Tempo storage bucket.
     - name: tempo-traces
       policy: none
       purge: false
+    # Bucket for traces storage if enterprise.enabled is true - requires license.
     - name: enterprise-traces
       policy: none
       purge: false
+    # Admin client bucket if enterprise.enabled is true - requires license.
     - name: enterprise-traces-admin
       policy: none
       purge: false


### PR DESCRIPTION
**What this PR does:**
Previously, the Admin Client section of the chart for Grafana
Enterprise Traces was only configured should MinIO be enabled.

These changes:
* Add a new `storage.admin` section for configuring the client
  backend storage type and bucket details.
* Finally, the README has been updated to document the new
  admin storage configuration section.

This commit fixes https://github.com/grafana/helm-charts/issues/2112.

Signed-off-by: Heds Simons <hedley.simons@grafana.com>

**Checklist**
[ ] Tests updated
[x] Documentation added