### PR TITLE
[grafana] default allowPrivilegeEscalation=false

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.56.3
+version: 6.56.4
 appVersion: 9.5.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -112,6 +112,7 @@ securityContext:
   fsGroup: 472
 
 containerSecurityContext:
+  allowPrivilegeEscalation: false
   capabilities:
     drop:
     - ALL


### PR DESCRIPTION
This adds another security control on the grafana container.  It shouldn't be user visible as no properly functioning grafana container should try to escalate its privileges.