### PR TITLE
[grafana] bump default grafana image tag to 9.3.8

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.51.1
-appVersion: 9.3.6
+version: 6.51.2
+appVersion: 9.3.8
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net


### PR DESCRIPTION
See details about included hotfixes (since 9.3.6):
- v9.3.7 was never released → but the changes are listed as 9.3.7 here: https://github.com/grafana/grafana/blob/main/CHANGELOG.md#938-2023-02-28
- https://github.com/grafana/grafana/releases/tag/v9.3.8