### PR TITLE
[promtail, ci] fix: skip existing releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,7 @@ jobs:
           config: cr.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_SKIP_EXISTING: "true"
 
       - name: Push charts to GHCR
         run: |


### PR DESCRIPTION
From the issue:

The release process fails in https://github.com/grafana/helm-charts/issues/2588 because chart-releaser discovers changes in promtail and tempo-distributed with tempo-distributed [existing already](https://github.com/grafana/helm-charts/actions/runs/5804536484/job/15734243055).

Chart-releaser lists this as a [common error](https://github.com/helm/chart-releaser#common-error-messages). I assume this can be fixed by adding the CR_SKIP_EXISTING=true to the [environment variables](https://github.com/helm/chart-releaser#environment-variables) section in the documentation.

closes #2591