### PR TITLE
[tempo-distributed] Service labels for distributor and query-frontend

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.4.1
+version: 1.4.2
 appVersion: 2.1.1
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
+![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -291,9 +291,11 @@ The memcached default args are removed and should be provided manually. The sett
 | distributor.replicas | int | `1` | Number of replicas for the distributor |
 | distributor.resources | object | `{}` | Resource requests and limits for the distributor |
 | distributor.service.annotations | object | `{}` | Annotations for distributor service |
+| distributor.service.labels | object | `{}` | Labels for distributor service |
 | distributor.service.loadBalancerIP | string | `""` | If type is LoadBalancer you can assign the IP to the LoadBalancer |
 | distributor.service.loadBalancerSourceRanges | list | `[]` | If type is LoadBalancer limit incoming traffic from IPs. |
 | distributor.service.type | string | `"ClusterIP"` | Type of service for the distributor |
+| distributor.serviceDiscovery.labels | object | `{}` | Labels for distributorDiscovery service |
 | distributor.terminationGracePeriodSeconds | int | `30` | Grace period to allow the distributor to shutdown before it is killed |
 | distributor.tolerations | list | `[]` | Tolerations for distributor pods |
 | distributor.topologySpreadConstraints | string | Defaults to allow skew no more then 1 node per AZ | topologySpread for distributor pods. Passed through `tpl` and, thus, to be configured as string |
@@ -636,11 +638,13 @@ The memcached default args are removed and should be provided manually. The sett
 | queryFrontend.replicas | int | `1` | Number of replicas for the query-frontend |
 | queryFrontend.resources | object | `{}` | Resource requests and limits for the query-frontend |
 | queryFrontend.service.annotations | object | `{}` | Annotations for queryFrontend service |
+| queryFrontend.service.labels | object | `{}` | Labels for queryFrontend service |
 | queryFrontend.service.loadBalancerIP | string | `""` | If type is LoadBalancer you can assign the IP to the LoadBalancer |
 | queryFrontend.service.loadBalancerSourceRanges | list | `[]` | If type is LoadBalancer limit incoming traffic from IPs. |
 | queryFrontend.service.port | int | `16686` | Port of the query-frontend service |
 | queryFrontend.service.type | string | `"ClusterIP"` | Type of service for the queryFrontend |
 | queryFrontend.serviceDiscovery.annotations | object | `{}` | Annotations for queryFrontendDiscovery service |
+| queryFrontend.serviceDiscovery.labels | object | `{}` | Labels for queryFrontendDiscovery service |
 | queryFrontend.terminationGracePeriodSeconds | int | `30` | Grace period to allow the query-frontend to shutdown before it is killed |
 | queryFrontend.tolerations | list | `[]` | Tolerations for query-frontend pods |
 | queryFrontend.topologySpreadConstraints | string | Defaults to allow skew no more then 1 node per AZ | topologySpread for query-frontend pods. Passed through `tpl` and, thus, to be configured as string |

--- a/charts/tempo-distributed/templates/distributor/service-distributor-discovery.yaml
+++ b/charts/tempo-distributed/templates/distributor/service-distributor-discovery.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- with .Values.distributor.serviceDiscovery.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     prometheus.io/service-monitor: "false"
   {{- with .Values.distributor.service.annotations }}
   annotations:

--- a/charts/tempo-distributed/templates/distributor/service-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/service-distributor.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- with .Values.distributor.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.distributor.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/tempo-distributed/templates/query-frontend/service-query-frontend-discovery.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/service-query-frontend-discovery.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "query-frontend") | nindent 4 }}
+    {{- with .Values.queryFrontend.serviceDiscovery.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.queryFrontend.serviceDiscovery.annotations }}
   annotations:
     {{ toYaml . | nindent 4 }}

--- a/charts/tempo-distributed/templates/query-frontend/service-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/service-query-frontend.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "query-frontend") | nindent 4 }}
+    {{- with .Values.queryFrontend.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.queryFrontend.service.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -358,12 +358,17 @@ distributor:
   service:
     # -- Annotations for distributor service
     annotations: {}
+    # -- Labels for distributor service
+    labels: {}
     # -- Type of service for the distributor
     type: ClusterIP
     # -- If type is LoadBalancer you can assign the IP to the LoadBalancer
     loadBalancerIP: ''
     # -- If type is LoadBalancer limit incoming traffic from IPs.
     loadBalancerSourceRanges: []
+  serviceDiscovery:
+    # -- Labels for distributorDiscovery service
+    labels: {}
   # -- The name of the PriorityClass for distributor pods
   priorityClassName: null
   # -- Labels for distributor pods
@@ -675,6 +680,8 @@ queryFrontend:
     port: 16686
     # -- Annotations for queryFrontend service
     annotations: {}
+    # -- Labels for queryFrontend service
+    labels: {}
     # -- Type of service for the queryFrontend
     type: ClusterIP
     # -- If type is LoadBalancer you can assign the IP to the LoadBalancer
@@ -684,6 +691,8 @@ queryFrontend:
   serviceDiscovery:
     # -- Annotations for queryFrontendDiscovery service
     annotations: {}
+    # -- Labels for queryFrontendDiscovery service
+    labels: {}
   ingress:
     # -- Specifies whether an ingress for the Jaeger should be created
     enabled: false


### PR DESCRIPTION
We have a need to add service labels to support some service mesh configuration specifically for the distributor and query-frontend. These are added following the pattern that is already used for other services that have labels for the main services.

For the existing services with user-settable labels, there aren't any that also have paired *discovery* services, so I wasn't sure what to do here. Looking at related annotations, there is inconsistency in how they are named across the distributor and queryFrontend:
- distributor.service.annotations
- queryFrontend.service.annotations
- queryFrontend.serviceDiscovery.annotations (the separate serviceDiscovery annotation was added by #1104)

The approach that I took was to add labels for the discovery services following the existing naming pattern followed for queryFrontend annotations. So, `distributor.serviceDiscovery.labels` and `queryFrontend.serviceDiscovery.labels`. I'm happy to rework this if you'd like it done differently (or if you'd like to avoid adding service annotations on the discovery services altogether). Of course, please feel free to edit as needed.

For reference, here are the services that previously allowed user-settable labels before this change, the ones that were added with this change, and those that do not have user-settable labels after this change. If you want them added to any other services, please let me know and I'll be happy to add them to this PR.

Previously had user-settable service labels:
- admin-api/admin-api-svc.yaml: already has adminApi.service.labels
- enterprise-gateway/gateway-svc.yaml: already has enterpriseGateway.service.labels
- gateway/service-gateway.yaml: already has gateway.service.labels

Added with this PR:
- distributor/service-distributor-discovery.yaml: adding distributor.serviceDiscovery.labels
- distributor/service-distributor.yaml: adding distributor.service.labels
- query-frontend/service-query-frontend-discovery.yaml: adding queryFrontend.serviceDiscovery.labels
- query-frontend/service-query-frontend.yaml: adding queryFrontend.service.labels

No user-settable service labels yet:
- compactor/service-compactor.yaml
- gossip-ring/service-gossip-ring.yaml
- ingester/service-ingester-discovery.yaml
- ingester/service-ingester.yaml
- memcached/service-memcached.yaml
- metrics-generator/service-metrics-generator-discovery.yaml
- metrics-generator/service-metrics-generator.yaml
- querier/service-querier.yaml

Lastly, this is my first contribution to this repository, so if I need to change anything, please let me know. Thanks!