### PR TITLE
Added namespacing to the loki-distributed helm chart resources

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.7.3
-version: 0.69.6
+version: 0.69.7
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/templates/compactor/deployment-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/deployment-compactor.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "loki.compactorFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.compactorLabels" . | nindent 4 }}
   {{- with .Values.loki.annotations }}

--- a/charts/loki-distributed/templates/compactor/persistentvolumeclaim-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/persistentvolumeclaim-compactor.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: data-{{ include "loki.compactorFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.compactorLabels" . | nindent 4 }}
   {{- with .Values.compactor.persistence.annotations }}

--- a/charts/loki-distributed/templates/compactor/service-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/service-compactor.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.compactorFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
     {{- with .Values.compactor.serviceLabels }}

--- a/charts/loki-distributed/templates/compactor/serviceaccount-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/serviceaccount-compactor.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "loki.compactorServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
   {{- with .Values.compactor.serviceAccount.annotations }}

--- a/charts/loki-distributed/templates/configmap.yaml
+++ b/charts/loki-distributed/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "loki.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 data:

--- a/charts/loki-distributed/templates/distributor/deployment-distributor.yaml
+++ b/charts/loki-distributed/templates/distributor/deployment-distributor.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "loki.distributorFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.distributorLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/charts/loki-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
+++ b/charts/loki-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
@@ -6,6 +6,7 @@ apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.distributorFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.distributorLabels" . | nindent 4 }}
 spec:

--- a/charts/loki-distributed/templates/distributor/service-distributor.yaml
+++ b/charts/loki-distributed/templates/distributor/service-distributor.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.distributorFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.distributorLabels" . | nindent 4 }}
     {{- with .Values.distributor.serviceLabels }}

--- a/charts/loki-distributed/templates/ingester/deployment-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/deployment-ingester.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "loki.ingesterFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.ingesterLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/charts/loki-distributed/templates/ingester/hpa.yaml
+++ b/charts/loki-distributed/templates/ingester/hpa.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.ingesterFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.ingesterLabels" . | nindent 4 }}
 spec:

--- a/charts/loki-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
@@ -6,6 +6,7 @@ apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.ingesterFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.ingesterLabels" . | nindent 4 }}
 spec:

--- a/charts/loki-distributed/templates/ingester/service-ingester-headless.yaml
+++ b/charts/loki-distributed/templates/ingester/service-ingester-headless.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.ingesterFullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.ingesterSelectorLabels" . | nindent 4 }}
     prometheus.io/service-monitor: "false"

--- a/charts/loki-distributed/templates/ingester/service-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/service-ingester.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.ingesterFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.ingesterLabels" . | nindent 4 }}
     {{- with .Values.ingester.serviceLabels }}

--- a/charts/loki-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/statefulset-ingester.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "loki.ingesterFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.ingesterLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/charts/loki-distributed/templates/ingress.yaml
+++ b/charts/loki-distributed/templates/ingress.yaml
@@ -6,6 +6,7 @@ apiVersion: {{ include "loki.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "loki.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/loki-distributed/templates/memcached-chunks/poddisruptionbudget-memcached-chunks.yaml
+++ b/charts/loki-distributed/templates/memcached-chunks/poddisruptionbudget-memcached-chunks.yaml
@@ -6,6 +6,7 @@ apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.memcachedChunksFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.memcachedChunksLabels" . | nindent 4 }}
 spec:

--- a/charts/loki-distributed/templates/memcached-chunks/service-memcached-chunks.yaml
+++ b/charts/loki-distributed/templates/memcached-chunks/service-memcached-chunks.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.memcachedChunksFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.memcachedChunksSelectorLabels" . | nindent 4 }}
     {{- with .Values.memcachedChunks.serviceLabels }}

--- a/charts/loki-distributed/templates/memcached-chunks/statefulset-memcached-chunks.yaml
+++ b/charts/loki-distributed/templates/memcached-chunks/statefulset-memcached-chunks.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "loki.memcachedChunksFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.memcachedChunksLabels" . | nindent 4 }}
   {{- with .Values.loki.annotations }}

--- a/charts/loki-distributed/templates/memcached-frontend/poddisruptionbudget-memcached-frontend.yaml
+++ b/charts/loki-distributed/templates/memcached-frontend/poddisruptionbudget-memcached-frontend.yaml
@@ -6,6 +6,7 @@ apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.memcachedFrontendFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.memcachedFrontendLabels" . | nindent 4 }}
 spec:

--- a/charts/loki-distributed/templates/memcached-frontend/service-memcached-frontend.yaml
+++ b/charts/loki-distributed/templates/memcached-frontend/service-memcached-frontend.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.memcachedFrontendFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.memcachedFrontendSelectorLabels" . | nindent 4 }}
     {{- with .Values.memcachedFrontend.serviceLabels }}

--- a/charts/loki-distributed/templates/memcached-frontend/statefulset-memcached-frontend.yaml
+++ b/charts/loki-distributed/templates/memcached-frontend/statefulset-memcached-frontend.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "loki.memcachedFrontendFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.memcachedFrontendLabels" . | nindent 4 }}
   {{- with .Values.loki.annotations }}

--- a/charts/loki-distributed/templates/memcached-index-queries/poddisruptionbudget-memcached-index-queries.yaml
+++ b/charts/loki-distributed/templates/memcached-index-queries/poddisruptionbudget-memcached-index-queries.yaml
@@ -6,6 +6,7 @@ apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.memcachedIndexQueriesFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.memcachedIndexQueriesLabels" . | nindent 4 }}
 spec:

--- a/charts/loki-distributed/templates/memcached-index-queries/service-memcached-index-queries.yaml
+++ b/charts/loki-distributed/templates/memcached-index-queries/service-memcached-index-queries.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.memcachedIndexQueriesFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.memcachedIndexQueriesSelectorLabels" . | nindent 4 }}
     {{- with .Values.memcachedIndexQueries.serviceLabels }}

--- a/charts/loki-distributed/templates/memcached-index-queries/statefulset-memcached-index-queries.yaml
+++ b/charts/loki-distributed/templates/memcached-index-queries/statefulset-memcached-index-queries.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "loki.memcachedIndexQueriesFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.memcachedIndexQueriesLabels" . | nindent 4 }}
   {{- with .Values.loki.annotations }}

--- a/charts/loki-distributed/templates/memcached-index-writes/poddisruptionbudget-memcached-index-writes.yaml
+++ b/charts/loki-distributed/templates/memcached-index-writes/poddisruptionbudget-memcached-index-writes.yaml
@@ -6,6 +6,7 @@ apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.memcachedIndexWritesFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.memcachedIndexWritesLabels" . | nindent 4 }}
 spec:

--- a/charts/loki-distributed/templates/memcached-index-writes/service-memcached-index-writes.yaml
+++ b/charts/loki-distributed/templates/memcached-index-writes/service-memcached-index-writes.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.memcachedIndexWritesFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.memcachedIndexWritesSelectorLabels" . | nindent 4 }}
     {{- with .Values.memcachedIndexWrites.serviceLabels }}

--- a/charts/loki-distributed/templates/memcached-index-writes/statefulset-memcached-index-writes.yaml
+++ b/charts/loki-distributed/templates/memcached-index-writes/statefulset-memcached-index-writes.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "loki.memcachedIndexWritesFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.memcachedIndexWritesLabels" . | nindent 4 }}
   {{- with .Values.loki.annotations }}

--- a/charts/loki-distributed/templates/querier/deployment-querier.yaml
+++ b/charts/loki-distributed/templates/querier/deployment-querier.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "loki.querierFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.querierLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/charts/loki-distributed/templates/querier/hpa.yaml
+++ b/charts/loki-distributed/templates/querier/hpa.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.querierFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.querierLabels" . | nindent 4 }}
 spec:

--- a/charts/loki-distributed/templates/querier/poddisruptionbudget-querier.yaml
+++ b/charts/loki-distributed/templates/querier/poddisruptionbudget-querier.yaml
@@ -6,6 +6,7 @@ apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.querierFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.querierLabels" . | nindent 4 }}
 spec:

--- a/charts/loki-distributed/templates/querier/service-querier-headless.yaml
+++ b/charts/loki-distributed/templates/querier/service-querier-headless.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.querierFullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.querierSelectorLabels" . | nindent 4 }}
     prometheus.io/service-monitor: "false"

--- a/charts/loki-distributed/templates/querier/service-querier.yaml
+++ b/charts/loki-distributed/templates/querier/service-querier.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.querierFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.querierLabels" . | nindent 4 }}
     {{- with .Values.querier.serviceLabels }}

--- a/charts/loki-distributed/templates/querier/statefulset-querier.yaml
+++ b/charts/loki-distributed/templates/querier/statefulset-querier.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "loki.querierFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.querierLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/charts/loki-distributed/templates/query-frontend/deployment-query-frontend.yaml
+++ b/charts/loki-distributed/templates/query-frontend/deployment-query-frontend.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "loki.queryFrontendFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.queryFrontendLabels" . | nindent 4 }}
   {{- with .Values.loki.annotations }}

--- a/charts/loki-distributed/templates/query-frontend/hpa.yaml
+++ b/charts/loki-distributed/templates/query-frontend/hpa.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.queryFrontendFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.queryFrontendLabels" . | nindent 4 }}
 spec:

--- a/charts/loki-distributed/templates/query-frontend/poddisruptionbudget-query-frontent.yaml
+++ b/charts/loki-distributed/templates/query-frontend/poddisruptionbudget-query-frontent.yaml
@@ -6,6 +6,7 @@ apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.queryFrontendFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.queryFrontendLabels" . | nindent 4 }}
 spec:

--- a/charts/loki-distributed/templates/query-frontend/service-query-frontend-headless.yaml
+++ b/charts/loki-distributed/templates/query-frontend/service-query-frontend-headless.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.queryFrontendFullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.queryFrontendLabels" . | nindent 4 }}
     {{- with .Values.queryFrontend.serviceLabels }}

--- a/charts/loki-distributed/templates/query-frontend/service-query-frontend.yaml
+++ b/charts/loki-distributed/templates/query-frontend/service-query-frontend.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.queryFrontendFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.queryFrontendLabels" . | nindent 4 }}
     {{- with .Values.queryFrontend.serviceLabels }}

--- a/charts/loki-distributed/templates/query-scheduler/deployment-query-scheduler.yaml
+++ b/charts/loki-distributed/templates/query-scheduler/deployment-query-scheduler.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "loki.querySchedulerFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.querySchedulerLabels" . | nindent 4 }}
   {{- with .Values.loki.annotations }}

--- a/charts/loki-distributed/templates/query-scheduler/poddisruptionbudget-query-scheduler.yaml
+++ b/charts/loki-distributed/templates/query-scheduler/poddisruptionbudget-query-scheduler.yaml
@@ -6,6 +6,7 @@ apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.querySchedulerFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.querySchedulerLabels" . | nindent 4 }}
 spec:

--- a/charts/loki-distributed/templates/query-scheduler/service-query-scheduler.yaml
+++ b/charts/loki-distributed/templates/query-scheduler/service-query-scheduler.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.querySchedulerFullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.querySchedulerLabels" . | nindent 4 }}
     {{- with .Values.queryScheduler.serviceLabels }}

--- a/charts/loki-distributed/templates/runtime-configmap.yaml
+++ b/charts/loki-distributed/templates/runtime-configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "loki.fullname" . }}-runtime
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 data:

--- a/charts/loki-distributed/templates/service-memberlist.yaml
+++ b/charts/loki-distributed/templates/service-memberlist.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.fullname" . }}-memberlist
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:

--- a/charts/loki-distributed/templates/serviceaccount.yaml
+++ b/charts/loki-distributed/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "loki.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
Currently, the loki-distributed chart unlike the tempo-distributed chart creates all of its resources in the default namespace when using tools such as kustomize with helm charts.
![image](https://user-images.githubusercontent.com/40371122/218635448-97e4e46c-4511-429a-8de3-56937d586f70.png)

I've updated the loki-distributed chart to match the namespacing of the tempo-distributed chart.