### PR TITLE
[grafana] Support including YAML files with alert rules using the `file` subkey.

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.50.7
+version: 6.50.8
 appVersion: 9.3.6
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.50.8
+version: 6.51.0
 appVersion: 9.3.6
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/configmap.yaml
+++ b/charts/grafana/templates/configmap.yaml
@@ -53,8 +53,13 @@ data:
   {{- end }}
 
   {{- range $key, $value := .Values.alerting }}
+  {{- if (hasKey $value "file") }}
+  {{- $key | nindent 2 }}:
+  {{- toYaml ( $files.Get $value.file ) | nindent 4}}
+  {{- else }}
   {{- $key | nindent 2 }}: |
     {{- tpl (toYaml $value | nindent 4) $root }}
+  {{- end }}
   {{- end }}
 
   {{- range $key, $value := .Values.dashboardProviders }}

--- a/charts/grafana/templates/configmap.yaml
+++ b/charts/grafana/templates/configmap.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.createConfigmap }}
+{{- $files := .Files }}
 {{- $root := . -}}
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
Hello everyone,

our team is migrating all our alert rules to the new provisioning mechanism and we were having trouble with the current Helm chart because the contents of each `rules.yaml` file must be inlined, making the `values.yaml` files extremely long.

I added the possibility of importing a YAML using the `file:` key similar to the mechanism for the dashboards. The configuration in `values.yaml` looks like this:

```yaml
alerting:
  team1-alert-rules.yaml:
    file: alerting/team1/rules.yaml
  team2-alert-rules.yaml:
    file: alerting/team2/rules.yaml
  team3-alert-rules.yaml:
    file: alerting/team3/rules.yaml
``` 

I hope this helps other users of the Helm chart. Thank you!