### PR TITLE
[tempo-distributed] Add support for custom ingress rules on query-frontend

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.4.13
+version: 1.4.14
 appVersion: 2.1.1
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/templates/query-frontend/ingress-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/ingress-query-frontend.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.queryFrontend.query.enabled .Values.queryFrontend.ingress.enabled -}}
+{{- if .Values.queryFrontend.ingress.enabled -}}
 {{ $dict := dict "ctx" . "component" "query-frontend"  }}
 {{- $ingressApiIsStable := eq (include "tempo.ingress.isStable" .) "true" -}}
 {{- $ingressSupportsIngressClassName := eq (include "tempo.ingress.supportsIngressClassName" .) "true" -}}
@@ -41,10 +41,17 @@ spec:
             {{- end }}
             backend:
               {{- if $ingressApiIsStable }}
+              {{- if $.Values.queryFrontend.ingress.custom }}
+              service:
+                name: {{ .backend.service.name }}
+                port:
+                  number: {{ .backend.service.port.number }}
+              {{- else }}
               service:
                 name: {{ include "tempo.resourceName" $dict }}
                 port:
                   number: {{ $.Values.queryFrontend.service.port }}
+              {{- end }}
               {{- else }}
               serviceName: {{ include "tempo.resourceName" $dict }}
               servicePort: {{ $.Values.queryFrontend.service.port }}

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -706,8 +706,10 @@ queryFrontend:
     # -- Labels for queryFrontendDiscovery service
     labels: {}
   ingress:
-    # -- Specifies whether an ingress for the Jaeger should be created
+    # -- Specifies whether an ingress should be created for the query-frontned. By default for a Jaeger UI
     enabled: false
+    # -- Specifies whether a custom ingress should be created. 
+    custom: false
     # -- Ingress Class Name. MAY be required for Kubernetes versions >= 1.18
     # ingressClassName: nginx
     # -- Annotations for the Jaeger ingress


### PR DESCRIPTION
Allows the possibility for the query frontend ingress controller to expose specific ports and not be tied to Jaeger UI.

An example of how to configure it:
```yaml
gateway:
  enabled: true
  ingress:
    enabled: true
    custom: true
    annotations:
      external-dns.alpha.kubernetes.io/hostname: tempo.usw2-staging.test
      external-dns.alpha.kubernetes.io/alias: "true"
      external-dns.alpha.kubernetes.io/ttl: '60'
      kubernetes.io/ingress.class: alb
      alb.ingress.kubernetes.io/scheme: internal
      alb.ingress.kubernetes.io/target-type: ip
      alb.ingress.kubernetes.io/group.name: ....
      alb.ingress.kubernetes.io/certificate-arn: ....
      alb.ingress.kubernetes.io/inbound-cidrs: 10.0.0.0/8
      alb.ingress.kubernetes.io/success-codes: '200,302'
      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
      alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
      alb.ingress.kubernetes.io/healthcheck-protocol: HTTP
      alb.ingress.kubernetes.io/healthcheck-port: '3100'
      alb.ingress.kubernetes.io/healthcheck-path: /ready
    hosts:
      - host: "tempo.usw2-staging.test"
        http:
          paths:
            - path: /
              pathType: ImplementationSpecific
              backend:
                service:
                  name: tempo-query-frontend
                  port:
                    number: 3100
```