### PR TITLE
Update Prometheus requirements.yaml

### DIFF
--- a/charts/loki-stack/requirements.yaml
+++ b/charts/loki-stack/requirements.yaml
@@ -17,7 +17,7 @@ dependencies:
   repository:  "https://grafana.github.io/helm-charts"
 - name: "prometheus"
   condition: prometheus.enabled
-  version: "~15.5.3"
+  version: "^18.0.0"
   repository:  "https://prometheus-community.github.io/helm-charts"
 - name: "filebeat"
   condition: filebeat.enabled


### PR DESCRIPTION
Update Prometheus to 18.0.0 so kube-state-metrics is at 2.7.0 (currently on 2.3.0 which corresponds to an end-of-life Kubernetes version for GKE, and 2.6.0 corresponds to Kubernetes 1.24, which is near EOL)

https://github.com/prometheus-community/helm-charts/blob/prometheus-18.0.0/charts/kube-state-metrics/Chart.yaml

https://github.com/kubernetes/kube-state-metrics#compatibility-matrix

Fixes

https://github.com/grafana/helm-charts/issues/2335