### PR TITLE
[promtail] allowing to configure Promtail log format

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.8.2
-version: 6.11.2
+version: 6.11.5
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 6.11.2](https://img.shields.io/badge/Version-6.11.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
+![Version: 6.11.8](https://img.shields.io/badge/Version-6.11.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 
@@ -74,6 +74,7 @@ The new release which will pick up again from the existing `positions.yaml`.
 | config.clients | list | See `values.yaml` | The config of clients of the Promtail server Must be reference in `config.file` to configure `clients` |
 | config.enableTracing | bool | `false` | The config to enable tracing |
 | config.file | string | See `values.yaml` | Config file contents for Promtail. Must be configured as string. It is templated so it can be assembled from reusable snippets in order to avoid redundancy. |
+| config.logFormat | string | `"logfmt"` | The log format of the Promtail server Must be reference in `config.file` to configure `server.log_format` Valid formats: `logfmt, json` See default config in `values.yaml` |
 | config.logLevel | string | `"info"` | The log level of the Promtail server Must be reference in `config.file` to configure `server.log_level` See default config in `values.yaml` |
 | config.serverPort | int | `3101` | The port of the Promtail server Must be reference in `config.file` to configure `server.http_listen_port` See default config in `values.yaml` |
 | config.snippets | object | See `values.yaml` | A section of reusable snippets that can be reference in `config.file`. Custom snippets may be added in order to reduce redundancy. This is especially helpful when multiple `kubernetes_sd_configs` are use which usually have large parts in common. |

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -340,6 +340,11 @@ config:
   # Must be reference in `config.file` to configure `server.log_level`
   # See default config in `values.yaml`
   logLevel: info
+  # -- The log format of the Promtail server
+  # Must be reference in `config.file` to configure `server.log_format`
+  # Valid formats: `logfmt, json`
+  # See default config in `values.yaml`
+  logFormat: logfmt
   # -- The port of the Promtail server
   # Must be reference in `config.file` to configure `server.http_listen_port`
   # See default config in `values.yaml`
@@ -467,6 +472,7 @@ config:
   file: |
     server:
       log_level: {{ .Values.config.logLevel }}
+      log_format: {{ .Values.config.logFormat }}
       http_listen_port: {{ .Values.config.serverPort }}
       {{- with .Values.httpPathPrefix }}
       http_path_prefix: {{ . }}


### PR DESCRIPTION
This PR allows to configure the Promtail log format to json and logfmt.