### PR TITLE
[promtail] bump promtail version to 2.8.2

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
-appVersion: 2.7.4
-version: 6.11.1
+appVersion: 2.8.2
+version: 6.11.2
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 6.11.1](https://img.shields.io/badge/Version-6.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.4](https://img.shields.io/badge/AppVersion-2.7.4-informational?style=flat-square)
+![Version: 6.11.2](https://img.shields.io/badge/Version-6.11.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 


### PR DESCRIPTION
As it seems there are no breaking changes concerning promtail between 2.7.4 and 2.8.2, 
this PR aim to bump promtail version (resolves #2379).