### PR TITLE
[tempo] Correctly sets the Tempo version for 2.1.1

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 1.2.1
+version: 1.3.0
 appVersion: 2.1.1
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 
@@ -70,7 +70,7 @@ Grafana Tempo Single Binary Mode
 | tempo.storage.trace.backend | string | `"local"` |  |
 | tempo.storage.trace.local.path | string | `"/var/tempo/traces"` |  |
 | tempo.storage.trace.wal.path | string | `"/var/tempo/wal"` |  |
-| tempo.tag | string | `"2.1.1"` |  |
+| tempo.tag | string | `nil` |  |
 | tempo.updateStrategy | string | `"RollingUpdate"` |  |
 | tempoQuery.enabled | bool | `false` | if False the tempo-query container is not deployed |
 | tempoQuery.extraArgs | object | `{}` |  |
@@ -89,7 +89,7 @@ Grafana Tempo Single Binary Mode
 | tempoQuery.resources | object | `{}` |  |
 | tempoQuery.securityContext | object | `{}` |  |
 | tempoQuery.service.port | int | `16686` |  |
-| tempoQuery.tag | string | `"2.1.1"` |  |
+| tempoQuery.tag | string | `nil` |  |
 | tolerations | list | `[]` | Tolerations for pod assignment. See: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
 
 ## Chart Repo

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -70,7 +70,7 @@ Grafana Tempo Single Binary Mode
 | tempo.storage.trace.backend | string | `"local"` |  |
 | tempo.storage.trace.local.path | string | `"/var/tempo/traces"` |  |
 | tempo.storage.trace.wal.path | string | `"/var/tempo/wal"` |  |
-| tempo.tag | string | `"2.0.1"` |  |
+| tempo.tag | string | `"2.1.1"` |  |
 | tempo.updateStrategy | string | `"RollingUpdate"` |  |
 | tempoQuery.enabled | bool | `false` | if False the tempo-query container is not deployed |
 | tempoQuery.extraArgs | object | `{}` |  |
@@ -89,7 +89,7 @@ Grafana Tempo Single Binary Mode
 | tempoQuery.resources | object | `{}` |  |
 | tempoQuery.securityContext | object | `{}` |  |
 | tempoQuery.service.port | int | `16686` |  |
-| tempoQuery.tag | string | `"2.0.1"` |  |
+| tempoQuery.tag | string | `"2.1.1"` |  |
 | tolerations | list | `[]` | Tolerations for pod assignment. See: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
 
 ## Chart Repo

--- a/charts/tempo/templates/statefulset.yaml
+++ b/charts/tempo/templates/statefulset.yaml
@@ -40,7 +40,7 @@ spec:
         {{- range $key, $value := .Values.tempo.extraArgs }}
         - "-{{ $key }}{{ if $value }}={{ $value }}{{ end }}"
         {{- end }}
-        image: {{ .Values.tempo.repository }}:{{ .Values.tempo.tag }}
+        image: {{ .Values.tempo.repository }}:{{ .Values.tempo.tag | default .Chart.AppVersion | quote }}
         imagePullPolicy: {{ .Values.tempo.pullPolicy }}
         name: tempo
         ports:
@@ -101,7 +101,7 @@ spec:
         {{- range $key, $value := .Values.tempoQuery.extraArgs }}
         - "-{{ $key }}{{ if $value }}={{ $value }}{{ end }}"
         {{- end }}
-        image: {{ .Values.tempoQuery.repository }}:{{ .Values.tempoQuery.tag }}
+        image: {{ .Values.tempoQuery.repository }}:{{ .Values.tempoQuery.tag | default .Chart.AppVersion | quote }}
         imagePullPolicy: {{ .Values.tempoQuery.pullPolicy }}
         name: tempo-query
         ports:

--- a/charts/tempo/templates/statefulset.yaml
+++ b/charts/tempo/templates/statefulset.yaml
@@ -40,7 +40,7 @@ spec:
         {{- range $key, $value := .Values.tempo.extraArgs }}
         - "-{{ $key }}{{ if $value }}={{ $value }}{{ end }}"
         {{- end }}
-        image: {{ .Values.tempo.repository }}:{{ .Values.tempo.tag | default .Chart.AppVersion | quote }}
+        image: {{ .Values.tempo.repository }}:{{ .Values.tempo.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.tempo.pullPolicy }}
         name: tempo
         ports:
@@ -101,7 +101,7 @@ spec:
         {{- range $key, $value := .Values.tempoQuery.extraArgs }}
         - "-{{ $key }}{{ if $value }}={{ $value }}{{ end }}"
         {{- end }}
-        image: {{ .Values.tempoQuery.repository }}:{{ .Values.tempoQuery.tag | default .Chart.AppVersion | quote }}
+        image: {{ .Values.tempoQuery.repository }}:{{ .Values.tempoQuery.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.tempoQuery.pullPolicy }}
         name: tempo-query
         ports:

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -12,7 +12,7 @@ annotations: {}
 
 tempo:
   repository: grafana/tempo
-  tag: 2.0.1
+  tag: 2.1.1
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -150,7 +150,7 @@ config: |
 
 tempoQuery:
   repository: grafana/tempo-query
-  tag: 2.0.1
+  tag: 2.1.1
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -12,7 +12,7 @@ annotations: {}
 
 tempo:
   repository: grafana/tempo
-  tag: 2.1.1
+  tag: null
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -150,7 +150,7 @@ config: |
 
 tempoQuery:
   repository: grafana/tempo-query
-  tag: 2.1.1
+  tag: null
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
The appversion was updated in the chart, but the actual images use these tags for some reason.