### PR TITLE
[grafana] Update Grafana to v10.0.2

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.58.2
-appVersion: 10.0.1
+version: 6.58.3
+appVersion: 10.0.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net


### PR DESCRIPTION
Just bumping up the Grafana tag to `v10.0.2` (from `v10.0.1`).