### PR TITLE
[promtail] fix: extraPort metadata placement

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.7.4
-version: 6.11.0
+version: 6.11.1
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 6.11.0](https://img.shields.io/badge/Version-6.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.4](https://img.shields.io/badge/AppVersion-2.7.4-informational?style=flat-square)
+![Version: 6.11.1](https://img.shields.io/badge/Version-6.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.4](https://img.shields.io/badge/AppVersion-2.7.4-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -277,6 +277,8 @@ extraContainers: {}
 extraPorts: {}
 #  syslog:
 #    name: tcp-syslog
+#    annotations: {}
+#    labels: {}
 #    containerPort: 1514
 #    protocol: TCP
 #    service:
@@ -285,8 +287,6 @@ extraPorts: {}
 #      port: 1514
 #      externalIPs: []
 #      nodePort: null
-#      annotations: {}
-#      labels: {}
 #      loadBalancerIP: null
 #      loadBalancerSourceRanges: []
 #      externalTrafficPolicy: null


### PR DESCRIPTION
As promtail helm template working with annotation, level, it should be moved to root level of ports in example values.yaml