### PR TITLE
[synthetic-monitoring-agent] Host aliases for synthetic monitoring agent

### DIFF
--- a/charts/synthetic-monitoring-agent/Chart.yaml
+++ b/charts/synthetic-monitoring-agent/Chart.yaml
@@ -15,4 +15,4 @@ name: synthetic-monitoring-agent
 sources:
   - https://github.com/grafana/synthetic-monitoring-agent
 type: application
-version: 0.1.0
+version: 0.2.0

--- a/charts/synthetic-monitoring-agent/README.md
+++ b/charts/synthetic-monitoring-agent/README.md
@@ -1,6 +1,6 @@
 # synthetic-monitoring-agent
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.9.3-0-gcd7aadd](https://img.shields.io/badge/AppVersion-v0.9.3--0--gcd7aadd-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.9.3-0-gcd7aadd](https://img.shields.io/badge/AppVersion-v0.9.3--0--gcd7aadd-informational?style=flat-square)
 
 Grafana's Synthetic Monitoring application. The agent provides probe functionality and executes network checks for monitoring remote targets.
 
@@ -39,6 +39,7 @@ Kubernetes: `^1.16.0-0`
 | autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory utilisation percentage |
 | extraObjects | list | `[]` | Add dynamic manifests via values: |
 | fullnameOverride | string | `""` | Override the fullname of the chart. |
+| hostAliases | list | `[]` | hostAliases to add |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | image.registry | string | `"docker.io"` | Base registry to pull the container image from. |
 | image.repository | string | `"grafana/synthetic-monitoring-agent"` | Base repository for container image. |

--- a/charts/synthetic-monitoring-agent/templates/deployment.yaml
+++ b/charts/synthetic-monitoring-agent/templates/deployment.yaml
@@ -29,6 +29,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "synthetic-monitoring-agent.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- if .Values.priorityClassName }}

--- a/charts/synthetic-monitoring-agent/values.yaml
+++ b/charts/synthetic-monitoring-agent/values.yaml
@@ -31,7 +31,7 @@ image:
 # -- Docker registry secret names as an array.
 imagePullSecrets: []
 # -- hostAliases to add
-hostAliases: [ ]
+hostAliases: []
 #  - ip: 1.2.3.4
 #    hostnames:
 #      - domain.tld

--- a/charts/synthetic-monitoring-agent/values.yaml
+++ b/charts/synthetic-monitoring-agent/values.yaml
@@ -30,6 +30,11 @@ image:
 
 # -- Docker registry secret names as an array.
 imagePullSecrets: []
+# -- hostAliases to add
+hostAliases: [ ]
+#  - ip: 1.2.3.4
+#    hostnames:
+#      - domain.tld
 # -- Override the name of the chart.
 nameOverride: ""
 # -- Override the fullname of the chart.


### PR DESCRIPTION
I need to set hostAliases in my environment for loki-distributed.
This PR adds this feature to the other helm-charts as well as for loki-distributed where I need this change initially.