### PR TITLE
[promtail] bugfix: Checksum annotation

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.8.2
-version: 6.11.2
+version: 6.11.3
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 6.11.2](https://img.shields.io/badge/Version-6.11.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
+![Version: 6.11.3](https://img.shields.io/badge/Version-6.11.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/templates/_pod.tpl
+++ b/charts/promtail/templates/_pod.tpl
@@ -10,7 +10,11 @@ metadata:
     {{- end }}
   annotations:
     {{- if not .Values.sidecar.configReloader.enabled }}
+    {{- if not .Values.configmap.enabled }}
     checksum/config: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
+    {{- else }}
+    checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
+    {{- end }}
     {{- end }}
     {{- with .Values.podAnnotations }}
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
When using the configuration `.Values.configmap.enabled` to use a Configmap instead of Secret for storing the configuration,
the checksum annotation used to force a pod re-roll is missing.