### PR TITLE
[tempo-distributed] bugfix: ingress name for tempo-query-frontend

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.4.1
+version: 1.4.2
 appVersion: 2.1.1
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
+![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/query-frontend/ingress-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/ingress-query-frontend.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.queryFrontend.query.enabled .Values.queryFrontend.ingress.enabled -}}
-{{ $dict := dict "ctx" . "component" "queryFrontend"  }}
+{{ $dict := dict "ctx" . "component" "query-frontend"  }}
 {{- $ingressApiIsStable := eq (include "tempo.ingress.isStable" .) "true" -}}
 {{- $ingressSupportsIngressClassName := eq (include "tempo.ingress.supportsIngressClassName" .) "true" -}}
 {{- $ingressSupportsPathType := eq (include "tempo.ingress.supportsPathType" .) "true" -}}


### PR DESCRIPTION
The component name is `queryFrontend` which produces an invalid kubernetes resource name. Changed by `query-frontend`.