### PR TITLE
[loki-distributed] manage compactor as statefulset

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.9.2
-version: 0.77.0
+version: 0.78.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -103,14 +103,22 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | compactor.image.repository | string | `nil` | Docker image repository for the compactor image. Overrides `loki.image.repository` |
 | compactor.image.tag | string | `nil` | Docker image tag for the compactor image. Overrides `loki.image.tag` |
 | compactor.initContainers | list | `[]` | Init containers to add to the compactor pods |
+| compactor.kind | string | `"StatefulSet"` | Kind of deployment [StatefulSet/Deployment] |
+| compactor.livenessProbe | object | `{}` | liveness probe settings for ingester pods. If empty use `loki.livenessProbe` |
 | compactor.nodeSelector | object | `{}` | Node selector for compactor pods |
 | compactor.persistence.annotations | object | `{}` | Annotations for compactor PVCs |
+| compactor.persistence.claims | list | `[{"name":"data","size":"10Gi","storageClass":null}]` | List of the compactor PVCs @notationType -- list |
+| compactor.persistence.enableStatefulSetAutoDeletePVC | bool | `false` | Enable StatefulSetAutoDeletePVC feature |
 | compactor.persistence.enabled | bool | `false` | Enable creating PVCs for the compactor |
 | compactor.persistence.size | string | `"10Gi"` | Size of persistent disk |
 | compactor.persistence.storageClass | string | `nil` | Storage class to be used. If defined, storageClassName: <storageClass>. If set to "-", storageClassName: "", which disables dynamic provisioning. If empty or set to null, no storageClassName spec is set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack). |
+| compactor.persistence.whenDeleted | string | `"Retain"` |  |
+| compactor.persistence.whenScaled | string | `"Retain"` |  |
 | compactor.podAnnotations | object | `{}` | Annotations for compactor pods |
 | compactor.podLabels | object | `{}` | Labels for compactor pods |
 | compactor.priorityClassName | string | `nil` | The name of the PriorityClass for compactor pods |
+| compactor.readinessProbe | object | `{}` | readiness probe settings for ingester pods. If empty, use `loki.readinessProbe` |
+| compactor.replicas | int | `1` | Number of replicas for the compactor |
 | compactor.resources | object | `{}` | Resource requests and limits for the compactor |
 | compactor.serviceAccount.annotations | object | `{}` | Annotations for the compactor service account |
 | compactor.serviceAccount.automountServiceAccountToken | bool | `true` | Set this toggle to false to opt out of automounting API credentials for the service account |

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.77.0](https://img.shields.io/badge/Version-0.77.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.2](https://img.shields.io/badge/AppVersion-2.9.2-informational?style=flat-square)
+![Version: 0.78.0](https://img.shields.io/badge/Version-0.78.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.2](https://img.shields.io/badge/AppVersion-2.9.2-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/templates/compactor/_helpers-compactor.tpl
+++ b/charts/loki-distributed/templates/compactor/_helpers-compactor.tpl
@@ -30,6 +30,36 @@ compactor image
 {{- end }}
 
 {{/*
+compactor readinessProbe
+*/}}
+{{- define "loki.compactor.readinessProbe" -}}
+{{- with .Values.compactor.readinessProbe }}
+readinessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- else }}
+{{- with .Values.loki.readinessProbe }}
+readinessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+compactor livenessProbe
+*/}}
+{{- define "loki.compactor.livenessProbe" -}}
+{{- with .Values.compactor.livenessProbe }}
+livenessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- else }}
+{{- with .Values.loki.livenessProbe }}
+livenessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
 compactor priority class name
 */}}
 {{- define "loki.compactorPriorityClassName" }}

--- a/charts/loki-distributed/templates/compactor/persistentvolumeclaim-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/persistentvolumeclaim-compactor.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.compactor.enabled .Values.compactor.persistence.enabled }}
+{{- if eq .Values.compactor.kind "Deployment"}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -19,4 +20,5 @@ spec:
   resources:
     requests:
       storage: "{{ .Values.compactor.persistence.size }}"
+{{- end }}
 {{- end }}

--- a/charts/loki-distributed/templates/compactor/statefulset-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/statefulset-compactor.yaml
@@ -1,21 +1,30 @@
 {{- if .Values.compactor.enabled }}
-{{- if eq .Values.compactor.kind "Deployment"}}
+{{- if eq .Values.compactor.kind "StatefulSet"}}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "loki.compactorFullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "loki.compactorLabels" . | nindent 4 }}
+    app.kubernetes.io/part-of: memberlist
   {{- with .Values.loki.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.compactor.replicas }}
+  podManagementPolicy: Parallel
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+  serviceName: {{ include "loki.compactorFullname" . }}-headless
   revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}
-  strategy:
-    type: Recreate
+  {{- if and (semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version) (.Values.compactor.persistence.enableStatefulSetAutoDeletePVC)  }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ .Values.compactor.persistence.whenDeleted }}
+    whenScaled: {{ .Values.compactor.persistence.whenScaled }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "loki.compactorSelectorLabels" . | nindent 6 }}
@@ -39,7 +48,13 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ include "loki.compactorServiceAccountName" . }}
+      {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+      {{- with .Values.compactor.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- tpl . $ | nindent 8 }}
+      {{- end }}
+      {{- end }}
+      serviceAccountName: {{ include "loki.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -67,7 +82,6 @@ spec:
           args:
             - -config.file=/etc/loki/config/config.yaml
             - -target=compactor
-            - -boltdb.shipper.compactor.working-directory=/var/loki/compactor
             {{- with .Values.compactor.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -91,10 +105,8 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
-          readinessProbe:
-            {{- toYaml .Values.loki.readinessProbe | nindent 12 }}
-          livenessProbe:
-            {{- toYaml .Values.loki.livenessProbe | nindent 12 }}
+          {{- include "loki.compactor.readinessProbe" . | nindent 10 }}
+          {{- include "loki.compactor.livenessProbe" . | nindent 10 }}
           volumeMounts:
             - name: temp
               mountPath: /tmp
@@ -107,8 +119,14 @@ spec:
             {{- with .Values.compactor.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.compactor.resources }}
           resources:
-            {{- toYaml .Values.compactor.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.compactor.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- if .Values.compactor.extraContainers }}
         {{- toYaml .Values.compactor.extraContainers | nindent 8}}
         {{- end }}
@@ -141,15 +159,32 @@ spec:
         - name: runtime-config
           configMap:
             name: {{ template "loki.fullname" . }}-runtime
+        {{- if not .Values.compactor.persistence.enabled }}
         - name: data
-          {{- if .Values.compactor.persistence.enabled }}
-          persistentVolumeClaim:
-            claimName: data-{{ include "loki.compactorFullname" . }}
-          {{- else }}
           emptyDir: {}
-          {{- end }}
+        {{- end }}
         {{- with .Values.compactor.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+  {{- if .Values.compactor.persistence.enabled }}
+  volumeClaimTemplates:
+  {{- range .Values.compactor.persistence.claims }}
+    - metadata:
+        name: {{ .name }}
+        {{- with .annotations }}
+        annotations:
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- with .storageClass }}
+        storageClassName: {{ if (eq "-" .) }}""{{ else }}{{ . }}{{ end }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .size | quote }}
+  {{- end }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -1325,6 +1325,10 @@ gateway:
 
 # Configuration for the compactor
 compactor:
+  # -- Kind of deployment [StatefulSet/Deployment]
+  kind: StatefulSet
+  # -- Number of replicas for the compactor
+  replicas: 1
   # -- Specifies whether compactor should be enabled
   enabled: false
   # -- hostAliases to add
@@ -1375,6 +1379,10 @@ compactor:
   extraVolumeMounts: []
   # -- Volumes to add to the compactor pods
   extraVolumes: []
+  # -- readiness probe settings for ingester pods. If empty, use `loki.readinessProbe`
+  readinessProbe: {}
+  # -- liveness probe settings for ingester pods. If empty use `loki.livenessProbe`
+  livenessProbe: {}
   # -- Resource requests and limits for the compactor
   resources: {}
   # -- Containers to add to the compactor pods
@@ -1403,6 +1411,24 @@ compactor:
     storageClass: null
     # -- Annotations for compactor PVCs
     annotations: {}
+    # -- List of the compactor PVCs
+    # @notationType -- list
+    claims:
+      - name: data
+        size: 10Gi
+        #   -- Storage class to be used.
+        #   If defined, storageClassName: <storageClass>.
+        #   If set to "-", storageClassName: "", which disables dynamic provisioning.
+        #   If empty or set to null, no storageClassName spec is
+        #   set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
+        storageClass: null
+      # - name: wal
+      #   size: 150Gi
+    # -- Enable StatefulSetAutoDeletePVC feature
+    enableStatefulSetAutoDeletePVC: false
+    whenDeleted: Retain
+    whenScaled: Retain
+
   serviceAccount:
     create: false
     # -- The name of the ServiceAccount to use for the compactor.


### PR DESCRIPTION
Hey there !

Small contribution here to allow users of the chart to manage the compactor as a statefulset

:warning: Also I draw you attention on the fact that in the `values.yaml` I set the compactor field `Kind` as `Statefulset` starting now : this might break existing setup. I did that since Statefulset is kind of the default way to manage stateful software in k8s IMHO, but let me know what you think about it :wink:

If you have any question, do not hesitate to reach me :wink:

Cheers :sunny:
