### PR TITLE
[tempo-distributed] call toYaml on list data type

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: 2.0.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -929,7 +929,7 @@ config: |
         {{- toYaml .Values.querier.config.frontend_worker.grpc_client_config | nindent 6 }}
       {{- end }}
     search:
-      external_endpoints: {{ .Values.querier.config.search.external_endpoints }}
+      external_endpoints: {{- toYaml .Values.querier.config.search.external_endpoints | nindent 6 }}
       query_timeout: {{ .Values.querier.config.search.query_timeout }}
       prefer_self: {{ .Values.querier.config.search.prefer_self }}
       external_hedge_requests_at: {{ .Values.querier.config.search.external_hedge_requests_at }}


### PR DESCRIPTION
I added a config option for `querier.config.search.external_endpoints` in a previous PR: https://github.com/grafana/helm-charts/pull/2195 but I forgot to call `toYaml` on it. I believe it needs the `toYaml` call because it is a `list` type.

While this doesn't cause an issue for regular strings:
```
querier:
  config:
    search:
      external_endpoints:
        - https://my-serverless-endpoint-asdf-uw.a.run.app
```

when we pass in an env var:

```
querier:
  config:
    search:
      external_endpoints:
        - ${MY_SERVERLESS_ENDPOINT}
```
we get the following error:

```
Error: 'error converting YAML to JSON: yaml: line 87: did not find expected '','' or '']'''
```

This PR fixes the bug.
I tested locally and can confirm the fix using both a single item and multi-item list.

Checklist:

 - [x] DCO signed
 - [x] Chart Version bumped
 - [x] Title of the PR starts with chart name (e.g. [tempo-distributed])