### PR TITLE
[grafana] Update Grafana to v9.5.5

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.57.3
-appVersion: 9.5.3
+version: 6.57.4
+appVersion: 9.5.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net


### PR DESCRIPTION
There are no breaking changes in this update. See the Grafana [changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md#955-2023-06-22) for details.