### PR TITLE
[agent-operator] Add extraObjects functionality

### DIFF
--- a/charts/agent-operator/Chart.yaml
+++ b/charts/agent-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: grafana-agent-operator
 description: A Helm chart for Grafana Agent Operator
 type: application
-version: 0.2.11
+version: 0.3.0
 appVersion: "0.31.2"
 home: https://grafana.com/docs/agent/v0.30/
 icon: https://raw.githubusercontent.com/grafana/agent/v0.31.2/docs/sources/assets/logo_and_name.png

--- a/charts/agent-operator/README.md
+++ b/charts/agent-operator/README.md
@@ -1,6 +1,6 @@
 # grafana-agent-operator
 
-![Version: 0.2.11](https://img.shields.io/badge/Version-0.2.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.31.2](https://img.shields.io/badge/AppVersion-0.31.2-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.31.2](https://img.shields.io/badge/AppVersion-0.31.2-informational?style=flat-square)
 
 A Helm chart for Grafana Agent Operator
 
@@ -57,6 +57,7 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 | annotations | object | `{}` | Annotations for the Deployment |
 | containerSecurityContext | object | `{}` | Container security context (allowPrivilegeEscalation, etc.) |
 | extraArgs | list | `[]` | List of additional cli arguments to configure agent-operator (example: `--log.level`) |
+| extraObjects | list | `[]` | Extra templated Kubernetes objects |
 | fullnameOverride | string | `""` | Overrides the chart's computed fullname |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.pullSecrets | list | `[]` | Image pull secrets |

--- a/charts/agent-operator/templates/extra-objects.yaml
+++ b/charts/agent-operator/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/agent-operator/values.yaml
+++ b/charts/agent-operator/values.yaml
@@ -63,3 +63,27 @@ tolerations: []
 
 # -- Pod affinity configuration
 affinity: {}
+
+# -- Extra templated Kubernetes objects
+extraObjects: []
+# - apiVersion: monitoring.grafana.com/v1alpha1
+#   kind: GrafanaAgent
+#   metadata:
+#     name: grafana-agent
+#     namespace: default
+#     labels:
+#       app: grafana-agent
+#   spec:
+#     image: grafana/agent:v0.31.2
+#     logLevel: info
+#     serviceAccountName: grafana-agent
+#     metrics:
+#       instanceSelector:
+#         matchLabels:
+#           agent: grafana-agent-metrics
+#       externalLabels:
+#         cluster: cloud
+#     logs:
+#       instanceSelector:
+#         matchLabels:
+#           agent: grafana-agent-logs


### PR DESCRIPTION
This adds an `extraObjects` value in the same way that the `loki` and `mimir-distributed` charts. This makes it possible for users to deploy GrafanaAgents, MetricsINstances, LogsInstances etc... as part of a single Helm release.