### PR TITLE
[loki-distributed] Updated query_range to use addresses instead of host

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.7.4
-version: 0.69.9
+version: 0.69.10
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/templates/memcached-frontend/_helpers-memcached-frontend.tpl
+++ b/charts/loki-distributed/templates/memcached-frontend/_helpers-memcached-frontend.tpl
@@ -6,7 +6,7 @@ memcached-frontend fullname
 {{- end }}
 
 {{/*
-memcached-frontend fullname
+memcached-frontend labels
 */}}
 {{- define "loki.memcachedFrontendLabels" -}}
 {{ include "loki.labels" . }}

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -166,7 +166,7 @@ loki:
         cache:
           {{- if .Values.memcachedFrontend.enabled }}
           memcached_client:
-            host: {{ include "loki.memcachedFrontendFullname" . }}
+            addresses: dnssrv+_memcached-client._tcp.{{ include "loki.memcachedFrontendFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
             consistent_hash: true
           {{- else }}
           embedded_cache:


### PR DESCRIPTION
I am getting an error when using memcached_frontend
```
level=warn ts=2023-03-23T15:09:31.785668334Z caller=memcached_client.go:228 msg="error updating memcache servers" err="lookup _memcached._tcp.loki-distributed-memcached-frontend on [169.254.20.10:53:](https://169.254.20.10:53/) no such host"
```
Using service instead works for me

Also fixed wrong naming