### PR TITLE
[grafana] bump default grafana version 10.0.1

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.57.4
-appVersion: 9.5.5
+version: 6.57.5
+appVersion: 10.0.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net


### PR DESCRIPTION
update grafana default version to `v10.0.1`
[grafana v10.0.1 changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md#1001-2023-06-22)