### PR TITLE
[grafana] Basic auth for dashboard downloader

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.50.7
+version: 6.50.8
 appVersion: 9.3.6
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/configmap.yaml
+++ b/charts/grafana/templates/configmap.yaml
@@ -88,6 +88,9 @@ data:
         {{- if $value.bearerToken }}
     -H "Authorization: Bearer {{ $value.bearerToken }}" \
         {{- end }}
+        {{- if $value.basic }}
+    -H "Basic: {{ $value.basic }}" \
+        {{- end }}
         {{- if $value.gitlabToken }}
     -H "PRIVATE-TOKEN: {{ $value.gitlabToken }}" \
         {{- end }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -675,7 +675,7 @@ dashboards: {}
   #     bearerToken: ''
   #   local-dashboard-azure:
   #     url: https://example.com/repository/test-azure.json
-  #     basic: '
+  #     basic: ''
 
 ## Reference to external ConfigMap per provider. Use provider name as key and ConfigMap name as value.
 ## A provider dashboards must be defined either by external ConfigMaps or in values.yaml, not in both.

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -673,6 +673,9 @@ dashboards: {}
   #   local-dashboard-bitbucket:
   #     url: https://example.com/repository/test-bitbucket.json
   #     bearerToken: ''
+  #   local-dashboard-azure:
+  #     url: https://example.com/repository/test-azure.json
+  #     basic: '
 
 ## Reference to external ConfigMap per provider. Use provider name as key and ConfigMap name as value.
 ## A provider dashboards must be defined either by external ConfigMaps or in values.yaml, not in both.


### PR DESCRIPTION
Hey everyone,

Tried to import a dashboard from a private Azure Repos but this needs an authorization header which is currently not supported by the chart.

See the [documentation](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows#use-a-pat).