### PR TITLE
[grafana] Range over extraVolumes 

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.60.7
+version: 6.60.8
 appVersion: 10.1.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.60.6
+version: 6.60.7
 appVersion: 10.1.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.60.8
+version: 6.61.2
 appVersion: 10.1.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -1137,17 +1137,20 @@ volumes:
       {{- toYaml .csi | nindent 6 }}
   {{- end }}
   {{- end }}
-  {{- range .Values.extraVolumeMounts }}
+  {{- range .Values.extraVolumes }}
   - name: {{ .name }}
     {{- if .existingClaim }}
     persistentVolumeClaim:
       claimName: {{ .existingClaim }}
     {{- else if .hostPath }}
     hostPath:
-      path: {{ .hostPath }}
+      {{ toYaml .hostPath | nindent 6 }}
     {{- else if .csi }}
     csi:
       {{- toYaml .data | nindent 6 }}
+    {{- else if .configMap }}
+    configMap:
+      {{- toYaml .configMap | nindent 6 }}
     {{- else }}
     emptyDir: {}
     {{- end }}
@@ -1160,3 +1163,4 @@ volumes:
   {{- tpl (toYaml .) $root | nindent 2 }}
   {{- end }}
 {{- end }}
+


### PR DESCRIPTION
Previously, this was ranging over extraVolumeClaims instead of extraVolumes, which meant extraVolumes was never read. This caused volumes mounted as extraVolumes to be mounted as emptyDirs.
This also correctly inserts all data from hostPath volumes, and allows configMaps to be used as an extraVolume.

This should fix https://github.com/prometheus-community/helm-charts/issues/3851