### PR TITLE
[tempo-distributed] Bump to 1.5.2

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.5.1
+version: 1.5.2
 appVersion: 2.2.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.5.1](https://img.shields.io/badge/Version-1.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
+![Version: 1.5.2](https://img.shields.io/badge/Version-1.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 


### PR DESCRIPTION
My last PR was just merged recently: https://github.com/grafana/helm-charts/pull/2553
which bumped the chart version to `1.5.1`, but those changes are not actually in the `1.5.1` chart because another PR was merged slightly earlier, which also bumped the chart version to `1.5.1`: https://github.com/grafana/helm-charts/pull/2563/files

So this PR bumps the version to `1.5.2` so that my changes will be available in the most recent chart version.

Maybe this will motivate me to start using the Tempo operator... :smile: 