### PR TITLE
[grafana] Fix grafana-image-renderer network policies and service monitor

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.50.1
+version: 6.50.2
 appVersion: 9.3.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/image-renderer-network-policy.yaml
+++ b/charts/grafana/templates/image-renderer-network-policy.yaml
@@ -25,15 +25,15 @@ spec:
         - namespaceSelector:
             matchLabels:
               name: {{ include "grafana.namespace" . }}
-        {{- with .Values.imageRenderer.networkPolicy.extraIngressSelectors -}}
-        {{ toYaml . | nindent 8 }}
-        {{- end }}
-        - podSelector:
+          podSelector:
             matchLabels:
               {{- include "grafana.selectorLabels" . | nindent 14 }}
               {{- with .Values.podLabels }}
               {{- toYaml . | nindent 14 }}
               {{- end }}
+        {{- with .Values.imageRenderer.networkPolicy.extraIngressSelectors -}}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
 {{- end }}
 
 {{- if and .Values.imageRenderer.enabled .Values.imageRenderer.networkPolicy.limitEgress }}
@@ -64,10 +64,13 @@ spec:
           protocol: TCP
     # talk only to grafana
     - ports:
-        - port: {{ .Values.service.port }}
+        - port: {{ .Values.service.targetPort }}
           protocol: TCP
       to:
-        - podSelector:
+        - namespaceSelector:
+            matchLabels:
+              name: {{ include "grafana.namespace" . }}
+          podSelector:
             matchLabels:
               {{- include "grafana.selectorLabels" . | nindent 14 }}
               {{- with .Values.podLabels }}

--- a/charts/grafana/templates/image-renderer-servicemonitor.yaml
+++ b/charts/grafana/templates/image-renderer-servicemonitor.yaml
@@ -41,7 +41,7 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ include "grafana.namespace" . }}
-  {{- with .Values.serviceMonitor.targetLabels }}
+  {{- with .Values.imageRenderer.serviceMonitor.targetLabels }}
   targetLabels:
     {{- toYaml . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
* Fix the grafana-image-renderer network policies
  * The namespace and pods selectors need to be in the same rule to really match only the Grafana pods and nothing else from the same namespace
  * The egress policy needs to target the target port of the Grafana service
* Use the proper target labels value for the `grafana-image-renderer` ServiceMonitor (see https://github.com/grafana/helm-charts/pull/2130#pullrequestreview-1263011569)