### PR TITLE
[grafana] Add global image registry support for extraInitContainers

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 7.0.1
+version: 7.0.2
 appVersion: 10.1.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -222,8 +222,19 @@ initContainers:
       - name: sc-notifiers-volume
         mountPath: "/etc/grafana/provisioning/notifiers"
 {{- end}}
-{{- with .Values.extraInitContainers }}
-  {{- tpl (toYaml .) $root | nindent 2 }}
+{{- if .Values.extraInitContainers }}
+{{- range $eic := .Values.extraInitContainers }}
+  - name: {{ $eic.name }}
+    {{- $registry := $.Values.global.imageRegistry | default $eic.image.registry -}}
+    {{- if $eic.image.sha }}
+    image: "{{ $registry }}/{{ $eic.image.repository }}:{{ $eic.image.tag }}@sha256:{{ $eic.image.sha }}"
+    {{- else }}
+    image: "{{ $registry }}/{{ $eic.image.repository }}:{{ $eic.image.tag }}"
+    {{- end }}
+    imagePullPolicy: {{ $eic.image.pullPolicy }}
+    volumeMounts:
+{{ toYaml $eic.volumeMounts | indent 6 }}
+{{- end }}
 {{- end }}
 {{- if or .Values.image.pullSecrets .Values.global.imagePullSecrets }}
 imagePullSecrets:


### PR DESCRIPTION
If a client sets `global.imageRegistry`, that registry should override whatever registries are specified in `extraInitContainers`.