### PR TITLE
[tempo] Make tmp directory read/write when using metricsGenerator

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: 2.0.1
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 

--- a/charts/tempo/templates/statefulset.yaml
+++ b/charts/tempo/templates/statefulset.yaml
@@ -90,6 +90,10 @@ spec:
         - mountPath: /var/tempo
           name: storage
         {{- end }}
+        {{- if .Values.tempo.metricsGenerator.enabled }}
+        - mountPath: /tmp
+          name: tmp
+        {{- end }}
       {{- if .Values.tempoQuery.enabled }}
       - args:
         - --query.base-path=/
@@ -150,6 +154,10 @@ spec:
       - configMap:
           name: {{ template "tempo.name" . }}
         name: tempo-conf
+      {{- if .Values.tempo.metricsGenerator.enabled }}
+      - name: tmp
+        emptyDir: {}
+      {{- end }}
   updateStrategy:
     type: {{- toYaml .Values.tempo.updateStrategy | nindent 6 }}
   {{- if .Values.persistence.enabled }}


### PR DESCRIPTION
I got an error when I enabled metricsGenerator:
```
/tmp/tempo: read-only file system
```

To fix this, this PR makes /tmp mounted to emptyDir