### PR TITLE
[tempo-distributed] adjust minReplicas for ingester

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.6.4
+version: 1.6.5
 appVersion: 2.2.2
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.6.4](https://img.shields.io/badge/Version-1.6.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.2](https://img.shields.io/badge/AppVersion-2.2.2-informational?style=flat-square)
+![Version: 1.6.5](https://img.shields.io/badge/Version-1.6.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.2](https://img.shields.io/badge/AppVersion-2.2.2-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -458,7 +458,7 @@ The memcached default args are removed and should be provided manually. The sett
 | ingester.autoscaling.behavior | object | `{}` | Autoscaling behavior configuration for the ingester |
 | ingester.autoscaling.enabled | bool | `false` | Enable autoscaling for the ingester. WARNING: Autoscaling ingesters can result in lost data. Only do this if you know what you're doing. |
 | ingester.autoscaling.maxReplicas | int | `3` | Maximum autoscaling replicas for the ingester |
-| ingester.autoscaling.minReplicas | int | `1` | Minimum autoscaling replicas for the ingester |
+| ingester.autoscaling.minReplicas | int | `2` | Minimum autoscaling replicas for the ingester |
 | ingester.autoscaling.targetCPUUtilizationPercentage | int | `60` | Target CPU utilisation percentage for the ingester |
 | ingester.autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory utilisation percentage for the ingester |
 | ingester.config.complete_block_timeout | string | `nil` | Duration to keep blocks in the ingester after they have been flushed |

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -116,7 +116,7 @@ ingester:
     # -- Enable autoscaling for the ingester. WARNING: Autoscaling ingesters can result in lost data. Only do this if you know what you're doing.
     enabled: false
     # -- Minimum autoscaling replicas for the ingester
-    minReplicas: 1
+    minReplicas: 2
     # -- Maximum autoscaling replicas for the ingester
     maxReplicas: 3
     # -- Autoscaling behavior configuration for the ingester


### PR DESCRIPTION
If autoscaling is turned for the ingester, the distributor component permanently fails.

```
ingester:
  autoscaling:
    enabled: true
```

This will result in the following Go error in the distributor component:

`level=error ts=2023-09-21T07:26:44.537318884Z caller=rate_limited_logger.go:27 msg="pusher failed to consume trace data" err="at least 2 live replicas required, could only find 1"`

Therefor I propose to change the minReplicas default value for the ingester component:

```
ingester:
  autoscaling:
    minReplicas: 2
```
