### PR TITLE
[tempo-distributed] add headless service for tempo-distributor

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.27.19
+version: 0.27.20
 appVersion: 1.5.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.27.20
+version: 0.28.0
 appVersion: 1.5.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.27.20](https://img.shields.io/badge/Version-0.27.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.28.0](https://img.shields.io/badge/Version-0.28.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.27.19](https://img.shields.io/badge/Version-0.27.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.27.20](https://img.shields.io/badge/Version-0.27.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/distributor/service-distributor-discovery.yaml
+++ b/charts/tempo-distributed/templates/distributor/service-distributor-discovery.yaml
@@ -2,27 +2,22 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "tempo.resourceName" $dict }}
+  name: {{ include "tempo.resourceName" $dict }}-discovery
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    prometheus.io/service-monitor: "false"
   {{- with .Values.distributor.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.distributor.service.type }}
+  type: ClusterIP
+  clusterIP: None
   ports:
     - name: http-metrics
       port: 3100
       targetPort: http-metrics
-    - name: grpc
-      port: 9095
-      protocol: TCP
-      targetPort: 9095
-      {{- if .Values.distributor.appProtocol.grpc }}
-      appProtocol: {{ .Values.distributor.appProtocol.grpc }}
-      {{- end }}
     {{- if .Values.traces.jaeger.thriftCompact.enabled }}
     - name: distributor-jaeger-thrift-compact
       port: 6831
@@ -84,13 +79,5 @@ spec:
       protocol: TCP
       targetPort: opencensus
     {{- end }}
-  {{- if .Values.distributor.service.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.distributor.service.loadBalancerIP  }}
-  {{- end }}
-  {{- with .Values.distributor.service.loadBalancerSourceRanges}}
-  loadBalancerSourceRanges:
-    {{ toYaml . | nindent 4 }}
-  {{- end }}
   selector:
     {{- include "tempo.selectorLabels" $dict | nindent 4 }}
-


### PR DESCRIPTION
This merge request will add a [headless service](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services) for the tempo-distributor.

When the OpenTelemetry Collector is using the [Load Balancing Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/loadbalancingexporter/README.md), and the load balancing exporter is configured to used the `dns` resolver, a headless service for the tempo-distributor is required for the dns resolver to get all endpoints. Without a headless service, the load balancing exporter will only see the Kubernetes service IP, and not the endpoints.

If you have suggestions, improvements or questions, feel free to ask or enlighten me.