### PR TITLE
[loki-stack] loki charts endpoint wrong

### DIFF
--- a/charts/loki-stack/values.yaml
+++ b/charts/loki-stack/values.yaml
@@ -27,7 +27,7 @@ promtail:
     logLevel: info
     serverPort: 3101
     clients:
-      - url: http://{{ .Release.Name }}:3100/loki/api/v1/push
+      - url: http://{{ .Release.Name }}-loki:3100/loki/api/v1/push
 
 fluent-bit:
   enabled: false


### PR DESCRIPTION
Loki service is not reachable with http://{{ .Release.Name }} but with http://{{ .Release.Name }}-loki by default.