### PR TITLE
[grafana] Use tpl in envSecrets

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.56.6
+version: 6.57.0
 appVersion: 9.5.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -121,7 +121,7 @@ This version requires Helm >= 3.1.0.
 | `envFromSecret`                           | Name of a Kubernetes secret (must be manually created in the same namespace) containing values to be added to the environment. Can be templated | `""` |
 | `envFromSecrets`                          | List of Kubernetes secrets (must be manually created in the same namespace) containing values to be added to the environment. Can be templated | `[]` |
 | `envFromConfigMaps`                       | List of Kubernetes ConfigMaps (must be manually created in the same namespace) containing values to be added to the environment. Can be templated | `[]` |
-| `envRenderSecret`                         | Sensible environment variables passed to pods and stored as secret | `{}`                               |
+| `envRenderSecret`                         | Sensible environment variables passed to pods and stored as secret. (passed through [tpl](https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function))   | `{}`                               |
 | `enableServiceLinks`                      | Inject Kubernetes services as environment variables. | `true`                                           |
 | `extraSecretMounts`                       | Additional grafana server secret mounts       | `[]`                                                    |
 | `extraVolumeMounts`                       | Additional grafana server volume mounts       | `[]`                                                    |

--- a/charts/grafana/templates/secret-env.yaml
+++ b/charts/grafana/templates/secret-env.yaml
@@ -9,6 +9,6 @@ metadata:
 type: Opaque
 data:
 {{- range $key, $val := .Values.envRenderSecret }}
-  {{ $key }}: {{ $val | b64enc | quote }}
+  {{ $key }}: {{ tpl ($val | toString) $ | b64enc | quote }}
 {{- end }}
 {{- end }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -452,7 +452,9 @@ envValueFrom: {}
 envFromSecret: ""
 
 ## Sensible environment variables that will be rendered as new secret object
-## This can be useful for auth tokens, etc
+## This can be useful for auth tokens, etc.
+## If the secret values contains "{{", they'll need to be properly escaped so that they are not interpreted by Helm
+## ref: https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function
 envRenderSecret: {}
 
 ## The names of secrets in the same kubernetes namespace which contain values to be added to the environment


### PR DESCRIPTION
All .Values.env values are already pass through tpl. I would like to have the same behavior for secrets, too.

https://github.com/grafana/helm-charts/blob/eb55960453f49814d3234fd4417ffb2d5b127b80/charts/grafana/templates/_pod.tpl#L950-L953