### PR TITLE
[grafana] Enabling the ability to omit the REQ_USERNAME and REQ_PASSWORD variables when sidecar.dashboards.skipReload is true

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.57.4
+version: 6.57.5
 appVersion: 9.5.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -182,7 +182,7 @@ This version requires Helm >= 3.1.0.
 | `sidecar.dashboards.searchNamespace`      | Namespaces list. If specified, the sidecar will search for dashboards config-maps  inside these namespaces. Otherwise the namespace in which the sidecar is running will be used. It's also possible to specify ALL to search in all namespaces. | `nil`                                |
 | `sidecar.dashboards.script`               | Absolute path to shell script to execute after a configmap got reloaded. | `nil`                                |
 | `sidecar.dashboards.reloadURL`            | Full url of dashboards configuration reload API endpoint, to invoke after a config-map change | `"http://localhost:3000/api/admin/provisioning/dashboards/reload"` |
-| `sidecar.dashboards.skipReload`           | Enabling this omits defining the REQ_URL and REQ_METHOD environment variables | `false` |
+| `sidecar.dashboards.skipReload`           | Enabling this omits defining the REQ_USERNAME, REQ_PASSWORD, REQ_URL and REQ_METHOD environment variables | `false` |
 | `sidecar.dashboards.resource`             | Should the sidecar looks into secrets, configmaps or both. | `both`                               |
 | `sidecar.dashboards.extraMounts`          | Additional dashboard sidecar volume mounts. | `[]`                               |
 | `sidecar.datasources.enabled`             | Enables the cluster wide search for datasources and adds/updates/deletes them in grafana |`false`       |

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -388,6 +388,7 @@ containers:
       - name: SCRIPT
         value: "{{ . }}"
       {{- end }}
+      {{- if not .Values.sidecar.dashboards.skipReload }}
       {{- if and (not .Values.env.GF_SECURITY_ADMIN_USER) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: REQ_USERNAME
         valueFrom:
@@ -402,7 +403,6 @@ containers:
             name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
             key: {{ .Values.admin.passwordKey | default "admin-password" }}
       {{- end }}
-      {{- if not .Values.sidecar.dashboards.skipReload }}
       - name: REQ_URL
         value: {{ .Values.sidecar.dashboards.reloadURL }}
       - name: REQ_METHOD


### PR DESCRIPTION
Currently the k8s-sidecar container will always use basic authentication when REQ_USERNAME and REQ_PASSWORD are set. This can cause issues when attempting to use any configmaps/secrets with `*.url` key configured.

There is an open bug issue here: https://github.com/kiwigrid/k8s-sidecar/issues/290

However when `sidecar.dashboards.skipReload` is **true** there doesn't seem to be a need/reason to set the REQ_USERNAME and REQ_PASSWORD environment variables. This PR allow omitting them to prevent triggering the current bug in the k8s-sidecar.

This issue was triggered by the following commit inside this repository: https://github.com/grafana/helm-charts/commit/3bcfc47221007e5f7f53830eec17c66d97fcd62f