### PR TITLE
[grafana] set security controls for pod-security-standards restricted

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.52.9
+version: 6.53.0
 appVersion: 9.4.7
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -106,11 +106,17 @@ testFramework:
   securityContext: {}
 
 securityContext:
+  runAsNonRoot: true
   runAsUser: 472
   runAsGroup: 472
   fsGroup: 472
 
-containerSecurityContext: {}
+containerSecurityContext:
+  capabilities:
+    drop:
+    - ALL
+  seccompProfile:
+    type: RuntimeDefault
 
 # Enable creating the grafana configmap
 createConfigmap: true


### PR DESCRIPTION
This adds the missing controls to permit the `grafana` container to run under https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted