### PR TITLE
[grafana] update chart to use grafana 9.5.1 by default

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.55.1
-appVersion: 9.4.7
+version: 6.56.0
+appVersion: 9.5.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net


### PR DESCRIPTION
let's move forward and use new and shiny grafana 9.5 by default