### PR TITLE
[grafana] Allow setting persistentVolumeReclaimPolicy for persistent volume

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.52.1
+version: 6.52.2
 appVersion: 9.4.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -106,6 +106,7 @@ This version requires Helm >= 3.1.0.
 | `persistence.finalizers`                  | PersistentVolumeClaim finalizers              | `[ "kubernetes.io/pvc-protection" ]`                    |
 | `persistence.extraPvcLabels`              | Extra labels to apply to a PVC.               | `{}`                                                    |
 | `persistence.subPath`                     | Mount a sub dir of the persistent volume (can be templated) | `nil`                                     |
+| `persistence.persistentVolumeReclaimPolicy` | persistentVolumeReclaimPolicy of the persistent volume | `Delete`                                     |
 | `persistence.inMemory.enabled`            | If persistence is not enabled, whether to mount the local storage in-memory to improve performance | `false`                                                   |
 | `persistence.inMemory.sizeLimit`          | SizeLimit for the in-memory local storage     | `nil`                                                   |
 | `initChownData.enabled`                   | If false, don't reset data ownership at startup | true                                                  |

--- a/charts/grafana/templates/pvc.yaml
+++ b/charts/grafana/templates/pvc.yaml
@@ -33,4 +33,7 @@ spec:
     matchLabels:
     {{- toYaml . | nindent 6 }}
   {{- end }}
+  {{- with .Values.persistence.persistentVolumeReclaimPolicy }}
+  persistentVolumeReclaimPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -318,6 +318,7 @@ persistence:
   # annotations: {}
   finalizers:
     - kubernetes.io/pvc-protection
+  persistentVolumeReclaimPolicy: Delete
   # selectorLabels: {}
   ## Sub-directory of the PV to mount. Can be templated.
   # subPath: ""


### PR DESCRIPTION
In the default configuration (using deployment instead of statefulset), a pod eviction can delete the persistent volume. Using StatefulSet helps somewhat, but I can sleep better at night if I know that my grafana persistent volume is not easily accidentally deleted. (This keeps the kubernetes default of `Delete` but can be set to e.g. `Retain`)