### PR TITLE
[grafana] bump default grafana image tag to 9.5.2

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.56.2
-appVersion: 9.5.1
+version: 6.56.3
+appVersion: 9.5.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net


### PR DESCRIPTION
See also https://github.com/grafana/grafana/releases/tag/v9.5.2
