### PR TITLE
[grafana] bump default grafana image tag to 9.3.6

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.50.4
-appVersion: 9.3.1
+version: 6.50.5
+appVersion: 9.3.6
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net


### PR DESCRIPTION
See details about included hotfixes (since 9.3.1):
- https://github.com/grafana/grafana/releases/tag/v9.3.2
- https://github.com/grafana/grafana/releases/tag/v9.3.4
- https://github.com/grafana/grafana/releases/tag/v9.3.6