### PR TITLE
[promtail] Add control to disable Promtail config in Helm chart

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.7.4
-version: 6.9.3
+version: 6.9.4
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 6.9.3](https://img.shields.io/badge/Version-6.9.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.4](https://img.shields.io/badge/AppVersion-2.7.4-informational?style=flat-square)
+![Version: 6.9.4](https://img.shields.io/badge/Version-6.9.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.4](https://img.shields.io/badge/AppVersion-2.7.4-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -73,6 +73,7 @@ The new release which will pick up again from the existing `positions.yaml`.
 | config | object | See `values.yaml` | Section for crafting Promtails config file. The only directly relevant value is `config.file` which is a templated string that references the other values and snippets below this key. |
 | config.clients | list | See `values.yaml` | The config of clients of the Promtail server Must be reference in `config.file` to configure `clients` |
 | config.enableTracing | bool | `false` | The config to enable tracing |
+| config.enabled | bool | `true` | Enable Promtail config from Helm chart Set `configmap.enabled: true` and this to `false` to manage your own Promtail config See default config in `values.yaml` |
 | config.file | string | See `values.yaml` | Config file contents for Promtail. Must be configured as string. It is templated so it can be assembled from reusable snippets in order to avoid redundancy. |
 | config.logFormat | string | `"logfmt"` | The log format of the Promtail server Must be reference in `config.file` to configure `server.log_format` Valid formats: `logfmt, json` See default config in `values.yaml` |
 | config.logLevel | string | `"info"` | The log level of the Promtail server Must be reference in `config.file` to configure `server.log_level` See default config in `values.yaml` |

--- a/charts/promtail/templates/configmap.yaml
+++ b/charts/promtail/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.configmap.enabled }}
+{{- if and .Values.config.enabled .Values.configmap.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -28,7 +28,7 @@ secret:
 
 configmap:
   # -- If enabled, promtail config will be created as a ConfigMap instead of a secret
-  enabled: false
+  enabled: true
 
 initContainer: []
   # # -- Specifies whether the init container for setting inotify max user instances is to be enabled
@@ -333,6 +333,10 @@ podSecurityPolicy:
 # which is a templated string that references the other values and snippets below this key.
 # @default -- See `values.yaml`
 config:
+  # -- Enable Promtail config from Helm chart
+  # Set `configmap.enabled: true` and this to `false` to manage your own Promtail config
+  # See default config in `values.yaml`
+  enabled: true
   # -- The log level of the Promtail server
   # Must be reference in `config.file` to configure `server.log_level`
   # See default config in `values.yaml`

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -28,7 +28,7 @@ secret:
 
 configmap:
   # -- If enabled, promtail config will be created as a ConfigMap instead of a secret
-  enabled: true
+  enabled: false
 
 initContainer: []
   # # -- Specifies whether the init container for setting inotify max user instances is to be enabled


### PR DESCRIPTION
I would like to be able to control my Promtail config from outside the Helm chart. The proposed change does not change default behaviour.

I use the Helm chart with Kustomize `HelmChartInflatorGenerator` and this would let me use my own ConfigMap for the Promtail config file which I can then e.g. use `ConfigMapGenerator` to restart my Promtail DaemonSet one config change.