### PR TITLE
[grafana] fix Chart.yaml - add license and keywords, remove gotpl

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
 version: 6.57.4
-appVersion: 9.5.5
+appVersion: 9.5.6
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
@@ -10,6 +10,7 @@ sources:
   - https://github.com/grafana/grafana
   - https://github.com/grafana/helm-charts
 annotations:
+  "artifacthub.io/license": AGPL-3.0-only
   "artifacthub.io/links": |
     - name: Chart Source
       url: https://github.com/grafana/helm-charts
@@ -26,5 +27,7 @@ maintainers:
     email: miroslav.hadzhiev@gmail.com
   - name: torstenwalter
     email: mail@torstenwalter.de
-engine: gotpl
 type: application
+keywords:
+  - monitoring
+  - metric


### PR DESCRIPTION
- fixes #2487

- fix Chart.yaml
  - Add [license annotations](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations)
    - Improved searchability
  - Add keywords
    - Improved searchability
  - Remove `engine: gotpl`
    - [helm v3](https://helm.sh/docs/topics/charts/#the-chartyaml-file) not allows `engine: gotpl`