### PR TITLE
[tempo-distributed] feat: add configs for querier.search.* to values.yaml

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.0.1
+version: 1.1.0
 appVersion: 2.0.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -553,6 +553,11 @@ The memcached default args are removed and should be provided manually. The sett
 | querier.autoscaling.targetCPUUtilizationPercentage | int | `60` | Target CPU utilisation percentage for the querier |
 | querier.autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory utilisation percentage for the querier |
 | querier.config.frontend_worker.grpc_client_config | object | `{}` | grpc client configuration |
+| querier.config.search.external_endpoints | list | `[]` | A list of external endpoints that the querier will use to offload backend search requests |
+| querier.config.search.external_hedge_requests_at | string | `"8s"` | If set to a non-zero value a second request will be issued at the provided duration. Recommended to be set to p99 of external search requests to reduce long tail latency. |
+| querier.config.search.external_hedge_requests_up_to | int | `2` | The maximum number of requests to execute when hedging. Requires hedge_requests_at to be set. |
+| querier.config.search.prefer_self | int | `10` | If search_external_endpoints is set then the querier will primarily act as a proxy for whatever serverless backend you have configured. This setting allows the operator to have the querier prefer itself for a configurable number of subqueries. |
+| querier.config.search.query_timeout | string | `"30s"` | Timeout for search requests |
 | querier.extraArgs | list | `[]` | Additional CLI args for the querier |
 | querier.extraEnv | list | `[]` | Environment variables to add to the querier pods |
 | querier.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the querier pods |

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -569,6 +569,18 @@ querier:
     frontend_worker:
       # -- grpc client configuration
       grpc_client_config: {}
+    search:
+      # -- A list of external endpoints that the querier will use to offload backend search requests
+      external_endpoints: []
+      # -- Timeout for search requests
+      query_timeout: 30s
+      # -- If search_external_endpoints is set then the querier will primarily act as a proxy for whatever serverless backend you have configured. This setting allows the operator to have the querier prefer itself for a configurable number of subqueries.
+      prefer_self: 10
+      # -- If set to a non-zero value a second request will be issued at the provided duration. Recommended to be set to p99 of external search requests to reduce long tail latency.
+      external_hedge_requests_at: 8s
+      # -- The maximum number of requests to execute when hedging. Requires hedge_requests_at to be set.
+      external_hedge_requests_up_to: 2
+
   service:
     # -- Annotations for querier service
     annotations: {}
@@ -916,6 +928,12 @@ config: |
       grpc_client_config:
         {{- toYaml .Values.querier.config.frontend_worker.grpc_client_config | nindent 6 }}
       {{- end }}
+    search:
+      external_endpoints: {{ .Values.querier.config.search.external_endpoints }}
+      query_timeout: {{ .Values.querier.config.search.query_timeout }}
+      prefer_self: {{ .Values.querier.config.search.prefer_self }}
+      external_hedge_requests_at: {{ .Values.querier.config.search.external_hedge_requests_at }}
+      external_hedge_requests_up_to: {{ .Values.querier.config.search.external_hedge_requests_up_to }}
   ingester:
     lifecycler:
       ring:


### PR DESCRIPTION
This PR enables a user to configure the options under `query.search.*`: https://grafana.com/docs/tempo/latest/configuration/#querier

I came across this need while trying to set up a serverless backend for the tempo-querier deployment, and described in this guide: https://grafana.com/docs/tempo/latest/operations/serverless_gcp/

Checklist

 - [x] DCO signed
 - [x] Chart Version bumped
 - [x] Title of the PR starts with chart name (e.g. [tempo-distributed])