### PR TITLE
Enable OCI chart push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,7 @@ jobs:
   release:
     permissions:
       contents: write # to push chart release and create a release (helm/chart-releaser-action)
+      packages: write # needed for ghcr access
 
     runs-on: ubuntu-latest
     steps:
@@ -23,10 +24,10 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Install Helm
-        uses: azure/setup-helm@v1
+      - name: Set up Helm
+        uses: azure/setup-helm@v3.5
         with:
-          version: v3.5.2
+          version: v3.12.0
 
       - name: Add dependency chart repos
         run: |
@@ -44,3 +45,13 @@ jobs:
           config: cr.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Push charts to GHCR
+        run: |
+          shopt -s nullglob
+          for pkg in .cr-release-packages/*; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts"
+          done


### PR DESCRIPTION
Fixes #2395

This PR start to publish OCI helm charts to ghcr.io/grafana/charts/, e.g. : `ghcr.io/grafana/charts/grafana`

Bitnami recently switches to OCI as default source for helm charts

* https://blog.bitnami.com/2023/04/httpsblog.bitnami.com202304bitnami-helm-charts-now-oci.html

and prometheus-community enable OCI based helm charts, too:

* https://github.com/prometheus-community/helm-charts/pull/3433

Fetch charts over OCI has multiple benefits:
* It's not longer necessary to download the 1.6M chart [index.yaml](https://grafana.github.io/helm-charts/index.yaml) each time.
* Mirroring to air-gapped environments would much easier, since existing service like Azure Container Registry, Elastic Container Registry and GoHarbor can be used to store/cache the helm charts.

I'm aware that this PR might be a bit aggressive, but I also would like to trigger the discussion here. As I know, this needs to be done at the loki chart, too.