### PR TITLE
[fluent-bit] Add automountServiceAccountToken variable

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: fluent-bit
-version: 2.4.0
+version: 2.5.0
 appVersion: v2.1.0
 kubeVersion: "^1.10.0-0"
 description: "Uses fluent-bit Loki go plugin for gathering logs and sending them to Loki"

--- a/charts/fluent-bit/README.md
+++ b/charts/fluent-bit/README.md
@@ -119,6 +119,7 @@ For more details, read the [Fluent Bit documentation](../../../cmd/fluent-bit/RE
 | `serviceMonitor.enabled` | Create a [Prometheus Operator](operator) serviceMonitor resource for Fluent Bit                    | `false`                          |
 | `podSecurityContext`     | Configure the pod level securityContext                                                            | `{}`                             |
 | `securityContext`        | Configure the fluent-bit container securityContext                                                 | `{}`                             |
+| `automountServiceAccountToken `  | Configure the fluent-bit container automountServiceAccountToken                            | `true`                           |
 
 
 

--- a/charts/fluent-bit/templates/daemonset.yaml
+++ b/charts/fluent-bit/templates/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/charts/fluent-bit/templates/serviceaccount.yaml
+++ b/charts/fluent-bit/templates/serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "fluent-bit-loki.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
 {{- end }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -48,6 +48,8 @@ affinity: {}
 
 annotations: {}
 
+automountServiceAccountToken: true
+
 deploymentStrategy: RollingUpdate
 
 image:


### PR DESCRIPTION
This PR adds the option to disable automounting serviceaccount tokens, both on the serviceaccount level and on the pods. 
This option is important as a best practice, because pods that don't make calls to the Kubernetes API should not have a Kubernetes API token in the first place.