### PR TITLE
[rollout-operator] Update for v0.4.0

### DIFF
--- a/charts/rollout-operator/Chart.yaml
+++ b/charts/rollout-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-operator
 description: "Grafana rollout-operator"
 type: application
-version: 0.2.0
-appVersion: v0.2.0
+version: 0.4.0
+appVersion: v0.4.0
 home: https://github.com/grafana/rollout-operator
 kubeVersion: ^1.10.0-0

--- a/charts/rollout-operator/README.md
+++ b/charts/rollout-operator/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana rollout-operator](https://github.com/grafana/r
 
 # rollout-operator
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.4.0](https://img.shields.io/badge/AppVersion-v0.4.0-informational?style=flat-square)
 
 Grafana rollout-operator
 


### PR DESCRIPTION
Updating the helm chart to correspond with the new [release](https://github.com/grafana/rollout-operator/releases/tag/v0.4.0) and [image](https://hub.docker.com/layers/grafana/rollout-operator/v0.4.0/images/sha256-f4c1cd20f97e6ca2248ed3c2e50d8d221a0ea2e7b431d9c56a9c001bcfd1984d?context=explore)