### PR TITLE
[tempo-distributed] fix: add flush all on shutdown for ingestors

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.6.0
+version: 1.6.1
 appVersion: 2.2.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
+![Version: 1.6.1](https://img.shields.io/badge/Version-1.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -462,6 +462,7 @@ The memcached default args are removed and should be provided manually. The sett
 | ingester.autoscaling.targetCPUUtilizationPercentage | int | `60` | Target CPU utilisation percentage for the ingester |
 | ingester.autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory utilisation percentage for the ingester |
 | ingester.config.complete_block_timeout | string | `nil` | Duration to keep blocks in the ingester after they have been flushed |
+| ingester.config.flush_all_on_shutdown | bool | `false` | Flush all traces to backend when ingester is stopped |
 | ingester.config.flush_check_period | string | `nil` | How often to sweep all tenants and move traces from live -> wal -> completed blocks. |
 | ingester.config.max_block_bytes | string | `nil` | Maximum size of a block before cutting it |
 | ingester.config.max_block_duration | string | `nil` | Maximum length of time before cutting a block |

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -213,6 +213,8 @@ ingester:
     max_block_duration: null
     # -- Duration to keep blocks in the ingester after they have been flushed
     complete_block_timeout: null
+    # -- Flush all traces to backend when ingester is stopped
+    flush_all_on_shutdown: false
   service:
     # -- Annotations for ingester service
     annotations: {}
@@ -1207,6 +1209,9 @@ config: |
     {{- end }}
     {{- if .Values.ingester.config.complete_block_timeout }}
     complete_block_timeout: {{ .Values.ingester.config.complete_block_timeout }}
+    {{- end }}
+    {{- if .Values.ingester.config.flush_all_on_shutdown }}
+    flush_all_on_shutdown: {{ .Values.ingester.config.flush_all_on_shutdown }}
     {{- end }}
   memberlist:
     {{- with .Values.memberlist }}


### PR DESCRIPTION
The option is in the documentation but missing in the helm chart. https://grafana.com/docs/tempo/latest/configuration/#ingester