### PR TITLE
Update Prometheus to update kube-state-metrics

### DIFF
--- a/charts/loki-stack/Chart.yaml
+++ b/charts/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 2.9.11
+version: 3.0.0
 appVersion: v2.6.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/charts/loki-stack/Chart.yaml
+++ b/charts/loki-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: "v1"
 name: loki-stack
 version: 3.0.0
 appVersion: v2.6.1
-kubeVersion: "^1.10.0-0"
+kubeVersion: "^1.24.0-0"
 description: "Loki: like Prometheus, but for logs."
 home: https://grafana.com/loki
 icon: https://raw.githubusercontent.com/grafana/loki/master/docs/sources/logo.png

--- a/charts/loki-stack/README.md
+++ b/charts/loki-stack/README.md
@@ -62,6 +62,10 @@ Navigate to <http://localhost:3000> and login with `admin` and the password outp
 Then follow the [instructions for adding the loki datasource](https://grafana.com/docs/grafana/latest/datasources/loki/), using the URL `http://loki:3100/`.
 
 ## Upgrade
+### Version >= 3.0.0
+Update Prometheus 15.5.3->18.0.0 to update `kube-state-metrics` to 2.7.0 to ensure compatibility with Kubernetes 1.25, 
+update Kubernetes to at least 1.24 [#2727](https://github.com/grafana/helm-charts/pull/2727)
+
 ### Version >= 2.8.0
 Provide support configurable datasource urls [#1374](https://github.com/grafana/helm-charts/pull/1374)
 

--- a/charts/loki-stack/requirements.yaml
+++ b/charts/loki-stack/requirements.yaml
@@ -17,7 +17,7 @@ dependencies:
   repository:  "https://grafana.github.io/helm-charts"
 - name: "prometheus"
   condition: prometheus.enabled
-  version: "~15.5.3"
+  version: "^18.0.0"
   repository:  "https://prometheus-community.github.io/helm-charts"
 - name: "filebeat"
   condition: filebeat.enabled


### PR DESCRIPTION
Update Prometheus to 18.0.0 so kube-state-metrics is at 2.7.0 (currently on 2.3.0 which corresponds to an end-of-life Kubernetes version for GKE, and 2.6.0 corresponds to Kubernetes 1.24, which is near EOL)

https://github.com/prometheus-community/helm-charts/blob/prometheus-18.0.0/charts/kube-state-metrics/Chart.yaml

https://github.com/kubernetes/kube-state-metrics#compatibility-matrix

https://github.com/grafana/helm-charts/issues/2335