### PR TITLE
[grafana] fix PR 2146 release

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.50.3
+version: 6.50.4
 appVersion: 9.3.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.


### PR DESCRIPTION
See:

https://github.com/grafana/helm-charts/pull/2146

Fixing release doesn't get thru because the chart version didn't get bumped.

Signed-off-by: zanac1986 <zanhsieh@protonmail.com>