### PR TITLE
[loki-distributed] Allow adding extra configurations for the index_gateway_client

### DIFF
--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -122,8 +122,8 @@ loki:
     {{- if .Values.loki.storageConfig}}
     storage_config:
     {{- if .Values.indexGateway.enabled}}
-    {{- $indexGatewayClient := dict "server_address" (printf "dns:///%s:9095" (include "loki.indexGatewayFullname" .)) }}
-    {{- $_ := set .Values.loki.storageConfig.boltdb_shipper "index_gateway_client" $indexGatewayClient }}
+      index_gateway_client:
+        server_address: dns:///{{ include "loki.indexGatewayFullname" .}}:9095
     {{- end}}
     {{- toYaml .Values.loki.storageConfig | nindent 2}}
     {{- if .Values.memcachedIndexQueries.enabled }}


### PR DESCRIPTION
Hi, 
There will be more configurations that we can or wants to add under the `index_gateway_client` for the `boltdb_shipper` block rather than just a `server_address`.
The main purpose of this simple PR is to make it easier to add some more configurations for the `index_gateway_client`.
