### PR TITLE
[loki-distributed] Query scheduler and index gateway join the memberlist

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.9.1
-version: 0.74.6
+version: 0.75.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.74.6](https://img.shields.io/badge/Version-0.74.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.1](https://img.shields.io/badge/AppVersion-2.9.1-informational?style=flat-square)
+![Version: 0.75.0](https://img.shields.io/badge/Version-0.75.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.1](https://img.shields.io/badge/AppVersion-2.9.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 
@@ -228,6 +228,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | indexGateway.image.repository | string | `nil` | Docker image repository for the index-gateway image. Overrides `loki.image.repository` |
 | indexGateway.image.tag | string | `nil` | Docker image tag for the index-gateway image. Overrides `loki.image.tag` |
 | indexGateway.initContainers | list | `[]` | Init containers to add to the index-gateway pods |
+| indexGateway.joinMemberlist | bool | `true` | Whether the index gateway should join the memberlist hashring |
 | indexGateway.maxUnavailable | string | `nil` | Pod Disruption Budget maxUnavailable |
 | indexGateway.nodeSelector | object | `{}` | Node selector for index-gateway pods |
 | indexGateway.persistence.annotations | object | `{}` | Annotations for index gateway PVCs |
@@ -275,7 +276,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | ingester.maxSurge | int | `0` | Max Surge for ingester pods |
 | ingester.maxUnavailable | string | `nil` | Pod Disruption Budget maxUnavailable |
 | ingester.nodeSelector | object | `{}` | Node selector for ingester pods |
-| ingester.persistence.claims | list | `[{"name":"data","size":"10Gi","storageClass":null}]` | List of the ingester PVCs @notationType -- list |
+| ingester.persistence.claims | list |  | List of the ingester PVCs |
 | ingester.persistence.enableStatefulSetAutoDeletePVC | bool | `false` | Enable StatefulSetAutoDeletePVC feature |
 | ingester.persistence.enabled | bool | `false` | Enable creating PVCs which is required when using boltdb-shipper |
 | ingester.persistence.inMemory | bool | `false` | Use emptyDir with ramdisk for storage. **Please note that all data in ingester will be lost on pod restart** |

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -216,6 +216,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | hostAliases | list | `[]` | hostAliases to add |
 | imagePullSecrets | list | `[]` | Image pull secrets for Docker images |
 | indexGateway.affinity | string | Hard node and soft zone anti-affinity | Affinity for index-gateway pods. Passed through `tpl` and, thus, to be configured as string |
+| indexGateway.appProtocol | object | `{"grpc":""}` | Set the optional grpc service protocol. Ex: "grpc", "http2" or "https" |
 | indexGateway.enabled | bool | `false` | Specifies whether the index-gateway should be enabled |
 | indexGateway.extraArgs | list | `[]` | Additional CLI args for the index-gateway |
 | indexGateway.extraContainers | list | `[]` | Containers to add to the index-gateway pods |
@@ -528,6 +529,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | queryFrontend.terminationGracePeriodSeconds | int | `30` | Grace period to allow the query-frontend to shutdown before it is killed |
 | queryFrontend.tolerations | list | `[]` | Tolerations for query-frontend pods |
 | queryScheduler.affinity | string | Hard node and soft zone anti-affinity | Affinity for query-scheduler pods. Passed through `tpl` and, thus, to be configured as string |
+| queryScheduler.appProtocol | object | `{"grpc":""}` | Set the optional grpc service protocol. Ex: "grpc", "http2" or "https" |
 | queryScheduler.enabled | bool | `false` | Specifies whether the query-scheduler should be decoupled from the query-frontend |
 | queryScheduler.extraArgs | list | `[]` | Additional CLI args for the query-scheduler |
 | queryScheduler.extraContainers | list | `[]` | Containers to add to the query-scheduler pods |

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -276,7 +276,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | ingester.maxSurge | int | `0` | Max Surge for ingester pods |
 | ingester.maxUnavailable | string | `nil` | Pod Disruption Budget maxUnavailable |
 | ingester.nodeSelector | object | `{}` | Node selector for ingester pods |
-| ingester.persistence.claims | list |  | List of the ingester PVCs |
+| ingester.persistence.claims | list | `[{"name":"data","size":"10Gi","storageClass":null}]` | List of the ingester PVCs @notationType -- list |
 | ingester.persistence.enableStatefulSetAutoDeletePVC | bool | `false` | Enable StatefulSetAutoDeletePVC feature |
 | ingester.persistence.enabled | bool | `false` | Enable creating PVCs which is required when using boltdb-shipper |
 | ingester.persistence.inMemory | bool | `false` | Use emptyDir with ramdisk for storage. **Please note that all data in ingester will be lost on pod restart** |

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -554,6 +554,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | rbac.pspEnabled | bool | `false` | If pspEnabled true, a PodSecurityPolicy is created for K8s that use psp. |
 | rbac.sccEnabled | bool | `false` | For OpenShift set pspEnabled to 'false' and sccEnabled to 'true' to use the SecurityContextConstraints. |
 | ruler.affinity | string | Hard node and soft zone anti-affinity | Affinity for ruler pods. Passed through `tpl` and, thus, to be configured as string |
+| ruler.appProtocol | object | `{"grpc":""}` | Set the optional grpc service protocol. Ex: "grpc", "http2" or "https" |
 | ruler.command | string | `nil` | Command to execute instead of defined in Docker image |
 | ruler.directories | object | `{}` | Directories containing rules files |
 | ruler.dnsConfig | object | `{}` | DNSConfig for ruler pods |

--- a/charts/loki-distributed/templates/index-gateway/service-index-gateway-headless.yaml
+++ b/charts/loki-distributed/templates/index-gateway/service-index-gateway-headless.yaml
@@ -18,6 +18,9 @@ spec:
       port: 9095
       targetPort: grpc
       protocol: TCP
+      {{- with .Values.indexGateway.appProtocol.grpc }}
+      appProtocol: {{ . }}
+      {{- end }}
   selector:
     {{- include "loki.indexGatewaySelectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/loki-distributed/templates/index-gateway/service-index-gateway.yaml
+++ b/charts/loki-distributed/templates/index-gateway/service-index-gateway.yaml
@@ -23,6 +23,9 @@ spec:
       port: 9095
       targetPort: grpc
       protocol: TCP
+      {{- with .Values.indexGateway.appProtocol.grpc }}
+      appProtocol: {{ . }}
+      {{- end }}
   selector:
     {{- include "loki.indexGatewaySelectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/loki-distributed/templates/index-gateway/statefulset-index-gateway.yaml
+++ b/charts/loki-distributed/templates/index-gateway/statefulset-index-gateway.yaml
@@ -46,6 +46,9 @@ spec:
         {{- with .Values.indexGateway.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- if .Values.indexGateway.joinMemberlist }}
+        app.kubernetes.io/part-of: memberlist
+        {{- end }}
     spec:
       serviceAccountName: {{ include "loki.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}
@@ -81,6 +84,11 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
+            {{- if .Values.indexGateway.joinMemberlist }}
+            - name: http-memberlist
+              containerPort: 7946
+              protocol: TCP
+            {{- end }}
           {{- with .Values.indexGateway.extraEnv }}
           env:
             {{- toYaml . | nindent 12 }}

--- a/charts/loki-distributed/templates/query-scheduler/deployment-query-scheduler.yaml
+++ b/charts/loki-distributed/templates/query-scheduler/deployment-query-scheduler.yaml
@@ -38,6 +38,7 @@ spec:
         {{- with .Values.queryScheduler.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        app.kubernetes.io/part-of: memberlist
     spec:
       serviceAccountName: {{ include "loki.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}
@@ -68,6 +69,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: http-memberlist
+              containerPort: 7946
               protocol: TCP
           {{- with .Values.queryScheduler.extraEnv }}
           env:

--- a/charts/loki-distributed/templates/query-scheduler/service-query-scheduler.yaml
+++ b/charts/loki-distributed/templates/query-scheduler/service-query-scheduler.yaml
@@ -26,6 +26,9 @@ spec:
       port: 9095
       targetPort: grpc
       protocol: TCP
+      {{- with .Values.queryScheduler.appProtocol.grpc }}
+      appProtocol: {{ . }}
+      {{- end }}
   selector:
     {{- include "loki.querySchedulerSelectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/loki-distributed/templates/ruler/service-ruler.yaml
+++ b/charts/loki-distributed/templates/ruler/service-ruler.yaml
@@ -24,6 +24,9 @@ spec:
       port: 9095
       targetPort: grpc
       protocol: TCP
+      {{- with .Values.ruler.appProtocol.grpc }}
+      appProtocol: {{ . }}
+      {{- end }}
   selector:
     {{- include "loki.rulerSelectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -1446,6 +1446,9 @@ ruler:
     storageClass: null
     # -- Annotations for ruler PVCs
     annotations: {}
+  # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
+  appProtocol:
+    grpc: ""
   # -- Directories containing rules files
   directories: {}
     # tenant_foo:

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -1517,6 +1517,8 @@ indexGateway:
   enabled: false
   # -- Number of replicas for the index-gateway
   replicas: 1
+  # -- Whether the index gateway should join the memberlist hashring
+  joinMemberlist: true
   # -- hostAliases to add
   hostAliases: []
   #  - ip: 1.2.3.4

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -497,7 +497,6 @@ ingester:
     enableStatefulSetAutoDeletePVC: false
     whenDeleted: Retain
     whenScaled: Retain
-
   # -- Adds the appProtocol field to the ingester service. This allows ingester to work with istio protocol selection.
   appProtocol:
     # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
@@ -860,6 +859,9 @@ queryScheduler:
   nodeSelector: {}
   # -- Tolerations for query-scheduler pods
   tolerations: []
+  # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
+  appProtocol:
+    grpc: ""
 
 # Configuration for the table-manager
 tableManager:
@@ -1598,6 +1600,9 @@ indexGateway:
     enableStatefulSetAutoDeletePVC: false
     whenDeleted: Retain
     whenScaled: Retain
+  # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
+  appProtocol:
+    grpc: ""
 
 memcached:
   readinessProbe:


### PR DESCRIPTION
According to the Grafana Loki [documentation](https://grafana.com/docs/loki/latest/get-started/hash-rings/):
* the query scheduler must be part of a hashring
* the index gateway may optionally be part of a hashring

This PR updates the chart such that the query scheduler and index gateway pods will expose the memberlist container port 7946, and include the member list selector label. 

The index gateway may optionally be prevented from joining the memberlist by setting `.Values.indexGateway.joinMemberlist` to false (default true), reflecting the current state of the documentation.

In addition, the `appProtocol` field may be optionally configured for the ruler, query scheduler, and index gateway.