### PR TITLE
[tempo] feat: allow changing the default revisionHistoryLimit

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 1.4.0
+version: 1.5.0
 appVersion: 2.2.0
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 

--- a/charts/tempo/templates/statefulset.yaml
+++ b/charts/tempo/templates/statefulset.yaml
@@ -11,6 +11,9 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicas }}
+  {{- if .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "tempo.selectorLabels" . | nindent 6 }}

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -7,6 +7,9 @@ fullnameOverride: ""
 # -- Define the amount of instances
 replicas: 1
 
+# -- Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
+# revisionHistoryLimit: 1
+
 # -- Annotations for the StatefulSet
 annotations: {}
 


### PR DESCRIPTION
You may want to clean up old replicasets so that these don't appear in metrics, OPA violations, ArgoCD UI and so on.
Therefore you want to overwrite the Kubernetes default revision history limit.

See [Kubernetes Clean up Policy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy).
_(also available for StatefulSets but not yet documented [here](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/), instead please see [openapi-spec](https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/swagger.json))_