### PR TITLE
[tempo] Disable tempo-query by default

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: 2.1.1
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
+![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 
@@ -72,7 +72,7 @@ Grafana Tempo Single Binary Mode
 | tempo.storage.trace.wal.path | string | `"/var/tempo/wal"` |  |
 | tempo.tag | string | `"2.0.1"` |  |
 | tempo.updateStrategy | string | `"RollingUpdate"` |  |
-| tempoQuery.enabled | bool | `true` | if False the tempo-query container is not deployed |
+| tempoQuery.enabled | bool | `false` | if False the tempo-query container is not deployed |
 | tempoQuery.extraArgs | object | `{}` |  |
 | tempoQuery.extraEnv | list | `[]` | Environment variables to add |
 | tempoQuery.extraVolumeMounts | list | `[]` | Volume mounts to add |

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -160,7 +160,7 @@ tempoQuery:
   #   - myRegistryKeySecretName
 
   # -- if False the tempo-query container is not deployed
-  enabled: true
+  enabled: false
 
   service:
     port: 16686


### PR DESCRIPTION
tempo-query was required for Grafana version <7.5 for compatibility with jaeger-ui. grafana version <7.5 didn't have Tempo datasource, and we used jaeger datasource to query tempo via tempo-query.

Grafana 7.5 was released on Mar 25, 2021, which was 2+ year ago. 