### PR TITLE
support metricRelabelings for tempo-distributed serviceMonitors

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.4.5
+version: 1.4.6
 appVersion: 2.1.1
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/templates/lib/service-monitor.tpl
+++ b/charts/tempo-distributed/templates/lib/service-monitor.tpl
@@ -57,6 +57,10 @@ spec:
         {{- with .relabelings }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- with .metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .scheme }}
       scheme: {{ . }}
       {{- end }}


### PR DESCRIPTION
Support `metricRelabelings` field in the crd `serviceMonitors` for the tempo-distributed chart.