### PR TITLE
[promtail] Implement config-reloader

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.7.2
-version: 6.8.2
+version: 6.9.0
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 6.8.2](https://img.shields.io/badge/Version-6.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.2](https://img.shields.io/badge/AppVersion-2.7.2-informational?style=flat-square)
+![Version: 6.9.0](https://img.shields.io/badge/Version-6.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.2](https://img.shields.io/badge/AppVersion-2.7.2-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 
@@ -147,6 +147,20 @@ The new release which will pick up again from the existing `positions.yaml`.
 | serviceMonitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | serviceMonitor.targetLabels | list | `[]` | ServiceMonitor will add labels from the service to the Prometheus metric https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitorspec |
 | serviceMonitor.tlsConfig | string | `nil` | ServiceMonitor will use these tlsConfig settings to make the health check requests |
+| sidecar.configReloader.config.serverPort | int | `9533` | The port of the config-reloader server |
+| sidecar.configReloader.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The security context for containers for sidecar config-reloader |
+| sidecar.configReloader.enabled | bool | `false` |  |
+| sidecar.configReloader.extraArgs | list | `[]` |  |
+| sidecar.configReloader.extraEnv | list | `[]` | Extra environment variables for sidecar config-reloader |
+| sidecar.configReloader.extraEnvFrom | list | `[]` | Extra environment variables from secrets or configmaps for sidecar config-reloader |
+| sidecar.configReloader.image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy for sidecar config-reloader |
+| sidecar.configReloader.image.registry | string | `"docker.io"` | The Docker registry for sidecar config-reloader |
+| sidecar.configReloader.image.repository | string | `"jimmidyson/configmap-reload"` | Docker image repository for sidecar config-reloader |
+| sidecar.configReloader.image.tag | string | `"v0.8.0"` | Docker image tag for sidecar config-reloader |
+| sidecar.configReloader.livenessProbe | object | `{}` | Liveness probe for sidecar config-reloader |
+| sidecar.configReloader.readinessProbe | object | `{}` | Readiness probe for sidecar config-reloader |
+| sidecar.configReloader.resources | object | `{}` | Resource requests and limits for sidecar config-reloader |
+| sidecar.configReloader.serviceMonitor.enabled | bool | `true` |  |
 | tolerations | list | `[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane","operator":"Exists"}]` | Tolerations for pods. By default, pods will be scheduled on master/control-plane nodes. |
 | updateStrategy | object | `{}` | The update strategy for the DaemonSet |
 

--- a/charts/promtail/templates/servicemonitor.yaml
+++ b/charts/promtail/templates/servicemonitor.yaml
@@ -50,6 +50,31 @@ spec:
       tlsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+    {{- if and $.Values.sidecar.configReloader.enabled $.Values.sidecar.configReloader.serviceMonitor.enabled }}
+    - port: reloader
+      path: "/metrics"
+      {{- with .interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
   {{- with .targetLabels }}
   targetLabels:
     {{- toYaml . | nindent 4 }}

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -486,6 +486,49 @@ networkPolicy:
 # -- Base path to server all API routes fro
 httpPathPrefix: ""
 
+sidecar:
+  configReloader:
+    enabled: false
+    image:
+      # -- The Docker registry for sidecar config-reloader
+      registry: docker.io
+      # -- Docker image repository for sidecar config-reloader
+      repository: jimmidyson/configmap-reload
+      # -- Docker image tag for sidecar config-reloader
+      tag: v0.8.0
+      # -- Docker image pull policy for sidecar config-reloader
+      pullPolicy: IfNotPresent
+    # Extra args for the config-reloader container.
+    extraArgs: []
+    # -- Extra environment variables for sidecar config-reloader
+    extraEnv: []
+    # -- Extra environment variables from secrets or configmaps for sidecar config-reloader
+    extraEnvFrom: []
+    # -- The security context for containers for sidecar config-reloader
+    containerSecurityContext:
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+      allowPrivilegeEscalation: false
+    # -- Readiness probe for sidecar config-reloader
+    readinessProbe: {}
+    # -- Liveness probe for sidecar config-reloader
+    livenessProbe: {}
+    # -- Resource requests and limits for sidecar config-reloader
+    resources: {}
+    #  limits:
+    #    cpu: 200m
+    #    memory: 128Mi
+    #  requests:
+    #    cpu: 100m
+    #    memory: 128Mi
+    config:
+      # -- The port of the config-reloader server
+      serverPort: 9533
+    serviceMonitor:
+      enabled: true
+
 # -- Extra K8s manifests to deploy
 extraObjects: []
   # - apiVersion: "kubernetes-client.io/v1"


### PR DESCRIPTION
Hi,

on large clusters, the rollout of promtail could take some time. This PR extends the current helm chart by an config reloader sidecar. It depends on https://github.com/grafana/loki/pull/7247.

I used the config-reloader images from prometheus helm chart. config-reloader implements inotify to detect changes instantly.