### PR TITLE
[grafana] allow configuring serviceMonitor.metricRelabelings

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.58.7
+version: 6.58.8
 appVersion: 10.0.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -245,7 +245,9 @@ This version requires Helm >= 3.1.0.
 | `serviceMonitor.tlsConfig`                | TLS configuration block for the endpoint      | `{}`                                                    |
 | `serviceMonitor.labels`                   | Labels for the servicemonitor passed to Prometheus Operator      |  `{}`                                |
 | `serviceMonitor.scrapeTimeout`            | Timeout after which the scrape is ended       | `30s`                                                   |
-| `serviceMonitor.relabelings`              | MetricRelabelConfigs to apply to samples before ingestion.  | `[]`                                      |
+| `serviceMonitor.relabelings`              | RelabelConfigs to apply to samples before scraping.     | `[]`                                      |
+| `serviceMonitor.metricRelabelings`        | MetricRelabelConfigs to apply to samples before ingestion.  | `[]`                                      |
+
 | `revisionHistoryLimit`                    | Number of old ReplicaSets to retain           | `10`                                                    |
 | `imageRenderer.enabled`                    | Enable the image-renderer deployment & service                                     | `false`                          |
 | `imageRenderer.image.repository`           | image-renderer Image repository                                                    | `grafana/grafana-image-renderer` |

--- a/charts/grafana/templates/servicemonitor.yaml
+++ b/charts/grafana/templates/servicemonitor.yaml
@@ -34,6 +34,10 @@ spec:
     relabelings:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   jobLabel: "{{ .Release.Name }}"
   selector:
     matchLabels:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -207,6 +207,7 @@ serviceMonitor:
   tlsConfig: {}
   scrapeTimeout: 30s
   relabelings: []
+  metricRelabelings: []
   targetLabels: []
 
 extraExposePorts: []


### PR DESCRIPTION
To actually allow filtering out metrics pre-ingestion.

The readme is erroneously using the [upstream docs](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint) docs for `metricRelabelings` on the `relabelings` field, which is wrong. Have copied the lines from the corresponding docs in the linked `ServiceMonitor.spec.endpoint` docs.