### PR TITLE
[loki-distributed] Updated the chart and app version to 2.7.2

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
-appVersion: 2.7.1
-version: 0.69.2
+appVersion: 2.7.2
+version: 0.69.3
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki


### PR DESCRIPTION
Loki has released the 2.7.2 version. But in helm charts, we have till 2.7.1 only. We have tested replacing 2.7.1 with the 2.7.2 image in our environment, it worked fine.