### PR TITLE
Add new Minio repo to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,7 @@ jobs:
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add hashicorp https://helm.releases.hashicorp.com
           helm repo add minio https://helm.min.io
+          helm repo add minio-new https://charts.min.io
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0


### PR DESCRIPTION
Minio hosts its charts at a new repo location now, so the release.yaml GH workflow needs to reflect that.

This adds it as a separate repo to not break anything existing.