### PR TITLE
[grafana] ADD: dashboard LoadBalancer file

### DIFF
--- a/charts/grafana/ci/with-only-local-values.yaml
+++ b/charts/grafana/ci/with-only-local-values.yaml
@@ -1,0 +1,4 @@
+service:
+  enabled: true
+  type: LoadBalancer
+  port: 3000


### PR DESCRIPTION
When developing or testing locally, every time 
example `kubectl --namespace default port-forward $POD_NAME 3000`
It is inconvenient to enter these commands, so add the corresponding values file under the CI directory to add convenience