### PR TITLE
Revert "Enable OCI chart push"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,5 +53,7 @@ jobs:
             if [ -z "${pkg:-}" ]; then
               break
             fi
-            helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts"
+            if ! helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts"; then
+              echo '::warning:: helm push failed!'
+            fi
           done


### PR DESCRIPTION
Reverts grafana/helm-charts#2443

@zanhsieh Here is the rollback. 

This PR set the error to an warning which give the time to do the correct config while the workflow is not blocked.

In https://github.com/prometheus-community/helm-charts/blob/8b91a619e9407c0e830df7071ee73cd160937b6b/.github/workflows/release.yaml#L52-L60, we are using the same workflow, it seems like that packages are not configured yet to allow an push from actions.

An Grafana org admin has to set this in order to allow helm push from the pipeline: https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-a-registry-using-a-personal-access-token

The documentations also describe that a Personal Access Token should not be used in this case.