### PR TITLE
[tempo-vulture] Host aliases for tempo vulture

### DIFF
--- a/charts/tempo-vulture/Chart.yaml
+++ b/charts/tempo-vulture/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-vulture
 description: Grafana Tempo Vulture - A tool to monitor Tempo performance.
 type: application
-version: 0.2.4
+version: 0.3.0
 appVersion: 2.1.1
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-vulture/README.md
+++ b/charts/tempo-vulture/README.md
@@ -1,6 +1,6 @@
 # tempo-vulture
 
-![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
 
 Grafana Tempo Vulture - A tool to monitor Tempo performance.
 
@@ -54,6 +54,7 @@ tempoAddress:
 | extraEnv | list | `[]` | Environment variables to add to the vulture pods |
 | extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the vulture pods |
 | fullnameOverride | string | `""` | Overrides the chart's computed fullname |
+| hostAliases | list | `[]` | hostAliases to add |
 | image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | image.repository | string | `"docker.io/grafana/tempo-vulture"` | Docker image repository |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart's appVersion |

--- a/charts/tempo-vulture/templates/deployment.yaml
+++ b/charts/tempo-vulture/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "tempo-vulture.serviceAccountName" . }}
       containers:
         - name: tempo-vulture

--- a/charts/tempo-vulture/values.yaml
+++ b/charts/tempo-vulture/values.yaml
@@ -4,6 +4,11 @@ nameOverride: ""
 fullnameOverride: ""
 # -- Image pull secrets for Docker images
 imagePullSecrets: []
+# -- hostAliases to add
+hostAliases: []
+#  - ip: 1.2.3.4
+#    hostnames:
+#      - domain.tld
 
 image:
   # -- Docker image repository


### PR DESCRIPTION
I need to set hostAliases in my environment for loki-distributed.
This PR adds this feature to the other helm-charts as well as for loki-distributed where I need this change initially.