### PR TITLE
[grafana] bump kiwigrid/k8s-sidecar version to 1.24.6

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.57.4
+version: 6.57.5
 appVersion: 9.5.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -147,7 +147,7 @@ This version requires Helm >= 3.1.0.
 | `podPortName`                             | Name of the grafana port on the pod           | `grafana`                                               |
 | `lifecycleHooks`                          | Lifecycle hooks for podStart and preStop [Example](https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/#define-poststart-and-prestop-handlers)     | `{}`                                                    |
 | `sidecar.image.repository`                | Sidecar image repository                      | `quay.io/kiwigrid/k8s-sidecar`                          |
-| `sidecar.image.tag`                       | Sidecar image tag                             | `1.24.3`                                                |
+| `sidecar.image.tag`                       | Sidecar image tag                             | `1.24.6`                                                |
 | `sidecar.image.sha`                       | Sidecar image sha (optional)                  | `""`                                                    |
 | `sidecar.imagePullPolicy`                 | Sidecar image pull policy                     | `IfNotPresent`                                          |
 | `sidecar.resources`                       | Sidecar resources                             | `{}`                                                    |

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -790,7 +790,7 @@ smtp:
 sidecar:
   image:
     repository: quay.io/kiwigrid/k8s-sidecar
-    tag: 1.24.3
+    tag: 1.24.6
     sha: ""
   imagePullPolicy: IfNotPresent
   resources: {}


### PR DESCRIPTION
There is a new sidecar upgrade which fixes some vulns:

- https://github.com/kiwigrid/k8s-sidecar/releases/tag/1.24.6

- [x] bumps the grafana chart version 6.57.5.
- [x] updates the README.md.