### PR TITLE
[tempo-distributed] Add support for HPA behavior customization

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.3.0
+version: 1.4.0
 appVersion: 2.1.1
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.4.2
+version: 1.4.3
 appVersion: 2.1.1
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -267,6 +267,7 @@ The memcached default args are removed and should be provided manually. The sett
 | distributor.affinity | string | Hard node and soft zone anti-affinity | Affinity for distributor pods. Passed through `tpl` and, thus, to be configured as string |
 | distributor.appProtocol | object | `{"grpc":null}` | Adds the appProtocol field to the distributor service. This allows distributor to work with istio protocol selection. |
 | distributor.appProtocol.grpc | string | `nil` | Set the optional grpc service protocol. Ex: "grpc", "http2" or "https" |
+| distributor.autoscaling.behavior | object | `{}` | Autoscaling behavior configuration for the distributor |
 | distributor.autoscaling.enabled | bool | `false` | Enable autoscaling for the distributor |
 | distributor.autoscaling.maxReplicas | int | `3` | Maximum autoscaling replicas for the distributor |
 | distributor.autoscaling.minReplicas | int | `1` | Minimum autoscaling replicas for the distributor |
@@ -340,6 +341,7 @@ The memcached default args are removed and should be provided manually. The sett
 | externalConfigVersion | string | `"0"` | When 'useExternalConfig' is true, then changing 'externalConfigVersion' triggers restart of services - otherwise changes to the configuration cause a restart. |
 | fullnameOverride | string | `""` |  |
 | gateway.affinity | string | Hard node and soft zone anti-affinity | Affinity for gateway pods. Passed through `tpl` and, thus, to be configured as string |
+| gateway.autoscaling.behavior | object | `{}` | Autoscaling behavior configuration for the gateway |
 | gateway.autoscaling.enabled | bool | `false` | Enable autoscaling for the gateway |
 | gateway.autoscaling.maxReplicas | int | `3` | Maximum autoscaling replicas for the gateway |
 | gateway.autoscaling.minReplicas | int | `1` | Minimum autoscaling replicas for the gateway |
@@ -405,6 +407,7 @@ The memcached default args are removed and should be provided manually. The sett
 | ingester.annotations | object | `{}` | Annotations for the ingester StatefulSet |
 | ingester.appProtocol | object | `{"grpc":null}` | Adds the appProtocol field to the ingester service. This allows ingester to work with istio protocol selection. |
 | ingester.appProtocol.grpc | string | `nil` | Set the optional grpc service protocol. Ex: "grpc", "http2" or "https" |
+| ingester.autoscaling.behavior | object | `{}` | Autoscaling behavior configuration for the ingester |
 | ingester.autoscaling.enabled | bool | `false` | Enable autoscaling for the ingester |
 | ingester.autoscaling.maxReplicas | int | `3` | Maximum autoscaling replicas for the ingester |
 | ingester.autoscaling.minReplicas | int | `1` | Minimum autoscaling replicas for the ingester |
@@ -556,6 +559,7 @@ The memcached default args are removed and should be provided manually. The sett
 | querier.affinity | string | Hard node and soft zone anti-affinity | Affinity for querier pods. Passed through `tpl` and, thus, to be configured as string |
 | querier.appProtocol | object | `{"grpc":null}` | Adds the appProtocol field to the querier service. This allows querier to work with istio protocol selection. |
 | querier.appProtocol.grpc | string | `nil` | Set the optional grpc service protocol. Ex: "grpc", "http2" or "https" |
+| querier.autoscaling.behavior | object | `{}` | Autoscaling behavior configuration for the querier |
 | querier.autoscaling.enabled | bool | `false` | Enable autoscaling for the querier |
 | querier.autoscaling.maxReplicas | int | `3` | Maximum autoscaling replicas for the querier |
 | querier.autoscaling.minReplicas | int | `1` | Minimum autoscaling replicas for the querier |
@@ -591,6 +595,7 @@ The memcached default args are removed and should be provided manually. The sett
 | queryFrontend.affinity | string | Hard node and soft zone anti-affinity | Affinity for query-frontend pods. Passed through `tpl` and, thus, to be configured as string |
 | queryFrontend.appProtocol | object | `{"grpc":null}` | Adds the appProtocol field to the queriyFrontend service. This allows queriyFrontend to work with istio protocol selection. |
 | queryFrontend.appProtocol.grpc | string | `nil` | Set the optional grpc service protocol. Ex: "grpc", "http2" or "https" |
+| queryFrontend.autoscaling.behavior | object | `{}` | Autoscaling behavior configuration for the query-frontend |
 | queryFrontend.autoscaling.enabled | bool | `false` | Enable autoscaling for the query-frontend |
 | queryFrontend.autoscaling.maxReplicas | int | `3` | Maximum autoscaling replicas for the query-frontend |
 | queryFrontend.autoscaling.minReplicas | int | `1` | Minimum autoscaling replicas for the query-frontend |

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
+![Version: 1.4.3](https://img.shields.io/badge/Version-1.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/distributor/hpa.yaml
+++ b/charts/tempo-distributed/templates/distributor/hpa.yaml
@@ -13,6 +13,10 @@ spec:
     name: {{ include "tempo.resourceName" (dict "ctx" . "component" "distributor") }}
   minReplicas: {{ .Values.distributor.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.distributor.autoscaling.maxReplicas }}
+  {{- if .Values.distributor.autoscaling.behavior }}
+  behavior:
+    {{- toYaml .Values.distributor.autoscaling.behavior | nindent 4 }}
+  {{- end }}
   metrics:
   {{- with .Values.distributor.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource

--- a/charts/tempo-distributed/templates/distributor/hpa.yaml
+++ b/charts/tempo-distributed/templates/distributor/hpa.yaml
@@ -13,9 +13,9 @@ spec:
     name: {{ include "tempo.resourceName" (dict "ctx" . "component" "distributor") }}
   minReplicas: {{ .Values.distributor.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.distributor.autoscaling.maxReplicas }}
-  {{- if .Values.distributor.autoscaling.behavior }}
+  {{- with .Values.distributor.autoscaling.behavior }}
   behavior:
-    {{- toYaml .Values.distributor.autoscaling.behavior | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   metrics:
   {{- with .Values.distributor.autoscaling.targetMemoryUtilizationPercentage }}

--- a/charts/tempo-distributed/templates/gateway/hpa.yaml
+++ b/charts/tempo-distributed/templates/gateway/hpa.yaml
@@ -13,6 +13,10 @@ spec:
     name: {{ include "tempo.resourceName" (dict "ctx" . "component" "gateway") }}
   minReplicas: {{ .Values.gateway.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.gateway.autoscaling.maxReplicas }}
+  {{- if .Values.gateway.autoscaling.behavior }}
+  behavior:
+    {{- toYaml .Values.gateway.autoscaling.behavior | nindent 4 }}
+  {{- end }}
   metrics:
   {{- with .Values.gateway.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource

--- a/charts/tempo-distributed/templates/gateway/hpa.yaml
+++ b/charts/tempo-distributed/templates/gateway/hpa.yaml
@@ -13,9 +13,9 @@ spec:
     name: {{ include "tempo.resourceName" (dict "ctx" . "component" "gateway") }}
   minReplicas: {{ .Values.gateway.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.gateway.autoscaling.maxReplicas }}
-  {{- if .Values.gateway.autoscaling.behavior }}
+  {{- with .Values.gateway.autoscaling.behavior }}
   behavior:
-    {{- toYaml .Values.gateway.autoscaling.behavior | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   metrics:
   {{- with .Values.gateway.autoscaling.targetMemoryUtilizationPercentage }}

--- a/charts/tempo-distributed/templates/ingester/hpa.yaml
+++ b/charts/tempo-distributed/templates/ingester/hpa.yaml
@@ -13,9 +13,9 @@ spec:
     name: {{ include "tempo.resourceName" (dict "ctx" . "component" "ingester") }}
   minReplicas: {{ .Values.ingester.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.ingester.autoscaling.maxReplicas }}
-  {{- if .Values.ingester.autoscaling.behavior }}
+  {{- with .Values.ingester.autoscaling.behavior }}
   behavior:
-    {{- toYaml .Values.ingester.autoscaling.behavior | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   metrics:
   {{- with .Values.ingester.autoscaling.targetMemoryUtilizationPercentage }}

--- a/charts/tempo-distributed/templates/ingester/hpa.yaml
+++ b/charts/tempo-distributed/templates/ingester/hpa.yaml
@@ -13,6 +13,10 @@ spec:
     name: {{ include "tempo.resourceName" (dict "ctx" . "component" "ingester") }}
   minReplicas: {{ .Values.ingester.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.ingester.autoscaling.maxReplicas }}
+  {{- if .Values.ingester.autoscaling.behavior }}
+  behavior:
+    {{- toYaml .Values.ingester.autoscaling.behavior | nindent 4 }}
+  {{- end }}
   metrics:
   {{- with .Values.ingester.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource

--- a/charts/tempo-distributed/templates/querier/hpa.yaml
+++ b/charts/tempo-distributed/templates/querier/hpa.yaml
@@ -13,6 +13,10 @@ spec:
     name: {{ include "tempo.resourceName" (dict "ctx" . "component" "querier") }}
   minReplicas: {{ .Values.querier.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.querier.autoscaling.maxReplicas }}
+  {{- if .Values.querier.autoscaling.behavior }}
+  behavior:
+    {{- toYaml .Values.querier.autoscaling.behavior | nindent 4 }}
+  {{- end }}
   metrics:
   {{- with .Values.querier.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource

--- a/charts/tempo-distributed/templates/querier/hpa.yaml
+++ b/charts/tempo-distributed/templates/querier/hpa.yaml
@@ -13,9 +13,9 @@ spec:
     name: {{ include "tempo.resourceName" (dict "ctx" . "component" "querier") }}
   minReplicas: {{ .Values.querier.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.querier.autoscaling.maxReplicas }}
-  {{- if .Values.querier.autoscaling.behavior }}
+  {{- with .Values.querier.autoscaling.behavior }}
   behavior:
-    {{- toYaml .Values.querier.autoscaling.behavior | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   metrics:
   {{- with .Values.querier.autoscaling.targetMemoryUtilizationPercentage }}

--- a/charts/tempo-distributed/templates/query-frontend/hpa.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/hpa.yaml
@@ -13,9 +13,9 @@ spec:
     name: {{ include "tempo.resourceName" (dict "ctx" . "component" "query-frontend") }}
   minReplicas: {{ .Values.queryFrontend.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.queryFrontend.autoscaling.maxReplicas }}
-  {{- if .Values.queryFrontend.autoscaling.behavior }}
+  {{- with .Values.queryFrontend.autoscaling.behavior }}
   behavior:
-    {{- toYaml .Values.queryFrontend.autoscaling.behavior | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   metrics:
   {{- with .Values.queryFrontend.autoscaling.targetMemoryUtilizationPercentage }}

--- a/charts/tempo-distributed/templates/query-frontend/hpa.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/hpa.yaml
@@ -13,6 +13,10 @@ spec:
     name: {{ include "tempo.resourceName" (dict "ctx" . "component" "query-frontend") }}
   minReplicas: {{ .Values.queryFrontend.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.queryFrontend.autoscaling.maxReplicas }}
+  {{- if .Values.queryFrontend.autoscaling.behavior }}
+  behavior:
+    {{- toYaml .Values.queryFrontend.autoscaling.behavior | nindent 4 }}
+  {{- end }}
   metrics:
   {{- with .Values.queryFrontend.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -110,6 +110,8 @@ ingester:
     minReplicas: 1
     # -- Maximum autoscaling replicas for the ingester
     maxReplicas: 3
+    # -- Autoscaling behavior configuration for the ingester
+    behavior: {}
     # -- Target CPU utilisation percentage for the ingester
     targetCPUUtilizationPercentage: 60
     # -- Target memory utilisation percentage for the ingester
@@ -342,6 +344,8 @@ distributor:
     minReplicas: 1
     # -- Maximum autoscaling replicas for the distributor
     maxReplicas: 3
+    # -- Autoscaling behavior configuration for the distributor
+    behavior: {}
     # -- Target CPU utilisation percentage for the distributor
     targetCPUUtilizationPercentage: 60
     # -- Target memory utilisation percentage for the distributor
@@ -511,6 +515,8 @@ querier:
     minReplicas: 1
     # -- Maximum autoscaling replicas for the querier
     maxReplicas: 3
+    # -- Autoscaling behavior configuration for the querier
+    behavior: {}
     # -- Target CPU utilisation percentage for the querier
     targetCPUUtilizationPercentage: 60
     # -- Target memory utilisation percentage for the querier
@@ -657,6 +663,8 @@ queryFrontend:
     minReplicas: 1
     # -- Maximum autoscaling replicas for the query-frontend
     maxReplicas: 3
+    # -- Autoscaling behavior configuration for the query-frontend
+    behavior: {}
     # -- Target CPU utilisation percentage for the query-frontend
     targetCPUUtilizationPercentage: 60
     # -- Target memory utilisation percentage for the query-frontend
@@ -1371,6 +1379,8 @@ gateway:
     minReplicas: 1
     # -- Maximum autoscaling replicas for the gateway
     maxReplicas: 3
+    # -- Autoscaling behavior configuration for the gateway
+    behavior: {}
     # -- Target CPU utilisation percentage for the gateway
     targetCPUUtilizationPercentage: 60
     # -- Target memory utilisation percentage for the gateway


### PR DESCRIPTION
We ran into a use case where it would have been helpful to fine tune a little bit HPA behaviour.

This PR will allow to optionally define a behaviour on the HorizontalPodAutoscaler resource. See https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/ and https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#horizontalpodautoscalerspec-v2-autoscaling for reference.