### PR TITLE
[tempo-distributed] fix: correct lookup of policy apiVersion for pbd

### DIFF
--- a/charts/tempo-distributed/templates/_helpers.tpl
+++ b/charts/tempo-distributed/templates/_helpers.tpl
@@ -152,7 +152,7 @@ Return if ingress supports pathType.
 Return the appropriate apiVersion for PodDisruptionBudget.
 */}}
 {{- define "tempo.pdb.apiVersion" -}}
-  {{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
+  {{- if .Capabilities.APIVersions.Has "policy/v1" -}}
     {{- print "policy/v1" -}}
   {{- else -}}
     {{- print "policy/v1beta1" -}}


### PR DESCRIPTION
`v1.25.5-gke.2000` supports only `policy/v1`, but the chart defaults to `policy/v1beta1`
Probably `kind` shouldn't append `apiVersion`

ArgoCD:
<img width="786" alt="image" src="https://user-images.githubusercontent.com/20767197/218818826-276b6ce3-d8e9-4a87-b3fa-263937dd102a.png">
