### PR TITLE
[fluent-bit] Add securityContext support

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: fluent-bit
-version: 2.3.2
+version: 2.3.3
 appVersion: v2.1.0
 kubeVersion: "^1.10.0-0"
 description: "Uses fluent-bit Loki go plugin for gathering logs and sending them to Loki"

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: fluent-bit
-version: 2.3.3
+version: 2.4.0
 appVersion: v2.1.0
 kubeVersion: "^1.10.0-0"
 description: "Uses fluent-bit Loki go plugin for gathering logs and sending them to Loki"

--- a/charts/fluent-bit/README.md
+++ b/charts/fluent-bit/README.md
@@ -117,6 +117,9 @@ For more details, read the [Fluent Bit documentation](../../../cmd/fluent-bit/RE
 | `volumes`                | [Volume]([volumes]) to mount                                                                       | `host containers log`            |
 | `volumeMounts`           | Volume mount mapping                                                                               |                                  |
 | `serviceMonitor.enabled` | Create a [Prometheus Operator](operator) serviceMonitor resource for Fluent Bit                    | `false`                          |
+| `podSecurityContext`     | Configure the pod level securityContext                                                            | `{}`                             |
+| `securityContext`        | Configure the fluent-bit container securityContext                                                 | `{}`                             |
+
 
 
 [toleration]: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/

--- a/charts/fluent-bit/templates/daemonset.yaml
+++ b/charts/fluent-bit/templates/daemonset.yaml
@@ -34,6 +34,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end}}
       serviceAccountName: {{ template "fluent-bit-loki.serviceAccountName" . }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
@@ -48,6 +52,10 @@ spec:
         - name: fluent-bit-loki
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: /fluent-bit/etc

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -92,6 +92,11 @@ serviceAccount:
   create: true
   name:
 
+
+podSecurityContext: {}
+
+securityContext: {}
+
 ## Tolerations for pod assignment
 ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations:


### PR DESCRIPTION
In order to comply with certain audit policies I'd like to set a securityContext on the fluent-bit pod.
It seems in the past a podSecurityPolicy was supplied, but that mechanism is deprecated now.
Would it be possible to add this support?
Sorry for opening the PR twice,  I'm new to contributing and I got lost in the whole signing procedure.

Kind regards,
Robin
