### PR TITLE
lint-test CI: make kubernetes version configurable

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -18,6 +18,11 @@ on:
         default: v3.8.2
         required: false
         type: string
+      k8s_version:
+        description: version of the kubectl binary used for the kind cluster
+        default: v1.26.4
+        required: false
+        type: string
 
 env:
   CT_CONFIGFILE: ${{ inputs.ct_configfile }}
@@ -60,6 +65,8 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@v1.8.0
         if: steps.list-changed.outputs.changed == 'true'
+        with:
+          kubectl_version: ${{ inputs.k8s_version }}
 
       - name: Run chart-testing (install)
         run: |


### PR DESCRIPTION
The recent update broke the mimir-distributed helm chart because it was relying on the default kubectl version in the kind-action. When kind-action was updated from 1.2.0 to 1.8.0 the kubectl version went from 1.20.8 to 1.26.4

This PR exposes the version of the version of kubernetes that kind-action should use.