### PR TITLE
[tempo-distributed] Moves to GET 2.2.1, reverts MinIO dependency.

### DIFF
--- a/charts/tempo-distributed/Chart.lock
+++ b/charts/tempo-distributed/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: minio
+  repository: https://charts.min.io/
+  version: 4.0.12
+- name: grafana-agent-operator
+  repository: https://grafana.github.io/helm-charts
+  version: 0.2.2
+digest: sha256:761a500ff2fd8b8c5a52b70683abcdec8b6ffcae6b81ad26ea4ddeddbaf609f1
+generated: "2023-09-28T13:42:34.486521-07:00"

--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.6.6
+version: 1.6.7
 appVersion: 2.2.3
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/
@@ -23,8 +23,8 @@ maintainers:
 dependencies:
   - name: minio
     alias: minio
-    version: 8.0.9
-    repository: https://helm.min.io/
+    version: 4.0.12
+    repository: https://charts.min.io/
     condition: minio.enabled
   - name: grafana-agent-operator
     alias: grafana-agent-operator

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.6.6](https://img.shields.io/badge/Version-1.6.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.3](https://img.shields.io/badge/AppVersion-2.2.3-informational?style=flat-square)
+![Version: 1.6.7](https://img.shields.io/badge/Version-1.6.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.3](https://img.shields.io/badge/AppVersion-2.2.3-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -12,8 +12,8 @@ Grafana Tempo in MicroService mode
 
 | Repository | Name | Version |
 |------------|------|---------|
+| https://charts.min.io/ | minio(minio) | 4.0.12 |
 | https://grafana.github.io/helm-charts | grafana-agent-operator(grafana-agent-operator) | 0.2.2 |
-| https://helm.min.io/ | minio(minio) | 8.0.9 |
 
 ## Chart Repo
 
@@ -314,7 +314,7 @@ The memcached default args are removed and should be provided manually. The sett
 | distributor.topologySpreadConstraints | string | Defaults to allow skew no more then 1 node per AZ | topologySpread for distributor pods. Passed through `tpl` and, thus, to be configured as string |
 | enterprise.enabled | bool | `false` |  |
 | enterprise.image.repository | string | `"grafana/enterprise-traces"` | Grafana Enterprise Metrics container image repository. Note: for Grafana Tempo use the value 'image.repository' |
-| enterprise.image.tag | string | `"v2.1.0"` | Grafana Enterprise Metrics container image tag. Note: for Grafana Tempo use the value 'image.tag' |
+| enterprise.image.tag | string | `"v2.2.1"` | Grafana Enterprise Metrics container image tag. Note: for Grafana Tempo use the value 'image.tag' |
 | enterpriseFederationFrontend.affinity | string | Hard node and soft zone anti-affinity | Affinity for federation-frontend pods. Passed through `tpl` and, thus, to be configured as string |
 | enterpriseFederationFrontend.autoscaling.enabled | bool | `false` | Enable autoscaling for the federation-frontend |
 | enterpriseFederationFrontend.autoscaling.maxReplicas | int | `3` | Maximum autoscaling replicas for the federation-frontend |

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -1825,7 +1825,7 @@ enterprise:
     # -- Grafana Enterprise Metrics container image repository. Note: for Grafana Tempo use the value 'image.repository'
     repository: grafana/enterprise-traces
     # -- Grafana Enterprise Metrics container image tag. Note: for Grafana Tempo use the value 'image.tag'
-    tag: v2.1.0
+    tag: v2.2.1
     # Note: pullPolicy and optional pullSecrets are set in toplevel 'image' section, not here
 
 # In order to use Grafana Enterprise Traces features, you will need to provide the contents of your Grafana Enterprise Traces

--- a/ct.yaml
+++ b/ct.yaml
@@ -9,6 +9,6 @@ chart-repos:
   - elastic=https://helm.elastic.co
   - bitnami=https://charts.bitnami.com/bitnami
   - hashicorp=https://helm.releases.hashicorp.com
-  - min.io=https://helm.min.io
+  - minio=https://charts.min.io
 helm-extra-args: --timeout 600s
 validate-maintainers: false


### PR DESCRIPTION
This primarly fixes a breaking change where the MinIO chart dependency had been reset to the prior, deprecated Chart, which broke the installation of this Chart from source.
This occured as part of this PR: https://github.com/grafana/helm-charts/pull/2384 presumably due to a failure to rebase between initial raising and merging.

Have also updated the GET version from 2.1.0 to 2.2.1, inline with latest release.

Fully E2E tested via GET k8s cluster, with Grafana and GrAgent setup.