### PR TITLE
[tempo-distributed] fix missing `publishNotReadyAddresses` in  query-frontend-discovery service

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.4.0
+version: 1.4.1
 appVersion: 2.1.1
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
+![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/query-frontend/service-query-frontend-discovery.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/service-query-frontend-discovery.yaml
@@ -38,5 +38,6 @@ spec:
       port: 16687
       targetPort: jaeger-metrics
     {{- end }}
+  publishNotReadyAddresses: true
   selector:
     {{- include "tempo.selectorLabels" (dict "ctx" . "component" "query-frontend") | nindent 4 }}


### PR DESCRIPTION
The `publishNotReadyAddresses` flag seems to be set in the jsonnet version of the deployment but is missing in the helm chart and prevents the `query-frontend-discovery` service to expose its underlying pods. 

fixes: https://github.com/grafana/helm-charts/issues/2404