### PR TITLE
[loki-canary] add host aliases

### DIFF
--- a/charts/loki-canary/Chart.yaml
+++ b/charts/loki-canary/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-canary
 description: Helm chart for Grafana Loki Canary
 type: application
 appVersion: 2.8.3
-version: 0.12.1
+version: 0.13.0
 home: https://github.com/grafana/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-canary/README.md
+++ b/charts/loki-canary/README.md
@@ -1,6 +1,6 @@
 # loki-canary
 
-![Version: 0.12.1](https://img.shields.io/badge/Version-0.12.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.3](https://img.shields.io/badge/AppVersion-2.8.3-informational?style=flat-square)
+![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.3](https://img.shields.io/badge/AppVersion-2.8.3-informational?style=flat-square)
 
 Helm chart for Grafana Loki Canary
 
@@ -33,6 +33,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | extraVolumeMounts | list | `[]` | Volume mounts to add to the containers |
 | extraVolumes | list | `[]` | Volumes to add to the containers |
 | fullnameOverride | string | `""` | Overrides the chart's computed fullname |
+| hostAliases | list | `[]` | hostAliases to add |
 | image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | image.repository | string | `"docker.io/grafana/loki-canary"` | Docker image repository |
 | image.tag | string | `nil` | Overrides the image tag whose default is the chart's appVersion |

--- a/charts/loki-canary/templates/daemonset.yaml
+++ b/charts/loki-canary/templates/daemonset.yaml
@@ -27,6 +27,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}

--- a/charts/loki-canary/values.yaml
+++ b/charts/loki-canary/values.yaml
@@ -13,7 +13,7 @@ namespace:
 imagePullSecrets: []
 
 # -- hostAliases to add
-hostAliases: [ ]
+hostAliases: []
 #  - ip: 1.2.3.4
 #    hostnames:
   #      - domain.tld

--- a/charts/loki-canary/values.yaml
+++ b/charts/loki-canary/values.yaml
@@ -12,6 +12,12 @@ namespace:
 # -- Image pull secrets for Docker images
 imagePullSecrets: []
 
+# -- hostAliases to add
+hostAliases: [ ]
+#  - ip: 1.2.3.4
+#    hostnames:
+  #      - domain.tld
+
 image:
   # -- Docker image repository
   repository: docker.io/grafana/loki-canary


### PR DESCRIPTION
I need to set hostAliases in my environment for loki-distributed.
This PR adds this feature to the other helm-charts as well as for loki-distributed where I need this change initially.