### PR TITLE
chore(github): Generate release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
           helm repo add minio https://helm.min.io
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.0
+        uses: helm/chart-releaser-action@v1.5.0
         with:
           charts_dir: charts
           config: cr.yaml

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,1 +1,5 @@
 sign: false
+
+# Enable automatic generation of release notes using GitHubs release notes generator.
+# see: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+generate-release-notes: true


### PR DESCRIPTION
## What

* Enables release note generation via an [option](https://github.com/helm/chart-releaser#create-github-releases-from-helm-chart-packages) provided by chart-releaser. chart-releaser uses GitHub's feature for automatic release note generation ([docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)).

## Why

* Current release notes provided in the release are unusable with tools like [Renovate](https://github.com/renovatebot/renovate).

## References

* Closes #1034