### PR TITLE
[grafana] Correct subPath in extraConfigmapMounts

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.56.0
+version: 6.56.1
 appVersion: 9.5.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -786,7 +786,7 @@ containers:
       {{- range .Values.extraConfigmapMounts }}
       - name: {{ tpl .name $root }}
         mountPath: {{ tpl .mountPath $root }}
-        subPath: {{ (tpl .subPath $root) | default "" }}
+        subPath: {{ tpl (.subPath | default "") $root }}
         readOnly: {{ .readOnly }}
       {{- end }}
       - name: storage


### PR DESCRIPTION
This PR corrects templating in `extraConfigmapMounts.subPath` which is currently failing even with the included default. As a result, a value must be supplied in the field.

Fixes #1446