### PR TITLE
[grafana] Possibility to change Accept header for dashboard downloader

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.51.5
+version: 6.51.6
 appVersion: 9.3.8
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/configmap.yaml
+++ b/charts/grafana/templates/configmap.yaml
@@ -87,7 +87,11 @@ data:
     --connect-timeout 60 \
     --max-time 60 \
       {{- if not $value.b64content }}
+        {{- if not $value.acceptHeader }}
     -H "Accept: application/json" \
+        {{- else }}
+    -H "Accept: {{ $value.acceptHeader }}" \
+        {{- end }}
         {{- if $value.token }}
     -H "Authorization: token {{ $value.token }}" \
         {{- end }}
@@ -95,7 +99,7 @@ data:
     -H "Authorization: Bearer {{ $value.bearerToken }}" \
         {{- end }}
         {{- if $value.basic }}
-    -H "Basic: {{ $value.basic }}" \
+    -H "Authorization: Basic {{ $value.basic }}" \
         {{- end }}
         {{- if $value.gitlabToken }}
     -H "PRIVATE-TOKEN: {{ $value.gitlabToken }}" \

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -676,6 +676,7 @@ dashboards: {}
   #   local-dashboard-azure:
   #     url: https://example.com/repository/test-azure.json
   #     basic: ''
+  #     acceptHeader: '*/*'
 
 ## Reference to external ConfigMap per provider. Use provider name as key and ConfigMap name as value.
 ## A provider dashboards must be defined either by external ConfigMaps or in values.yaml, not in both.


### PR DESCRIPTION
Hey,

The cURL Accept header needs to be different from the default _"application/json"_ in order to download from Azure repos.
You won't receive the actual file content in the response if the default one is used.