### PR TITLE
[tempo-distributed] add metrics_generator_processors when metrics generator is enabled

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.27.18
+version: 0.27.19
 appVersion: 1.5.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -42,7 +42,6 @@ helm delete my-release
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
-
 ## Upgrading
 
 A major chart version change indicates that there is an incompatible breaking change needing manual actions.
@@ -71,7 +70,6 @@ minio:
   enabled: true
 ```
 * allow configuration to be stored in a secret.  See the documentation for `useExternalConfig` and `configStorageType` in the values file for more details.
-
 
 ### From chart version < 0.26.0
 
@@ -674,7 +672,6 @@ The other components are optional and must be explicitly enabled.
 | memcached | yes |
 | gateway | yes |
 
-
 ## [Configuration](https://grafana.com/docs/tempo/latest/configuration/)
 
 This chart configures Tempo in microservices mode.
@@ -727,7 +724,6 @@ global_overrides:
 
 * Volumes are mounted to `/var/tempo`. The various directories Tempo needs should be configured as subdirectories (e. g. `/var/tempo/wal`, `/var/tempo/traces`). Tempo will create the directories automatically.
 * The config file is mounted to `/conf/tempo-query.yaml` and passed as CLI arg.
-
 
 ### Example configuration using S3 for storage
 

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,7 @@
 # tempo-distributed
 
-![Version: 0.27.18](https://img.shields.io/badge/Version-0.27.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+
+![Version: 0.27.19](https://img.shields.io/badge/Version-0.27.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square) 
 
 Grafana Tempo in MicroService mode
 
@@ -41,6 +42,7 @@ helm delete my-release
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
+
 ## Upgrading
 
 A major chart version change indicates that there is an incompatible breaking change needing manual actions.
@@ -69,6 +71,7 @@ minio:
   enabled: true
 ```
 * allow configuration to be stored in a secret.  See the documentation for `useExternalConfig` and `configStorageType` in the values file for more details.
+
 
 ### From chart version < 0.26.0
 
@@ -671,6 +674,7 @@ The other components are optional and must be explicitly enabled.
 | memcached | yes |
 | gateway | yes |
 
+
 ## [Configuration](https://grafana.com/docs/tempo/latest/configuration/)
 
 This chart configures Tempo in microservices mode.
@@ -723,6 +727,7 @@ global_overrides:
 
 * Volumes are mounted to `/var/tempo`. The various directories Tempo needs should be configured as subdirectories (e. g. `/var/tempo/wal`, `/var/tempo/traces`). Tempo will create the directories automatically.
 * The config file is mounted to `/conf/tempo-query.yaml` and passed as CLI arg.
+
 
 ### Example configuration using S3 for storage
 

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,7 +1,6 @@
 # tempo-distributed
 
-
-![Version: 0.27.19](https://img.shields.io/badge/Version-0.27.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square) 
+![Version: 0.27.19](https://img.shields.io/badge/Version-0.27.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -888,6 +888,11 @@ config: |
       - {{ include "tempo.fullname" . }}-gossip-ring
   overrides:
     {{- toYaml .Values.global_overrides | nindent 2 }}
+    {{- if .Values.metricsGenerator.enabled }}
+    metrics_generator_processors:
+    - service-graphs
+    - span-metrics
+    {{- end }}
   server:
     http_listen_port: {{ .Values.server.httpListenPort }}
     log_level: {{ .Values.server.logLevel }}
@@ -951,9 +956,6 @@ storage:
 # Global overrides
 global_overrides:
   per_tenant_override_config: /conf/overrides.yaml
-  # metrics_generator_processors:
-  #   - service-graphs
-  #   - span-metrics
 
 # Per tenants overrides
 overrides: |


### PR DESCRIPTION
@joe-elliott: Second attempt at this. New fork, new branch, with essentially the same changes.  Hopefully this time we got it right. The other PR (https://github.com/grafana/helm-charts/pull/2070) can be deleted if all is well with this one.