### PR TITLE
[tempo-distributed] Align nginx TLD usage with `loki`

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: 2.0.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -1444,7 +1444,7 @@ gateway:
         {{- if .Values.gateway.nginxConfig.resolver }}
         resolver {{ .Values.gateway.nginxConfig.resolver }};
         {{- else }}
-        resolver {{ .Values.global.dnsService }}.{{ .Values.global.dnsNamespace }}.svc.{{ .Values.global.clusterDomain }};
+        resolver {{ .Values.global.dnsService }}.{{ .Values.global.dnsNamespace }}.svc.{{ .Values.global.clusterDomain }}.;
         {{- end }}
 
         {{- with .Values.gateway.nginxConfig.httpSnippet }}


### PR DESCRIPTION
Currently, the tempo-distributed chart renders can render a broken nginx configuration when the name given for `clusterDomain` is not a root domain.   In some environments when recursing the DNS name given within the search domain of the resolvers causes an invalid name to be queried, nginx will not start.  Here we adjust the nginx template to append the root zone `.` to the `clusterDomain`.  This will mean that any name given will be treated as a TLD by the nginx resolver confguration.