### PR TITLE
[promtail] Render pipelineStages with tpl function revert

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 2.8.3
-version: 6.14.1
+version: 6.14.2
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 6.14.1](https://img.shields.io/badge/Version-6.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.3](https://img.shields.io/badge/AppVersion-2.8.3-informational?style=flat-square)
+![Version: 6.14.2](https://img.shields.io/badge/Version-6.14.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.3](https://img.shields.io/badge/AppVersion-2.8.3-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -485,7 +485,7 @@ config:
       # See also https://github.com/grafana/loki/blob/master/production/ksonnet/promtail/scrape_config.libsonnet for reference
       - job_name: kubernetes-pods
         pipeline_stages:
-          {{- tpl (toYaml .Values.config.snippets.pipelineStages) . | nindent 4 }}
+          {{- toYaml .Values.config.snippets.pipelineStages | nindent 4 }}
         kubernetes_sd_configs:
           - role: pod
         relabel_configs:


### PR DESCRIPTION
Revert of #2575

Also see discussion at #2428 - the change to `tpl` lead to the conflict with all Go template definitions inside of `pipelineStages`. As it turns out this is also a typical use case in `pipelineStages`, e.g. by using promtail's [template](https://grafana.com/docs/loki/latest/clients/promtail/stages/template/) stage. In this context the `tpl` makes more problems than it is useful.