### PR TITLE
[loki-distributed] update helpers template from hpa

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.7.1
-version: 0.69.2
+version: 0.69.3
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.69.2](https://img.shields.io/badge/Version-0.69.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.1](https://img.shields.io/badge/AppVersion-2.7.1-informational?style=flat-square)
+![Version: 0.69.3](https://img.shields.io/badge/Version-0.69.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.1](https://img.shields.io/badge/AppVersion-2.7.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/templates/_helpers.tpl
+++ b/charts/loki-distributed/templates/_helpers.tpl
@@ -145,7 +145,7 @@ Return the appropriate apiVersion for PodDisruptionBudget.
 Return the appropriate apiVersion for HorizontalPodAutoscaler.
 */}}
 {{- define "loki.hpa.apiVersion" -}}
-  {{- if .Capabilities.APIVersions.Has "autoscaling/v2" -}}
+  {{- if and (.Capabilities.APIVersions.Has "autoscaling/v2") (semverCompare ">=1.23-0" .Capabilities.KubeVersion.Version) -}}
     {{- print "autoscaling/v2" -}}
   {{- else if .Capabilities.APIVersions.Has "autoscaling/v2beta2" -}}
     {{- print "autoscaling/v2beta2" -}}

--- a/charts/loki-distributed/templates/_helpers.tpl
+++ b/charts/loki-distributed/templates/_helpers.tpl
@@ -145,9 +145,9 @@ Return the appropriate apiVersion for PodDisruptionBudget.
 Return the appropriate apiVersion for HorizontalPodAutoscaler.
 */}}
 {{- define "loki.hpa.apiVersion" -}}
-  {{- if .Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler" -}}
+  {{- if .Capabilities.APIVersions.Has "autoscaling/v2" -}}
     {{- print "autoscaling/v2" -}}
-  {{- else if .Capabilities.APIVersions.Has "autoscaling/v2beta2/HorizontalPodAutoscaler" -}}
+  {{- else if .Capabilities.APIVersions.Has "autoscaling/v2beta2" -}}
     {{- print "autoscaling/v2beta2" -}}
   {{- else }}
     {{- print "autoscaling/v2beta1" -}}

--- a/charts/loki-distributed/templates/_helpers.tpl
+++ b/charts/loki-distributed/templates/_helpers.tpl
@@ -145,9 +145,11 @@ Return the appropriate apiVersion for PodDisruptionBudget.
 Return the appropriate apiVersion for HorizontalPodAutoscaler.
 */}}
 {{- define "loki.hpa.apiVersion" -}}
-  {{- if and (.Capabilities.APIVersions.Has "autoscaling/v2") (semverCompare ">=1.23-0" .Capabilities.KubeVersion.Version) -}}
+  {{- if .Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler" -}}
     {{- print "autoscaling/v2" -}}
-  {{- else -}}
+  {{- else if .Capabilities.APIVersions.Has "autoscaling/v2beta2/HorizontalPodAutoscaler" -}}
+    {{- print "autoscaling/v2beta2" -}}
+  {{- else }}
     {{- print "autoscaling/v2beta1" -}}
   {{- end -}}
 {{- end -}}

--- a/charts/loki-distributed/templates/distributor/hpa.yaml
+++ b/charts/loki-distributed/templates/distributor/hpa.yaml
@@ -18,24 +18,24 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if (eq $apiVersion "autoscaling/v2") }}
+        {{- if (eq $apiVersion "autoscaling/v2beta1") }}
+        targetAverageUtilization: {{ . }}
+        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
         {{- end }}
   {{- end }}
   {{- with .Values.distributor.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
-        {{- if (eq $apiVersion "autoscaling/v2") }}
+        {{- if (eq $apiVersion "autoscaling/v2beta1") }}
+        targetAverageUtilization: {{ . }}
+        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/gateway/hpa.yaml
+++ b/charts/loki-distributed/templates/gateway/hpa.yaml
@@ -18,24 +18,24 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if (eq $apiVersion "autoscaling/v2") }}
+        {{- if (eq $apiVersion "autoscaling/v2beta1") }}
+        targetAverageUtilization: {{ . }}
+        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
         {{- end }}
   {{- end }}
   {{- with .Values.gateway.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
-        {{- if (eq $apiVersion "autoscaling/v2") }}
+        {{- if (eq $apiVersion "autoscaling/v2beta1") }}
+        targetAverageUtilization: {{ . }}
+        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/ingester/hpa.yaml
+++ b/charts/loki-distributed/templates/ingester/hpa.yaml
@@ -18,24 +18,24 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if (eq $apiVersion "autoscaling/v2") }}
+        {{- if (eq $apiVersion "autoscaling/v2beta1") }}
+        targetAverageUtilization: {{ . }}
+        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
         {{- end }}
   {{- end }}
   {{- with .Values.ingester.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
-        {{- if (eq $apiVersion "autoscaling/v2") }}
+        {{- if (eq $apiVersion "autoscaling/v2beta1") }}
+        targetAverageUtilization: {{ . }}
+        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/querier/hpa.yaml
+++ b/charts/loki-distributed/templates/querier/hpa.yaml
@@ -18,24 +18,24 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if (eq $apiVersion "autoscaling/v2") }}
+        {{- if (eq $apiVersion "autoscaling/v2beta1") }}
+        targetAverageUtilization: {{ . }}
+        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
         {{- end }}
   {{- end }}
   {{- with .Values.querier.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
-        {{- if (eq $apiVersion "autoscaling/v2") }}
+        {{- if (eq $apiVersion "autoscaling/v2beta1") }}
+        targetAverageUtilization: {{ . }}
+        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/query-frontend/hpa.yaml
+++ b/charts/loki-distributed/templates/query-frontend/hpa.yaml
@@ -18,24 +18,24 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if (eq $apiVersion "autoscaling/v2") }}
+        {{- if (eq $apiVersion "autoscaling/v2beta1") }}
+        targetAverageUtilization: {{ . }}
+        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
         {{- end }}
   {{- end }}
   {{- with .Values.queryFrontend.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
-        {{- if (eq $apiVersion "autoscaling/v2") }}
+        {{- if (eq $apiVersion "autoscaling/v2beta1") }}
+        targetAverageUtilization: {{ . }}
+        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 0.28.0
-appVersion: 1.5.0
+version: 1.0.0
+appVersion: 2.0.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/
 icon: https://raw.githubusercontent.com/grafana/tempo/master/docs/tempo/website/logo_and_name.png

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 0.28.0](https://img.shields.io/badge/Version-0.28.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -44,6 +44,13 @@ The command removes all the Kubernetes components associated with the chart and 
 ## Upgrading
 
 A major chart version change indicates that there is an incompatible breaking change needing manual actions.
+
+### From Chart versions < 1.0.0
+
+Please note that we've incremented the major version when upgrading to Tempo 2.0. There were a large number of
+changes in this release (breaking and otherwise). It is encouraged to review the [release notes](https://grafana.com/docs/tempo/latest/release-notes/v2-0/)
+and [1.5 -> 2.0 upgrade guide](https://grafana.com/docs/tempo/latest/setup/upgrade/) before upgrading.
+
 ### From chart version < 0.27.0
 
 Version 0.27.0:

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -226,16 +226,16 @@ The memcached default args are removed and should be provided manually. The sett
 | adminApi.tolerations | list | `[]` |  |
 | adminApi.topologySpreadConstraints | string | Defaults to allow skew no more then 1 node per AZ | topologySpread for admin-api pods. Passed through `tpl` and, thus, to be configured as string |
 | compactor.config.compaction.block_retention | string | `"48h"` | Duration to keep blocks |
-| compactor.config.compaction.chunk_size_bytes | int | `5242880` | Amount of data to buffer from input blocks |
 | compactor.config.compaction.compacted_block_retention | string | `"1h"` |  |
 | compactor.config.compaction.compaction_cycle | string | `"30s"` | The time between compaction cycles |
 | compactor.config.compaction.compaction_window | string | `"1h"` | Blocks in this time window will be compacted together |
-| compactor.config.compaction.flush_size_bytes | int | `20971520` | Flush data to backend when buffer is this large |
-| compactor.config.compaction.iterator_buffer_size | int | `1000` | Number of traces to buffer in memory during compaction |
 | compactor.config.compaction.max_block_bytes | int | `107374182400` | Maximum size of a compacted block in bytes |
 | compactor.config.compaction.max_compaction_objects | int | `6000000` | Maximum number of traces in a compacted block. WARNING: Deprecated. Use max_block_bytes instead. |
 | compactor.config.compaction.max_time_per_tenant | string | `"5m"` | The maximum amount of time to spend compacting a single tenant before moving to the next |
 | compactor.config.compaction.retention_concurrency | int | `10` | Number of tenants to process in parallel during retention |
+| compactor.config.compaction.v2_in_buffer_bytes | int | `5242880` | Amount of data to buffer from input blocks |
+| compactor.config.compaction.v2_out_buffer_bytes | int | `20971520` | Flush data to backend when buffer is this large |
+| compactor.config.compaction.v2_prefetch_traces_count | int | `1000` | Number of traces to buffer in memory during compaction |
 | compactor.extraArgs | list | `[]` | Additional CLI args for the compactor |
 | compactor.extraEnv | list | `[]` | Environment variables to add to the compactor pods |
 | compactor.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the compactor pods |
@@ -617,7 +617,6 @@ The memcached default args are removed and should be provided manually. The sett
 | queryFrontend.topologySpreadConstraints | string | Defaults to allow skew no more then 1 node per AZ | topologySpread for query-frontend pods. Passed through `tpl` and, thus, to be configured as string |
 | rbac.create | bool | `false` | Specifies whether RBAC manifests should be created |
 | rbac.pspEnabled | bool | `false` | Specifies whether a PodSecurityPolicy should be created |
-| search.enabled | bool | `false` | Enable Tempo search |
 | server.grpc_server_max_recv_msg_size | int | `4194304` | Max gRPC message size that can be received |
 | server.grpc_server_max_send_msg_size | int | `4194304` | Max gRPC message size that can be sent |
 | server.httpListenPort | int | `3100` | HTTP server listen host |

--- a/charts/tempo-distributed/README.md.gotmpl
+++ b/charts/tempo-distributed/README.md.gotmpl
@@ -38,6 +38,13 @@ The command removes all the Kubernetes components associated with the chart and 
 ## Upgrading
 
 A major chart version change indicates that there is an incompatible breaking change needing manual actions.
+
+### From Chart versions < 1.0.0
+
+Please note that we've incremented the major version when upgrading to Tempo 2.0. There were a large number of
+changes in this release (breaking and otherwise). It is encouraged to review the [release notes](https://grafana.com/docs/tempo/latest/release-notes/v2-0/)
+and [1.5 -> 2.0 upgrade guide](https://grafana.com/docs/tempo/latest/setup/upgrade/) before upgrading.
+
 ### From chart version < 0.27.0
 
 Version 0.27.0:

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -473,9 +473,9 @@ compactor:
       # -- Blocks in this time window will be compacted together
       compaction_window: 1h
       # -- Amount of data to buffer from input blocks
-      chunk_size_bytes: 5242880
+      v2_in_buffer_bytes: 5242880
       # -- Flush data to backend when buffer is this large
-      flush_size_bytes: 20971520
+      v2_out_buffer_bytes: 20971520
       # -- Maximum number of traces in a compacted block. WARNING: Deprecated. Use max_block_bytes instead.
       max_compaction_objects: 6000000
       # -- Maximum size of a compacted block in bytes
@@ -483,7 +483,7 @@ compactor:
       # -- Number of tenants to process in parallel during retention
       retention_concurrency: 10
       # -- Number of traces to buffer in memory during compaction
-      iterator_buffer_size: 1000
+      v2_prefetch_traces_count: 1000
       # -- The maximum amount of time to spend compacting a single tenant before moving to the next
       max_time_per_tenant: 5m
       # -- The time between compaction cycles
@@ -693,10 +693,6 @@ queryFrontend:
     # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
     grpc: null
 
-search:
-  # -- Enable Tempo search
-  enabled: false
-
 multitenancyEnabled: false
 
 traces:
@@ -750,8 +746,6 @@ traces:
 # @default -- See values.yaml
 config: |
   multitenancy_enabled: {{ .Values.multitenancyEnabled }}
-  search_enabled: {{ .Values.search.enabled }}
-  metrics_generator_enabled: {{ .Values.metricsGenerator.enabled }}
 
   {{- if .Values.enterprise.enabled }}
   license:
@@ -803,12 +797,12 @@ config: |
       block_retention: {{ .Values.compactor.config.compaction.block_retention }}
       compacted_block_retention: {{ .Values.compactor.config.compaction.compacted_block_retention }}
       compaction_window: {{ .Values.compactor.config.compaction.compaction_window }}
-      chunk_size_bytes: {{ .Values.compactor.config.compaction.chunk_size_bytes }}
-      flush_size_bytes: {{ .Values.compactor.config.compaction.flush_size_bytes }}
+      v2_in_buffer_bytes: {{ .Values.compactor.config.compaction.v2_in_buffer_bytes }}
+      v2_out_buffer_bytes: {{ .Values.compactor.config.compaction.v2_out_buffer_bytes }}
       max_compaction_objects: {{ .Values.compactor.config.compaction.max_compaction_objects }}
       max_block_bytes: {{ .Values.compactor.config.compaction.max_block_bytes }}
       retention_concurrency: {{ .Values.compactor.config.compaction.retention_concurrency }}
-      iterator_buffer_size: {{ .Values.compactor.config.compaction.iterator_buffer_size }}
+      v2_prefetch_traces_count: {{ .Values.compactor.config.compaction.v2_prefetch_traces_count }}
       max_time_per_tenant: {{ .Values.compactor.config.compaction.max_time_per_tenant }}
       compaction_cycle: {{ .Values.compactor.config.compaction.compaction_cycle }}
     ring:
@@ -990,9 +984,9 @@ server:
 #   trace:
 #     backend: azure
 #     azure:
-#       container-name:
-#       storage-account-name:
-#       storage-account-key:
+#       container_name:
+#       storage_account_name:
+#       storage_account_key:
 storage:
   trace:
     # -- The supported storage backends are gcs, s3 and azure, as specified in https://grafana.com/docs/tempo/latest/configuration/#storage

--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 0.17.0
+version: 1.0.0
 appVersion: 2.0.0
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 0.16.9
-appVersion: 1.5.0
+version: 0.17.0
+appVersion: 2.0.0
 engine: gotpl
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/tempo/master/docs/tempo/website/logo_and_name.png

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 
@@ -112,6 +112,12 @@ The command removes all the Kubernetes components associated with the chart and 
 ## Upgrading
 
 A major chart version change indicates that there is an incompatible breaking change needing manual actions.
+
+### From Chart versions < 1.0.0
+
+Please note that we've incremented the major version when upgrading to Tempo 2.0. There were a large number of
+changes in this release (breaking and otherwise). It is encouraged to review the [release notes](https://grafana.com/docs/tempo/latest/release-notes/v2-0/)
+and [1.5 -> 2.0 upgrade guide](https://grafana.com/docs/tempo/latest/setup/upgrade/) before upgrading.
 
 ### From Chart versions < 0.7.0
 

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 0.16.9](https://img.shields.io/badge/Version-0.16.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 
@@ -65,13 +65,12 @@ Grafana Tempo Single Binary Mode
 | tempo.repository | string | `"grafana/tempo"` |  |
 | tempo.resources | object | `{}` |  |
 | tempo.retention | string | `"24h"` |  |
-| tempo.searchEnabled | bool | `false` | If true, enables Tempo's native search |
 | tempo.securityContext | object | `{}` |  |
 | tempo.server.http_listen_port | int | `3100` | HTTP server listen port |
 | tempo.storage.trace.backend | string | `"local"` |  |
 | tempo.storage.trace.local.path | string | `"/var/tempo/traces"` |  |
 | tempo.storage.trace.wal.path | string | `"/var/tempo/wal"` |  |
-| tempo.tag | string | `"1.5.0"` |  |
+| tempo.tag | string | `"2.0.0"` |  |
 | tempo.updateStrategy | string | `"RollingUpdate"` |  |
 | tempoQuery.enabled | bool | `true` | if False the tempo-query container is not deployed |
 | tempoQuery.extraArgs | object | `{}` |  |
@@ -81,7 +80,7 @@ Grafana Tempo Single Binary Mode
 | tempoQuery.repository | string | `"grafana/tempo-query"` |  |
 | tempoQuery.resources | object | `{}` |  |
 | tempoQuery.securityContext | object | `{}` |  |
-| tempoQuery.tag | string | `"1.5.0"` |  |
+| tempoQuery.tag | string | `"2.0.0"` |  |
 | tolerations | list | `[]` | Tolerations for pod assignment. See: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
 
 ## Chart Repo

--- a/charts/tempo/README.md.gotmpl
+++ b/charts/tempo/README.md.gotmpl
@@ -40,6 +40,12 @@ The command removes all the Kubernetes components associated with the chart and 
 
 A major chart version change indicates that there is an incompatible breaking change needing manual actions.
 
+### From Chart versions < 1.0.0
+
+Please note that we've incremented the major version when upgrading to Tempo 2.0. There were a large number of
+changes in this release (breaking and otherwise). It is encouraged to review the [release notes](https://grafana.com/docs/tempo/latest/release-notes/v2-0/) 
+and [1.5 -> 2.0 upgrade guide](https://grafana.com/docs/tempo/latest/setup/upgrade/) before upgrading.
+
 ### From Chart versions < 0.7.0
 
 Upgrading from pre 0.7.0 will, by default, move your trace storage from `/tmp/tempo/traces` to `/var/tempo/traces`.

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -12,7 +12,7 @@ annotations: {}
 
 tempo:
   repository: grafana/tempo
-  tag: 1.5.0
+  tag: 2.0.0
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -32,8 +32,6 @@ tempo:
 
   memBallastSizeMbs: 1024
   multitenancyEnabled: false
-  # -- If true, enables Tempo's native search
-  searchEnabled: false
   # -- If true, Tempo will report anonymous usage data about the shape of a deployment to Grafana Labs
   reportingEnabled: true
   metricsGenerator:
@@ -119,10 +117,8 @@ tempo:
 # @default -- Dynamically generated tempo configmap
 config: |
     multitenancy_enabled: {{ .Values.tempo.multitenancyEnabled }}
-    search_enabled: {{ .Values.tempo.searchEnabled }}
     usage_report:
       reporting_enabled: {{ .Values.tempo.reportingEnabled }}
-    metrics_generator_enabled: {{ .Values.tempo.metricsGenerator.enabled }}
     compactor:
       compaction:
         block_retention: {{ .Values.tempo.retention }}
@@ -154,7 +150,7 @@ config: |
 
 tempoQuery:
   repository: grafana/tempo-query
-  tag: 1.5.0
+  tag: 2.0.0
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Update hpa template helpers to avoid the following error below:
```
W0131 17:34:38.212781  571863 warnings.go:70] autoscaling/v2beta1 HorizontalPodAutoscaler is deprecated in v1.22+, unavailable in v1.25+; use autoscaling/v2beta2 HorizontalPodAutoscaler
```