### PR TITLE
[tempo-distributed] fix: disable minio by default

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.2.1
+version: 1.2.2
 appVersion: 2.0.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -530,7 +530,7 @@ The memcached default args are removed and should be provided manually. The sett
 | minio.buckets[2].policy | string | `"none"` |  |
 | minio.buckets[2].purge | bool | `false` |  |
 | minio.configPathmc | string | `"/tmp/minio/mc/"` |  |
-| minio.enabled | bool | `true` |  |
+| minio.enabled | bool | `false` |  |
 | minio.mode | string | `"standalone"` |  |
 | minio.persistence.size | string | `"5Gi"` |  |
 | minio.resources.requests.cpu | string | `"100m"` |  |

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -1259,7 +1259,7 @@ prometheusRule:
   #       expr: sum(rate(container_cpu_usage_seconds_total[1m])) by (node, namespace, pod, container)
 
 minio:
-  enabled: true
+  enabled: false
   mode: standalone
   rootUser: grafana-tempo
   rootPassword: supersecret


### PR DESCRIPTION
after https://github.com/grafana/helm-charts/pull/1759 was merged, the tempo-distributed chart unexpectedly installed minio in our k8s cluster which resulted in a bunch of new pods crash looping and setting off prom alerts. as a side note, something about the way the minio chart generates resources causes a bunch of merge conflicts in our gitops CI commitback logic. because of this, the helm principal that charts should always be installable using only default values, and the below linked commit, it seems best to disable minio by default
ref: https://github.com/grafana/helm-charts/pull/1759#issuecomment-1448460904