### PR TITLE
[tempo-distributed] Add support for querier.config.search.external_backend

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.5.0
+version: 1.5.1
 appVersion: 2.2.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
+![Version: 1.5.1](https://img.shields.io/badge/Version-1.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -44,6 +44,11 @@ The command removes all the Kubernetes components associated with the chart and 
 ## Upgrading
 
 A major chart version change indicates that there is an incompatible breaking change needing manual actions.
+
+### From Chart versions < 1.5.0
+
+Please be aware that we've updated the minor version to Tempo 2.2, which includes breaking changes.
+We recommend reviewing the [release notes](https://github.com/grafana/tempo/releases/tag/v2.2.0) before upgrading.
 
 ### From Chart versions < 1.3.0
 
@@ -602,9 +607,11 @@ The memcached default args are removed and should be provided manually. The sett
 | querier.autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory utilisation percentage for the querier |
 | querier.config.frontend_worker.grpc_client_config | object | `{}` | grpc client configuration |
 | querier.config.max_concurrent_queries | int | `20` | This value controls the overall number of simultaneous subqueries that the querier will service at once. It does not distinguish between the types of queries. |
+| querier.config.search.external_backend | string | `""` | credentials when querying the external backend. |
 | querier.config.search.external_endpoints | list | `[]` | A list of external endpoints that the querier will use to offload backend search requests |
 | querier.config.search.external_hedge_requests_at | string | `"8s"` | If set to a non-zero value a second request will be issued at the provided duration. Recommended to be set to p99 of external search requests to reduce long tail latency. |
 | querier.config.search.external_hedge_requests_up_to | int | `2` | The maximum number of requests to execute when hedging. Requires hedge_requests_at to be set. |
+| querier.config.search.google_cloud_run | object | `{}` | external_backend is "google_cloud_run". |
 | querier.config.search.prefer_self | int | `10` | If search_external_endpoints is set then the querier will primarily act as a proxy for whatever serverless backend you have configured. This setting allows the operator to have the querier prefer itself for a configurable number of subqueries. |
 | querier.config.search.query_timeout | string | `"30s"` | Timeout for search requests |
 | querier.config.trace_by_id.query_timeout | string | `"10s"` | Timeout for trace lookup requests |

--- a/charts/tempo-distributed/README.md.gotmpl
+++ b/charts/tempo-distributed/README.md.gotmpl
@@ -39,6 +39,11 @@ The command removes all the Kubernetes components associated with the chart and 
 
 A major chart version change indicates that there is an incompatible breaking change needing manual actions.
 
+### From Chart versions < 1.5.0
+
+Please be aware that we've updated the minor version to Tempo 2.2, which includes breaking changes.
+We recommend reviewing the [release notes](https://github.com/grafana/tempo/releases/tag/v2.2.0) before upgrading.
+
 ### From Chart versions < 1.3.0
 
 Please be aware that we've updated the minor version to Tempo 2.1, which includes breaking changes.

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -596,8 +596,6 @@ querier:
       # -- Timeout for trace lookup requests
       query_timeout: 10s
     search:
-      # -- A list of external endpoints that the querier will use to offload backend search requests
-      external_endpoints: []
       # -- Timeout for search requests
       query_timeout: 30s
       # -- If search_external_endpoints is set then the querier will primarily act as a proxy for whatever serverless backend you have configured. This setting allows the operator to have the querier prefer itself for a configurable number of subqueries.
@@ -606,6 +604,14 @@ querier:
       external_hedge_requests_at: 8s
       # -- The maximum number of requests to execute when hedging. Requires hedge_requests_at to be set.
       external_hedge_requests_up_to: 2
+      # -- A list of external endpoints that the querier will use to offload backend search requests
+      external_endpoints: []
+      # -- The serverless backend to use. The default value of "" omits
+      # -- credentials when querying the external backend.
+      external_backend: ""
+      # -- Google Cloud Run configuration. Will be used only if the value of
+      # -- external_backend is "google_cloud_run".
+      google_cloud_run: {}
     # -- This value controls the overall number of simultaneous subqueries that the querier will service at once. It does not distinguish between the types of queries.
     max_concurrent_queries: 20
 
@@ -1129,6 +1135,11 @@ config: |
       prefer_self: {{ .Values.querier.config.search.prefer_self }}
       external_hedge_requests_at: {{ .Values.querier.config.search.external_hedge_requests_at }}
       external_hedge_requests_up_to: {{ .Values.querier.config.search.external_hedge_requests_up_to }}
+      external_backend: {{ .Values.querier.config.search.external_backend }}
+      {{- if .Values.querier.config.search.google_cloud_run }}
+      google_cloud_run:
+        {{- toYaml .Values.querier.config.search.google_cloud_run | nindent 6 }}
+      {{- end }}
     max_concurrent_queries: {{ .Values.querier.config.max_concurrent_queries }}
   query_frontend:
     max_retries: {{ .Values.queryFrontend.config.max_retries }}


### PR DESCRIPTION
This PR does the following:
~~1. Updates the tempo-distributed helm chart to the latest v2.2 Tempo release~~
~~2. Removes the now-incompatible `tolerate_failed_blocks` config, as announced in the Tempo v2.2.x release: https://github.com/grafana/tempo/releases/tag/v2.2.0-rc.0~~
3. Adds support for the `external_backend` and `google_cloud_run` configs, to leverage the new RBAC feature

I tested a local build of this helm chart, and can confirm that it works correctly with the new 2.2 release.

Checklist:

 - [x] DCO signed
 - [x] Chart Version bumped
 - [x] Title of the PR starts with chart name (e.g. [tempo-distributed])