### PR TITLE
[tempo-distributed] use appropriate HorizontalPodAutoscaling apiVersion

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: 2.0.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/_helpers.tpl
+++ b/charts/tempo-distributed/templates/_helpers.tpl
@@ -160,6 +160,17 @@ Return the appropriate apiVersion for PodDisruptionBudget.
 {{- end -}}
 
 {{/*
+Return the appropriate apiVersion for HorizontalPodAutoscaler.
+*/}}
+{{- define "tempo.hpa.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "autoscaling/v2") (semverCompare ">=1.23-0" .Capabilities.KubeVersion.Version) -}}
+    {{- print "autoscaling/v2" -}}
+  {{- else -}}
+    {{- print "autoscaling/v2beta1" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Resource name template
 */}}
 {{- define "tempo.resourceName" -}}

--- a/charts/tempo-distributed/templates/distributor/hpa.yaml
+++ b/charts/tempo-distributed/templates/distributor/hpa.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.distributor.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+{{- $apiVersion := include "tempo.hpa.apiVersion" . -}}
+apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "tempo.resourceName" (dict "ctx" . "component" "distributor") }}
@@ -17,12 +18,24 @@ spec:
     - type: Resource
       resource:
         name: memory
+        {{- if (eq $apiVersion "autoscaling/v2") }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
         targetAverageUtilization: {{ . }}
+        {{- end }}
   {{- end }}
   {{- with .Values.distributor.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
+        {{- if (eq $apiVersion "autoscaling/v2") }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
         targetAverageUtilization: {{ . }}
+        {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/gateway/hpa.yaml
+++ b/charts/tempo-distributed/templates/gateway/hpa.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.gateway.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+{{- $apiVersion := include "tempo.hpa.apiVersion" . -}}
+apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "tempo.resourceName" (dict "ctx" . "component" "gateway") }}
@@ -17,12 +18,24 @@ spec:
     - type: Resource
       resource:
         name: memory
+        {{- if (eq $apiVersion "autoscaling/v2") }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
         targetAverageUtilization: {{ . }}
+        {{- end }}
   {{- end }}
   {{- with .Values.gateway.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
+        {{- if (eq $apiVersion "autoscaling/v2") }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
         targetAverageUtilization: {{ . }}
+        {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/ingester/hpa.yaml
+++ b/charts/tempo-distributed/templates/ingester/hpa.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingester.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+{{- $apiVersion := include "tempo.hpa.apiVersion" . -}}
+apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "tempo.resourceName" (dict "ctx" . "component" "ingester") }}
@@ -17,12 +18,24 @@ spec:
     - type: Resource
       resource:
         name: memory
+        {{- if (eq $apiVersion "autoscaling/v2") }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
         targetAverageUtilization: {{ . }}
+        {{- end }}
   {{- end }}
   {{- with .Values.ingester.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
+        {{- if (eq $apiVersion "autoscaling/v2") }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
         targetAverageUtilization: {{ . }}
+        {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/querier/hpa.yaml
+++ b/charts/tempo-distributed/templates/querier/hpa.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.querier.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+{{- $apiVersion := include "tempo.hpa.apiVersion" . -}}
+apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "tempo.resourceName" (dict "ctx" . "component" "querier") }}
@@ -17,12 +18,24 @@ spec:
     - type: Resource
       resource:
         name: memory
+        {{- if (eq $apiVersion "autoscaling/v2") }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
         targetAverageUtilization: {{ . }}
+        {{- end }}
   {{- end }}
   {{- with .Values.querier.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
+        {{- if (eq $apiVersion "autoscaling/v2") }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
         targetAverageUtilization: {{ . }}
+        {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/query-frontend/hpa.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/hpa.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.queryFrontend.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+{{- $apiVersion := include "tempo.hpa.apiVersion" . -}}
+apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "tempo.resourceName" (dict "ctx" . "component" "query-frontend") }}
@@ -17,12 +18,24 @@ spec:
     - type: Resource
       resource:
         name: memory
+        {{- if (eq $apiVersion "autoscaling/v2") }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
         targetAverageUtilization: {{ . }}
+        {{- end }}
   {{- end }}
   {{- with .Values.queryFrontend.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
+        {{- if (eq $apiVersion "autoscaling/v2") }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
         targetAverageUtilization: {{ . }}
+        {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
> autoscaling/v2beta1 HorizontalPodAutoscaler is deprecated in v1.22+, unavailable in v1.25+; use autoscaling/v2 HorizontalPodAutoscaler

Taken [inspiration](https://github.com/grafana/helm-charts/blob/main/charts/loki-distributed/templates/_helpers.tpl#L144-L153) from [loki-distributed Helm chart](https://github.com/grafana/helm-charts/blob/main/charts/loki-distributed/).

This Pull Request will make the Horizontal Pod Autoscaling resources toggle between `autoscaling/v2beta1` and `autoscaling/v2` depending on whether the the cluster can support the `apiVersion` or not.

I noticed the issue https://github.com/grafana/helm-charts/issues/1944 to avoid `apiVersion` toggling, but perhaps this can be merged and then adjusted later when / if a cleanup is happening?