### PR TITLE
[promtail] feat: allow changing the default revisionHistoryLimit

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.8.3
-version: 6.13.1
+version: 6.14.0
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 6.13.1](https://img.shields.io/badge/Version-6.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.3](https://img.shields.io/badge/AppVersion-2.8.3-informational?style=flat-square)
+![Version: 6.14.0](https://img.shields.io/badge/Version-6.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.3](https://img.shields.io/badge/AppVersion-2.8.3-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/templates/daemonset.yaml
+++ b/charts/promtail/templates/daemonset.yaml
@@ -11,6 +11,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "promtail.selectorLabels" . | nindent 6 }}

--- a/charts/promtail/templates/deployment.yaml
+++ b/charts/promtail/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
   {{- if not .Values.deployment.autoscaling.enabled }}
   replicas: {{ .Values.deployment.replicaCount }}
   {{- end }}
+  {{- if .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   {{- with .Values.deployment.strategy }}
   strategy:
     {{- toYaml . | trim | nindent 4 }}

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -108,6 +108,9 @@ hostAliases: []
 # -- Annotations for the DaemonSet
 annotations: {}
 
+# -- Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
+# revisionHistoryLimit: 1
+
 # -- The update strategy for the DaemonSet
 updateStrategy: {}
 


### PR DESCRIPTION
You may want to clean up old replicasets so that these don't appear in metrics, OPA violations, ArgoCD UI and so on.
Therefore you want to overwrite the Kubernetes default revision history limit.

See [Kubernetes Clean up Policy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy).
(also available for DaemonSets but not yet documented [here](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/), instead please see [openapi-spec](https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/swagger.json))