### PR TITLE
[grafana] bump default grafana image tag to 9.5.3

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
 version: 6.57.0
-appVersion: 9.5.2
+appVersion: 9.5.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.57.0
+version: 6.57.1
 appVersion: 9.5.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.


### PR DESCRIPTION
## Reason of the update
[Grafana security release](https://grafana.com/blog/2023/06/06/grafana-security-release-new-grafana-versions-with-security-fixes-for-cve-2023-2183-and-cve-2023-2801/)


See also: https://github.com/grafana/grafana/releases/tag/v9.5.3