### PR TITLE
[grafana] fix image-renderer network policy

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.50.8
+version: 6.50.9
 appVersion: 9.3.6
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/image-renderer-network-policy.yaml
+++ b/charts/grafana/templates/image-renderer-network-policy.yaml
@@ -24,7 +24,7 @@ spec:
       from:
         - namespaceSelector:
             matchLabels:
-              name: {{ include "grafana.namespace" . }}
+              kubernetes.io/metadata.name: {{ include "grafana.namespace" . }}
           podSelector:
             matchLabels:
               {{- include "grafana.selectorLabels" . | nindent 14 }}


### PR DESCRIPTION
The currently defined network policy only works when the image renderer
is matching the authorized namespace based on the `name` label, which is
not a label all kubernetes namespace have, but instead a widely used but
nevertheless not universal label.

The default label for all namespace, added by the API server, is
`kubernetes.io/metadata.name`, as documented here:
https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-metadata-name

By changing this labelSelector for the `namespaceSelector` clause, we
permit users of kubernetes distribution where no `name` label is
set on namespaces to use the image renderer without issue,
and we don't impact the usability of other users.
