### PR TITLE
[tempo-distributed] add missing namespaces to gateway resource

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.6.10
+version: 1.6.12
 appVersion: 2.2.3
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.6.10](https://img.shields.io/badge/Version-1.6.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.3](https://img.shields.io/badge/AppVersion-2.2.3-informational?style=flat-square)
+![Version: 1.6.12](https://img.shields.io/badge/Version-1.6.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.3](https://img.shields.io/badge/AppVersion-2.2.3-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/gateway/configmap-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/configmap-gateway.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "tempo.resourceName" (dict "ctx" . "component" "gateway") }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "gateway") | nindent 4 }}
 data:

--- a/charts/tempo-distributed/templates/gateway/deployment-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/deployment-gateway.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "tempo.resourceName" $dict }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
 spec:

--- a/charts/tempo-distributed/templates/gateway/hpa.yaml
+++ b/charts/tempo-distributed/templates/gateway/hpa.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "tempo.resourceName" (dict "ctx" . "component" "gateway") }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "gateway") | nindent 4 }}
 spec:

--- a/charts/tempo-distributed/templates/gateway/ingress-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/ingress-gateway.yaml
@@ -8,6 +8,7 @@ apiVersion: {{ include "tempo.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "tempo.resourceName" $dict }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "gateway") | nindent 4 }}
   {{- with .Values.gateway.ingress.annotations }}

--- a/charts/tempo-distributed/templates/gateway/poddisruptionbudget-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/poddisruptionbudget-gateway.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ include "tempo.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "tempo.resourceName" $dict }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
 spec:

--- a/charts/tempo-distributed/templates/gateway/secret-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/secret-gateway.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "tempo.resourceName" $dict }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
 stringData:

--- a/charts/tempo-distributed/templates/gateway/service-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/service-gateway.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "tempo.resourceName" (dict "ctx" . "component" "gateway") }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "gateway") | nindent 4 }}
     {{- with .Values.gateway.service.labels }}


### PR DESCRIPTION
Realized this when installing with `helm template ... ` followed by `kubectl apply`. 

If that is intended I'm happy to change it. Please let me know if I did something wrong w.r.t. contributing :) 