### PR TITLE
[grafana] fix: add missing `| quote` for `sidecar.dashboards.labelValue`

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.60.3
+version: 6.60.4
 appVersion: 10.1.4
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/dashboards-json-configmap.yaml
+++ b/charts/grafana/templates/dashboards-json-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "grafana.labels" $ | nindent 4 }}
     dashboard-provider: {{ $provider }}
     {{- if $.Values.sidecar.dashboards.enabled }}
-    {{ $.Values.sidecar.dashboards.label }}: {{ $.Values.sidecar.dashboards.labelValue }}
+    {{ $.Values.sidecar.dashboards.label }}: {{ $.Values.sidecar.dashboards.labelValue | quote }}
     {{- end }}
 {{- if $dashboards }}
 data:


### PR DESCRIPTION
Otherwise problems such as https://github.com/prometheus-community/helm-charts/issues/3866 happen

I tried adding a test;

```yaml
sidecar:
  dashboards:
    enabled: true
    labelValue: "1"
dashboards:
  my-provider:
    my-awesome-dashboard:
      gnetId: 10000
      revision: 1
      datasource: Prometheus
```

but this mistake doesn't get detected via `ct lint`