### PR TITLE
[grafana] add default-container annotation to default to grafana container

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.55.0
+version: 6.55.1
 appVersion: 9.4.7
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/deployment.yaml
+++ b/charts/grafana/templates/deployment.yaml
@@ -42,6 +42,7 @@ spec:
         {{- if .Values.envRenderSecret }}
         checksum/secret-env: {{ include (print $.Template.BasePath "/secret-env.yaml") . | sha256sum }}
         {{- end }}
+        kubectl.kubernetes.io/default-container: {{ .Chart.Name }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/grafana/templates/statefulset.yaml
+++ b/charts/grafana/templates/statefulset.yaml
@@ -31,6 +31,7 @@ spec:
         {{- if and (or (and (not .Values.admin.existingSecret) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD)) (and .Values.ldap.enabled (not .Values.ldap.existingSecret))) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
+        kubectl.kubernetes.io/default-container: {{ .Chart.Name }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
This change introduces the `kubectl.kubernetes.io/default-container` annotations to the `grafana` pod to make kubectl default to this container when running `kubectl exec` or `kubectl logs`.