### PR TITLE
[grafana] option to allow optional args

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.50.5
+version: 6.50.7
 appVersion: 9.3.6
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -220,7 +220,8 @@ This version requires Helm >= 3.1.0.
 | `rbac.pspUseAppArmor`                     | Enforce AppArmor in created PodSecurityPolicy (requires `rbac.pspEnabled`)  | `true`                    |
 | `rbac.extraRoleRules`                     | Additional rules to add to the Role           | []                                                      |
 | `rbac.extraClusterRoleRules`              | Additional rules to add to the ClusterRole    | []                                                      |
-| `command`                     | Define command to be executed by grafana container at startup  | `nil`                                              |
+| `command`                                 | Define command to be executed by grafana container at startup | `nil`                                   |
+| `args`                                    | Define additional args if command is used     | `nil`                                                   |
 | `testFramework.enabled`                   | Whether to create test-related resources      | `true`                                                  |
 | `testFramework.image`                     | `test-framework` image repository.            | `bats/bats`                                             |
 | `testFramework.tag`                       | `test-framework` image tag.                   | `v1.4.1`                                                |

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -763,7 +763,13 @@ containers:
     {{- range .Values.command }}
       - {{ . | quote }}
     {{- end }}
-    {{- end}}
+    {{- end }}
+    {{- if .Values.args }}
+    args:
+    {{- range .Values.args }}
+      - {{ . | quote }}
+    {{- end }}
+    {{- end }}
     {{- with .Values.containerSecurityContext }}
     securityContext:
       {{- toYaml . | nindent 6 }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -384,6 +384,14 @@ admin:
 # - "sh"
 # - "/run.sh"
 
+## Optionally define args if command is used
+## Needed if using `hashicorp/envconsul` to manage secrets
+## By default no arguments are set
+# args:
+# - "-secret"
+# - "secret/grafana"
+# - "./grafana"
+
 ## Extra environment variables that will be pass onto deployment pods
 ##
 ## to provide grafana with access to CloudWatch on AWS EKS:


### PR DESCRIPTION
when its possible to set a alternative `command` for the grafana container, it should also be possible to set `args` for this command.
would be useful when using hashicorp/envconsul.

Signed-off-by: gietschess <49275246+gietschess@users.noreply.github.com>