### PR TITLE
[grafana] Rename global.image.registry to global.imageRegistry

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 6.61.1
+version: 7.0.0
 appVersion: 10.1.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -46,6 +46,13 @@ You have to add --force to your helm upgrade command as the labels of the chart 
 
 This version requires Helm >= 3.1.0.
 
+### To 7.0.0
+
+For consistency with other Helm charts, the `global.image.registry` parameter was renamed 
+to `global.imageRegistry`. If you were not previously setting `global.image.registry`, no action
+is required on upgrade. If you were previously setting `global.image.registry`, you will
+need to instead set `global.imageRegistry`.
+
 ## Configuration
 
 | Parameter                                 | Description                                   | Default                                                 |

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -140,7 +140,7 @@ This version requires Helm >= 3.1.0.
 | `dashboards`                              | Dashboards to import                          | `{}`                                                    |
 | `dashboardsConfigMaps`                    | ConfigMaps reference that contains dashboards | `{}`                                                    |
 | `grafana.ini`                             | Grafana's primary configuration               | `{}`                                                    |
-| `global.image.registry`                   | Global image pull registry for all images.    | `null`                                   |
+| `global.imageRegistry`                    | Global image pull registry for all images.    | `null`                                   |
 | `global.imagePullSecrets`                 | Global image pull secrets (can be templated). Allows either an array of {name: pullSecret} maps (k8s-style), or an array of strings (more common helm-style).  | `[]`                                                    |
 | `ldap.enabled`                            | Enable LDAP authentication                    | `false`                                                 |
 | `ldap.existingSecret`                     | The name of an existing secret containing the `ldap.toml` file, this must have the key `ldap-toml`. | `""` |

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -22,7 +22,7 @@ initContainers:
 {{- end }}
 {{- if ( and .Values.persistence.enabled .Values.initChownData.enabled ) }}
   - name: init-chown-data
-    {{- $registry := .Values.global.image.registry | default .Values.initChownData.image.registry -}}
+    {{- $registry := .Values.global.imageRegistry | default .Values.initChownData.image.registry -}}
     {{- if .Values.initChownData.image.sha }}
     image: "{{ $registry }}/{{ .Values.initChownData.image.repository }}:{{ .Values.initChownData.image.tag }}@sha256:{{ .Values.initChownData.image.sha }}"
     {{- else }}
@@ -51,7 +51,7 @@ initContainers:
 {{- end }}
 {{- if .Values.dashboards }}
   - name: download-dashboards
-    {{- $registry := .Values.global.image.registry | default .Values.downloadDashboardsImage.registry -}}
+    {{- $registry := .Values.global.imageRegistry | default .Values.downloadDashboardsImage.registry -}}
     {{- if .Values.downloadDashboardsImage.sha }}
     image: "{{ $registry }}/{{ .Values.downloadDashboardsImage.repository }}:{{ .Values.downloadDashboardsImage.tag }}@sha256:{{ .Values.downloadDashboardsImage.sha }}"
     {{- else }}
@@ -100,7 +100,7 @@ initContainers:
 {{- end }}
 {{- if and .Values.sidecar.datasources.enabled .Values.sidecar.datasources.initDatasources }}
   - name: {{ include "grafana.name" . }}-init-sc-datasources
-    {{- $registry := .Values.global.image.registry | default .Values.sidecar.image.registry -}}
+    {{- $registry := .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
     {{- if .Values.sidecar.image.sha }}
     image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
     {{- else }}
@@ -158,7 +158,7 @@ initContainers:
 {{- end }}
 {{- if and .Values.sidecar.notifiers.enabled .Values.sidecar.notifiers.initNotifiers }}
   - name: {{ include "grafana.name" . }}-init-sc-notifiers
-    {{- $registry := .Values.global.image.registry | default .Values.sidecar.image.registry -}}
+    {{- $registry := .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
     {{- if .Values.sidecar.image.sha }}
     image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
     {{- else }}
@@ -235,7 +235,7 @@ enableServiceLinks: {{ .Values.enableServiceLinks }}
 containers:
 {{- if .Values.sidecar.alerts.enabled }}
   - name: {{ include "grafana.name" . }}-sc-alerts
-    {{- $registry := .Values.global.image.registry | default .Values.sidecar.image.registry -}}
+    {{- $registry := .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
     {{- if .Values.sidecar.image.sha }}
     image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
     {{- else }}
@@ -342,7 +342,7 @@ containers:
 {{- end}}
 {{- if .Values.sidecar.dashboards.enabled }}
   - name: {{ include "grafana.name" . }}-sc-dashboard
-    {{- $registry := .Values.global.image.registry | default .Values.sidecar.image.registry -}}
+    {{- $registry := .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
     {{- if .Values.sidecar.image.sha }}
     image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
     {{- else }}
@@ -453,7 +453,7 @@ containers:
 {{- end}}
 {{- if .Values.sidecar.datasources.enabled }}
   - name: {{ include "grafana.name" . }}-sc-datasources
-    {{- $registry := .Values.global.image.registry | default .Values.sidecar.image.registry -}}
+    {{- $registry := .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
     {{- if .Values.sidecar.image.sha }}
     image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
     {{- else }}
@@ -557,7 +557,7 @@ containers:
 {{- end}}
 {{- if .Values.sidecar.notifiers.enabled }}
   - name: {{ include "grafana.name" . }}-sc-notifiers
-    {{- $registry := .Values.global.image.registry | default .Values.sidecar.image.registry -}}
+    {{- $registry := .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
     {{- if .Values.sidecar.image.sha }}
     image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
     {{- else }}
@@ -661,7 +661,7 @@ containers:
 {{- end}}
 {{- if .Values.sidecar.plugins.enabled }}
   - name: {{ include "grafana.name" . }}-sc-plugins
-    {{- $registry := .Values.global.image.registry | default .Values.sidecar.image.registry -}}
+    {{- $registry := .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
     {{- if .Values.sidecar.image.sha }}
     image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
     {{- else }}
@@ -764,7 +764,7 @@ containers:
         mountPath: "/etc/grafana/provisioning/plugins"
 {{- end}}
   - name: {{ .Chart.Name }}
-    {{- $registry := .Values.global.image.registry | default .Values.image.registry -}}
+    {{- $registry := .Values.global.imageRegistry | default .Values.image.registry -}}
     {{- if .Values.image.sha }}
     image: "{{ $registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}@sha256:{{ .Values.image.sha }}"
     {{- else }}

--- a/charts/grafana/templates/image-renderer-deployment.yaml
+++ b/charts/grafana/templates/image-renderer-deployment.yaml
@@ -65,7 +65,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}-image-renderer
-          {{- $registry := .Values.global.image.registry | default .Values.imageRenderer.image.registry -}}
+          {{- $registry := .Values.global.imageRegistry | default .Values.imageRenderer.image.registry -}}
           {{- if .Values.imageRenderer.image.sha }}
           image: "{{ $registry }}/{{ .Values.imageRenderer.image.repository }}:{{ .Values.imageRenderer.image.tag }}@sha256:{{ .Values.imageRenderer.image.sha }}"
           {{- else }}

--- a/charts/grafana/templates/tests/test.yaml
+++ b/charts/grafana/templates/tests/test.yaml
@@ -34,7 +34,7 @@ spec:
   {{- end }}
   containers:
     - name: {{ .Release.Name }}-test
-      image: "{{ .Values.global.image.registry | default .Values.testFramework.image.registry }}/{{ .Values.testFramework.image.repository }}:{{ .Values.testFramework.image.tag }}"
+      image: "{{ .Values.global.imageRegistry | default .Values.testFramework.image.registry }}/{{ .Values.testFramework.image.repository }}:{{ .Values.testFramework.image.tag }}"
       imagePullPolicy: "{{ .Values.testFramework.imagePullPolicy}}"
       command: ["/opt/bats/bin/bats", "-t", "/tests/run.sh"]
       volumeMounts:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1,7 +1,6 @@
 global:
-  image:
-    # -- Overrides the Docker registry globally for all images
-    registry: null
+  # -- Overrides the Docker registry globally for all images
+  imageRegistry: null
 
   # To help compatibility with other charts which use global.imagePullSecrets.
   # Allow either an array of {name: pullSecret} maps (k8s-style), or an array of strings (more common helm-style).


### PR DESCRIPTION
Many popular Helm charts, such as those provided by [Bitnami](https://github.com/bitnami/charts/tree/main/bitnami) ([1](https://github.com/bitnami/charts/blob/3f08ec6ab4335af812b8625ef0f1c41b7659206a/bitnami/mongodb/values.yaml#L16C1-L16C20), [2](https://github.com/bitnami/charts/blob/3f08ec6ab4335af812b8625ef0f1c41b7659206a/bitnami/grafana/values.yaml#L14), [3](https://github.com/bitnami/charts/blob/3f08ec6ab4335af812b8625ef0f1c41b7659206a/bitnami/redis/values.yaml#L16), plus 105 other charts) and [Prometheus](https://github.com/prometheus-community/helm-charts/tree/main/charts) ([1](https://github.com/prometheus-community/helm-charts/blob/1d917846c4f9dc3157d1ae8fc5511d63c3813aa3/charts/kube-state-metrics/values.yaml#L29), [2](https://github.com/prometheus-community/helm-charts/blob/1d917846c4f9dc3157d1ae8fc5511d63c3813aa3/charts/kube-prometheus-stack/values.yaml#L196)), support specifying a global image registry via a `global.imageRegistry` parameter in a Helm values file. Support for specifying a global image registry was [recently added](https://github.com/grafana/helm-charts/pull/2695) to the Grafana chart, but the parameter was named `global.image.registry`. The name of the new parameter breaks from the convention used by most other Helm charts. It also breaks with the convention established by the existing `global.imagePullSecrets` parameter present in the Grafana Helm chart. For consistency with most other Helm charts, I think we should rename the parameter to `global.imageRegistry`. Standard naming conventions are especially important for global parameters -- without a consistently named parameter, top-level Helm charts depending on Grafana and other popular Helm charts will need to set both `global.image.registry` and `global.imageRegistry`.

It's worth acknowledging that Helm charts in this repo are internally inconsistent, but do favor the less common `global.image.registry`. The following chart uses `global.imageRegistry`:
- [`promtail`](https://github.com/grafana/helm-charts/blob/c8dc0d5c88839d1c24a3a9290cc6e159a2ccb9e4/charts/promtail/values.yaml#L9C1-L9C20)

The following charts in this repo use `global.image.registry`:
- [`grafana-agent`](https://github.com/grafana/agent/blob/93397be0fdfcec95f694c4abcfb8fa9749251c85/operations/helm/charts/grafana-agent/values.yaml#L13C1-L13C17)
- [`tempo-distributed`](https://github.com/grafana/helm-charts/blob/c8dc0d5c88839d1c24a3a9290cc6e159a2ccb9e4/charts/tempo-distributed/values.yaml#L4)
- [`loki`](https://github.com/grafana/loki/blob/60ea954f5df20978b9724ca6180d7986276c1caa/production/helm/loki/values.yaml#L4C12-L4C12)
- [`loki-distributed`](https://github.com/grafana/helm-charts/blob/c8dc0d5c88839d1c24a3a9290cc6e159a2ccb9e4/charts/loki-distributed/values.yaml#L4C1-L4C19)

Internal inconsistencies notwithstanding, I think it makes sense to rename this parameter to `global.imageRegistry`. I think we should also rename the parameter in the other charts, but not in this PR. Global image registry support was added to Grafana just last week, so it's less disruptive to rename it now.

Even though the parameter was added just last week, this is technically a breaking change, so I've revved the version number in the `Chart.yaml` file. I'm open to suggestions on whether we think this is worth a major version bump.