### PR TITLE
[grafana] bumped grafana version to 9.4.3

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.51.5
-appVersion: 9.3.8
+version: 6.52.0
+appVersion: 9.4.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net


### PR DESCRIPTION
bumped Grafana to the latest version `9.4.3` released on the 2nd of March, 2023 (https://github.com/grafana/grafana/blob/main/CHANGELOG.md)