### PR TITLE
[grafana] Update Grafana to v10.1.0

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 6.58.9
-appVersion: 10.0.3
+version: 6.59.0
+appVersion: 10.1.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net


### PR DESCRIPTION
There are breaking changes. Take a look into the [release notes](https://github.com/grafana/grafana/releases/tag/v10.1.0).