### PR TITLE
[grafana] H/A gossip port bug fix

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.50.2
+version: 6.50.3
 appVersion: 9.3.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -598,6 +598,9 @@ grafana.ini:
   unified_alerting:
     enabled: true
     ha_peers: {{ Name }}-headless:9094
+    ha_listen_address: ${POD_IP}:9094
+    ha_advertise_address: ${POD_IP}:9094
+
   alerting:
     enabled: false
 ```

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -878,7 +878,14 @@ containers:
       - name: {{ .Values.podPortName }}
         containerPort: {{ .Values.service.targetPort }}
         protocol: TCP
+      - name: {{ .Values.gossipPortName }}
+        containerPort: 9094
+        protocol: TCP
     env:
+      - name: POD_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
       {{- if and (not .Values.env.GF_SECURITY_ADMIN_USER) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: GF_SECURITY_ADMIN_USER
         valueFrom:

--- a/charts/grafana/templates/headless-service.yaml
+++ b/charts/grafana/templates/headless-service.yaml
@@ -17,7 +17,6 @@ spec:
     {{- include "grafana.selectorLabels" . | nindent 4 }}
   type: ClusterIP
   ports:
-  - protocol: TCP
-    port: 3000
-    targetPort: {{ .Values.service.targetPort }}
+  - name: grafana-alert
+    port: 9094
 {{- end }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -160,7 +160,7 @@ downloadDashboards:
 # podLabels: {}
 
 podPortName: grafana
-
+gossipPortName: grafana-alert
 ## Deployment annotations
 # annotations: {}
 


### PR DESCRIPTION
* The guide for H/A defines ha_peers port as 9094
* https://github.com/grafana/helm-charts/tree/main/charts/grafana#high-availability-for-unified-alerting
ISSUE:
* When i set the ha_peers value as {{ Name }}-headless:9094, i get a lookup error. 
* I also get an (failed to join)error when i set it to port 3000 
* I've made changes to my helm-generated-yaml and i don't get the error log anymore, and is working as intended. I applied the changes i made to the chart. please review! thanks

