### PR TITLE
[fluent-bit] Allow specify custom parsers to input tail

### DIFF
--- a/charts/fluent-bit/templates/configmap.yaml
+++ b/charts/fluent-bit/templates/configmap.yaml
@@ -22,7 +22,7 @@ data:
         Name              tail
         Tag               kube.*
         Path              /var/log/containers/*.log
-        Parser            docker
+        Parser            {{ .Values.config.parser }}
         DB                /run/fluent-bit/flb_kube.db
         Mem_Buf_Limit     {{ .Values.config.memBufLimit }}
         Buffer_Chunk_size {{ .Values.config.bufChunkSize }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -13,6 +13,7 @@ config:
   batchSize: 1048576
   loglevel: warn
   lineFormat: json
+  parser: cri
   k8sLoggingExclude: "Off"
   k8sLoggingParser: "Off"
   memBufLimit: "5MB"


### PR DESCRIPTION
To Allow users to configure a default parser in the configuration rather than the docker parser specified by default within the configuration. we have added an attribute parser to be configured from the values.yaml file.

this will help users add additional parsers and also configure them to be used by default.
