### PR TITLE
[promtail] Allow parent charts to override registry hostname and credentials

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.7.3
-version: 6.9.0
+version: 6.10.0
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
-appVersion: 2.7.3
+appVersion: 2.7.4
 version: 6.10.0
 home: https://grafana.com/loki
 sources:

--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.8.3
-version: 6.11.8
+version: 6.11.9
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 6.11.9](https://img.shields.io/badge/Version-6.11.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
+![Version: 6.11.9](https://img.shields.io/badge/Version-6.11.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.3](https://img.shields.io/badge/AppVersion-2.8.3-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 6.11.8](https://img.shields.io/badge/Version-6.11.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
+![Version: 6.11.9](https://img.shields.io/badge/Version-6.11.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 
@@ -106,6 +106,8 @@ The new release which will pick up again from the existing `positions.yaml`.
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `nil` | Overrides the chart's computed fullname |
+| global.imagePullSecrets | list | `[]` | Allow parent charts to override registry credentials |
+| global.imageRegistry | string | `""` | Allow parent charts to override registry hostname |
 | httpPathPrefix | string | `""` | Base path to server all API routes fro |
 | image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | image.registry | string | `"docker.io"` | The Docker registry |

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -102,8 +102,6 @@ The new release which will pick up again from the existing `positions.yaml`.
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `nil` | Overrides the chart's computed fullname |
-| global.imageRegistry | string | `""` | Global Docker image registry |
-| global.imagePullSecrets | list | `[]` | Global Docker registry secret names as an array |
 | httpPathPrefix | string | `""` | Base path to server all API routes fro |
 | image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | image.registry | string | `"docker.io"` | The Docker registry |

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -102,6 +102,8 @@ The new release which will pick up again from the existing `positions.yaml`.
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `nil` | Overrides the chart's computed fullname |
+| global.imageRegistry | string | `""` | Global Docker image registry |
+| global.imagePullSecrets | list | `[]` | Global Docker registry secret names as an array |
 | httpPathPrefix | string | `""` | Base path to server all API routes fro |
 | image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | image.registry | string | `"docker.io"` | The Docker registry |

--- a/charts/promtail/templates/_pod.tpl
+++ b/charts/promtail/templates/_pod.tpl
@@ -25,7 +25,7 @@ spec:
   initContainers:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .Values.imagePullSecrets }}
+  {{- with .Values.global.imagePullSecrets | default .Values.imagePullSecrets }}
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -33,7 +33,7 @@ spec:
     {{- toYaml .Values.podSecurityContext | nindent 4 }}
   containers:
     - name: promtail
-      image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+      image: "{{ .Values.global.imageRegistry | default .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
       imagePullPolicy: {{ .Values.image.pullPolicy }}
       args:
         - "-config.file=/etc/promtail/promtail.yaml"

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -4,6 +4,12 @@ nameOverride: null
 # -- Overrides the chart's computed fullname
 fullnameOverride: null
 
+global:
+  # -- Allow parent charts to override registry hostname
+  imageRegistry: ""
+  # -- Allow parent charts to override registry credentials
+  imagePullSecrets: []
+
 daemonset:
   # -- Deploys Promtail as a DaemonSet
   enabled: true


### PR DESCRIPTION
Reworked PR #2219 with a rebase and incremented minor version.

Add support for optionally overriding the registry hostname and credentials from a parent chart.

This is important for air-gapped installations which do not have direct access to the public internet and must use a private, internal container registry.

It also avoids having to modify the Promtail Helm chart directly.

FAO: @unguiculus and @Whyeasy 