### PR TITLE
[tempo-distributed] feat(tempo-distributes/values.yaml): add remaining tempo compaction flags

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.27.17
+version: 0.27.18
 appVersion: 1.5.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.27.17](https://img.shields.io/badge/Version-0.27.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.27.18](https://img.shields.io/badge/Version-0.27.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -218,9 +218,16 @@ The memcached default args are removed and should be provided manually. The sett
 | adminApi.terminationGracePeriodSeconds | int | `60` |  |
 | adminApi.tolerations | list | `[]` |  |
 | compactor.config.compaction.block_retention | string | `"48h"` | Duration to keep blocks |
+| compactor.config.compaction.chunk_size_bytes | int | `5242880` | Amount of data to buffer from input blocks |
+| compactor.config.compaction.compacted_block_retention | string | `"1h"` |  |
 | compactor.config.compaction.compaction_cycle | string | `"30s"` | The time between compaction cycles |
+| compactor.config.compaction.compaction_window | string | `"1h"` | Blocks in this time window will be compacted together |
+| compactor.config.compaction.flush_size_bytes | int | `20971520` | Flush data to backend when buffer is this large |
 | compactor.config.compaction.iterator_buffer_size | int | `1000` | Number of traces to buffer in memory during compaction |
+| compactor.config.compaction.max_block_bytes | int | `107374182400` | Maximum size of a compacted block in bytes |
+| compactor.config.compaction.max_compaction_objects | int | `6000000` | Maximum number of traces in a compacted block. WARNING: Deprecated. Use max_block_bytes instead. |
 | compactor.config.compaction.max_time_per_tenant | string | `"5m"` | The maximum amount of time to spend compacting a single tenant before moving to the next |
+| compactor.config.compaction.retention_concurrency | int | `10` | Number of tenants to process in parallel during retention |
 | compactor.extraArgs | list | `[]` | Additional CLI args for the compactor |
 | compactor.extraEnv | list | `[]` | Environment variables to add to the compactor pods |
 | compactor.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the compactor pods |

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -441,6 +441,20 @@ compactor:
     compaction:
       # -- Duration to keep blocks
       block_retention: 48h
+      # Duration to keep blocks that have been compacted elsewhere
+      compacted_block_retention: 1h
+      # -- Blocks in this time window will be compacted together
+      compaction_window: 1h
+      # -- Amount of data to buffer from input blocks
+      chunk_size_bytes: 5242880
+      # -- Flush data to backend when buffer is this large
+      flush_size_bytes: 20971520
+      # -- Maximum number of traces in a compacted block. WARNING: Deprecated. Use max_block_bytes instead.
+      max_compaction_objects: 6000000
+      # -- Maximum size of a compacted block in bytes
+      max_block_bytes: 107374182400
+      # -- Number of tenants to process in parallel during retention
+      retention_concurrency: 10
       # -- Number of traces to buffer in memory during compaction
       iterator_buffer_size: 1000
       # -- The maximum amount of time to spend compacting a single tenant before moving to the next
@@ -742,6 +756,13 @@ config: |
   compactor:
     compaction:
       block_retention: {{ .Values.compactor.config.compaction.block_retention }}
+      compacted_block_retention: {{ .Values.compactor.config.compaction.compacted_block_retention }}
+      compaction_window: {{ .Values.compactor.config.compaction.compaction_window }}
+      chunk_size_bytes: {{ .Values.compactor.config.compaction.chunk_size_bytes }}
+      flush_size_bytes: {{ .Values.compactor.config.compaction.flush_size_bytes }}
+      max_compaction_objects: {{ .Values.compactor.config.compaction.max_compaction_objects }}
+      max_block_bytes: {{ .Values.compactor.config.compaction.max_block_bytes }}
+      retention_concurrency: {{ .Values.compactor.config.compaction.retention_concurrency }}
       iterator_buffer_size: {{ .Values.compactor.config.compaction.iterator_buffer_size }}
       max_time_per_tenant: {{ .Values.compactor.config.compaction.max_time_per_tenant }}
       compaction_cycle: {{ .Values.compactor.config.compaction.compaction_cycle }}


### PR DESCRIPTION
This PR allows us to customize all of the flags under the `compactor.compaction` configs: https://grafana.com/docs/tempo/latest/configuration/#compactor

Related to a [previous PR](https://github.com/grafana/helm-charts/pull/2086) which added a few of these flags, but not all of them.

Checklist:

 - [x] DCO signed
 - [x] Chart Version bumped
 - [x] Title of the PR starts with chart name (e.g. [tempo-distributed])