### PR TITLE
[loki-canary] Allow to configure canary namespace and update to latest app version (2.7.4)

### DIFF
--- a/charts/loki-canary/Chart.yaml
+++ b/charts/loki-canary/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: loki-canary
 description: Helm chart for Grafana Loki Canary
 type: application
-appVersion: 2.7.3
+appVersion: 2.7.4
 version: 0.11.0
 home: https://github.com/grafana/helm-charts
 sources:

--- a/charts/loki-canary/Chart.yaml
+++ b/charts/loki-canary/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: loki-canary
 description: Helm chart for Grafana Loki Canary
 type: application
-appVersion: 2.6.1
-version: 0.10.0
+appVersion: 2.7.3
+version: 0.11.0
 home: https://github.com/grafana/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-canary/README.md
+++ b/charts/loki-canary/README.md
@@ -1,6 +1,6 @@
 # loki-canary
 
-![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.3](https://img.shields.io/badge/AppVersion-2.7.3-informational?style=flat-square)
 
 Helm chart for Grafana Loki Canary
 
@@ -39,6 +39,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | imagePullSecrets | list | `[]` | Image pull secrets for Docker images |
 | lokiAddress | string | `nil` | The Loki server URL:Port, e.g. loki:3100 |
 | nameOverride | string | `""` | Overrides the chart's name |
+| namespace.name | string | `nil` | The name of the Namespace to deploy If not set, `.Release.Namespace` is used |
 | nodeSelector | object | `{}` | Node selector for canary pods |
 | podAnnotations | object | `{}` | Common annotations for all pods |
 | podLabels | object | `{}` | Common labels for all pods |

--- a/charts/loki-canary/README.md
+++ b/charts/loki-canary/README.md
@@ -1,6 +1,6 @@
 # loki-canary
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.3](https://img.shields.io/badge/AppVersion-2.7.3-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.4](https://img.shields.io/badge/AppVersion-2.7.4-informational?style=flat-square)
 
 Helm chart for Grafana Loki Canary
 

--- a/charts/loki-canary/templates/_helpers.tpl
+++ b/charts/loki-canary/templates/_helpers.tpl
@@ -51,6 +51,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Create the name of the namespace
+*/}}
+{{- define "loki-canary.namespaceName" -}}
+{{- default .Release.Namespace .Values.namespace.name }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "loki-canary.serviceAccountName" -}}

--- a/charts/loki-canary/templates/daemonset.yaml
+++ b/charts/loki-canary/templates/daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "loki-canary.fullname" . }}
+  namespace: {{ include "loki-canary.namespaceName" . }}
   labels:
     {{- include "loki-canary.labels" . | nindent 4 }}
 spec:

--- a/charts/loki-canary/templates/secret.yaml
+++ b/charts/loki-canary/templates/secret.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "loki-canary.fullname" $ }}
+  namespace: {{ include "loki-canary.namespaceName" $ }}
   labels:
     {{- include "loki-canary.labels" $ | nindent 4 }}
 stringData:

--- a/charts/loki-canary/templates/service.yaml
+++ b/charts/loki-canary/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki-canary.fullname" . }}
+  namespace: {{ include "loki-canary.namespaceName" . }}
   labels:
     {{- include "loki-canary.labels" . | nindent 4 }}
 spec:

--- a/charts/loki-canary/templates/serviceaccount.yaml
+++ b/charts/loki-canary/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "loki-canary.fullname" . }}
+  namespace: {{ include "loki-canary.namespaceName" . }}
   labels:
     {{- include "loki-canary.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/loki-canary/values.yaml
+++ b/charts/loki-canary/values.yaml
@@ -4,6 +4,11 @@ nameOverride: ""
 # -- Overrides the chart's computed fullname
 fullnameOverride: ""
 
+namespace:
+  # -- The name of the Namespace to deploy
+  # If not set, `.Release.Namespace` is used
+  name: null
+
 # -- Image pull secrets for Docker images
 imagePullSecrets: []
 


### PR DESCRIPTION
As it was done for promtail https://github.com/grafana/helm-charts/pull/2064, now for loki-canary.