### PR TITLE
[grafana] Alerting: expose UDP port

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.50.5
+version: 6.50.6
 appVersion: 9.3.6
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -878,9 +878,12 @@ containers:
       - name: {{ .Values.podPortName }}
         containerPort: {{ .Values.service.targetPort }}
         protocol: TCP
-      - name: {{ .Values.gossipPortName }}
+      - name: {{ .Values.gossipPortName }}-tcp
         containerPort: 9094
         protocol: TCP
+      - name: {{ .Values.gossipPortName }}-udp
+        containerPort: 9094
+        protocol: UDP
     env:
       - name: POD_IP
         valueFrom:

--- a/charts/grafana/templates/headless-service.yaml
+++ b/charts/grafana/templates/headless-service.yaml
@@ -17,6 +17,6 @@ spec:
     {{- include "grafana.selectorLabels" . | nindent 4 }}
   type: ClusterIP
   ports:
-  - name: grafana-alert
+  - name: {{ .Values.gossipPortName }}-tcp
     port: 9094
 {{- end }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -160,7 +160,7 @@ downloadDashboards:
 # podLabels: {}
 
 podPortName: grafana
-gossipPortName: grafana-alert
+gossipPortName: gossip
 ## Deployment annotations
 # annotations: {}
 


### PR DESCRIPTION
This change will expose the UDP port needed by the gossip protocol. It also changes the name of the gossip port, as the old one was too long (15 chars limit on port names in Kubernetes).