### PR TITLE
[loki-canary] bump loki version to 2.8.3

### DIFF
--- a/charts/loki-canary/Chart.yaml
+++ b/charts/loki-canary/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: loki-canary
 description: Helm chart for Grafana Loki Canary
 type: application
-appVersion: 2.8.2
-version: 0.12.0
+appVersion: 2.8.3
+version: 0.12.1
 home: https://github.com/grafana/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-canary/README.md
+++ b/charts/loki-canary/README.md
@@ -1,6 +1,6 @@
 # loki-canary
 
-![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
+![Version: 0.12.1](https://img.shields.io/badge/Version-0.12.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.3](https://img.shields.io/badge/AppVersion-2.8.3-informational?style=flat-square)
 
 Helm chart for Grafana Loki Canary
 


### PR DESCRIPTION
https://github.com/grafana/loki/releases/tag/v2.8.3