### PR TITLE
[agent-operator] Update operator to version 0.31.2

### DIFF
--- a/charts/agent-operator/Chart.yaml
+++ b/charts/agent-operator/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: grafana-agent-operator
 description: A Helm chart for Grafana Agent Operator
 type: application
-version: 0.2.10
-appVersion: "0.31.0"
+version: 0.2.11
+appVersion: "0.31.2"
 home: https://grafana.com/docs/agent/v0.30/
-icon: https://raw.githubusercontent.com/grafana/agent/v0.31.0/docs/sources/assets/logo_and_name.png
+icon: https://raw.githubusercontent.com/grafana/agent/v0.31.2/docs/sources/assets/logo_and_name.png
 sources:
-  - https://github.com/grafana/agent/tree/v0.31.0/pkg/operator
+  - https://github.com/grafana/agent/tree/v0.31.2/pkg/operator
 maintainers:
   - name: Grafana Agent Team
     email: grafana-agent-team@googlegroups.com

--- a/charts/agent-operator/README.md
+++ b/charts/agent-operator/README.md
@@ -1,6 +1,6 @@
 # grafana-agent-operator
 
-![Version: 0.2.10](https://img.shields.io/badge/Version-0.2.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.31.0](https://img.shields.io/badge/AppVersion-0.31.0-informational?style=flat-square)
+![Version: 0.2.11](https://img.shields.io/badge/Version-0.2.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.31.2](https://img.shields.io/badge/AppVersion-0.31.2-informational?style=flat-square)
 
 A Helm chart for Grafana Agent Operator
 
@@ -8,7 +8,7 @@ A Helm chart for Grafana Agent Operator
 
 ## Source Code
 
-* <https://github.com/grafana/agent/tree/v0.31.0/pkg/operator>
+* <https://github.com/grafana/agent/tree/v0.31.2/pkg/operator>
 
 Note that this chart does not provision custom resources like `GrafanaAgent` and `MetricsInstance` (formerly `PrometheusInstance`) or any `*Monitor` resources.
 
@@ -62,7 +62,7 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 | image.pullSecrets | list | `[]` | Image pull secrets |
 | image.registry | string | `"docker.io"` | Image registry |
 | image.repository | string | `"grafana/agent-operator"` | Image repo |
-| image.tag | string | `"v0.31.0"` | Image tag |
+| image.tag | string | `"v0.31.2"` | Image tag |
 | kubeletService | object | `{"namespace":"default","serviceName":"kubelet"}` | If both are set, Agent Operator will create and maintain a service for scraping kubelets https://grafana.com/docs/agent/latest/operator/getting-started/#monitor-kubelets |
 | nameOverride | string | `""` | Overrides the chart's name |
 | nodeSelector | object | `{}` | nodeSelector configuration |

--- a/charts/agent-operator/values.yaml
+++ b/charts/agent-operator/values.yaml
@@ -37,7 +37,7 @@ image:
   # -- Image repo
   repository: grafana/agent-operator
   # -- Image tag
-  tag: v0.31.0
+  tag: v0.31.2
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Image pull secrets


### PR DESCRIPTION
A new version of the operator Helm charts following the release of Agent Operator [0.31.2](https://github.com/grafana/agent/releases/tag/v0.31.2)