### PR TITLE
[promtail] remove definition of loki.serviceName

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.7.4
-version: 6.10.0
+version: 6.10.1
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 6.10.0](https://img.shields.io/badge/Version-6.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.4](https://img.shields.io/badge/AppVersion-2.7.4-informational?style=flat-square)
+![Version: 6.10.1](https://img.shields.io/badge/Version-6.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.4](https://img.shields.io/badge/AppVersion-2.7.4-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/templates/_helpers.tpl
+++ b/charts/promtail/templates/_helpers.tpl
@@ -69,24 +69,6 @@ Create the name of the service account
 {{- end }}
 
 {{/*
-The service name to connect to Loki. Defaults to the same logic as "loki.fullname"
-*/}}
-{{- define "loki.serviceName" -}}
-{{- if .Values.loki.serviceName }}
-{{- .Values.loki.serviceName }}
-{{- else if .Values.loki.fullnameOverride }}
-{{- .Values.loki.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default "loki" .Values.loki.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
-{{- end }}
-
-{{/*
 Configure enableServiceLinks in pod
 */}}
 {{- define "promtail.enableServiceLinks" -}}


### PR DESCRIPTION
loki.serviceName is no longer used anywhere.
The dependency on loki.serviceName was removed in commit 9b576e19 ([promtail] Refactor chart).