### PR TITLE
[grafana] allow sc-alerts as init container

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,8 @@
 /charts/promtail/ @grafana/loki-squad @unguiculus @Whyeasy
 /charts/tempo/ @grafana/tempo @dgzlopes @swartz-k @BitProcessor @faustodavid
 /charts/tempo-distributed/ @grafana/tempo @mapno @swartz-k @BitProcessor @faustodavid
-/charts/enterprise-metrics/ @grafana/mimir-maintainers 
+/charts/enterprise-metrics/ @grafana/mimir-maintainers
+/charts/rollout-operator/ @grafana/mimir-maintainers
 /charts/enterprise-logs/ @grafana/loki-squad
 /charts/tempo-vulture/ @grafana/tempo @Whyeasy @dgzlopes
 /charts/synthetic-monitoring-agent/ @torstenwalter @zanhsieh

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 7.0.2
+version: 7.1.0
 appVersion: 10.1.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -206,7 +206,7 @@ need to instead set `global.imageRegistry`.
 | `sidecar.datasources.resource`            | Should the sidecar looks into secrets, configmaps or both. | `both`                               |
 | `sidecar.datasources.reloadURL`           | Full url of datasource configuration reload API endpoint, to invoke after a config-map change | `"http://localhost:3000/api/admin/provisioning/datasources/reload"` |
 | `sidecar.datasources.skipReload`          | Enabling this omits defining the REQ_URL and REQ_METHOD environment variables | `false` |
-| `sidecar.datasources.initDatasources`     | Set to true to deploy the datasource sidecar as an initContainer in addition to a container. This is needed if skipReload is true, to load any datasources defined at startup time. | `false` |
+| `sidecar.datasources.initAlerts`     | Set to true to deploy the datasource sidecar as an initContaine. This is needed if skipReload is true, to load any datasources defined at startup time. | `false` |
 | `sidecar.notifiers.enabled`               | Enables the cluster wide search for notifiers and adds/updates/deletes them in grafana | `false`        |
 | `sidecar.notifiers.label`                 | Label that config maps with notifiers should have to be added | `grafana_notifier`                               |
 | `sidecar.notifiers.labelValue`            | Label value that config maps with notifiers should have to be added | `""`                                |

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -206,7 +206,7 @@ need to instead set `global.imageRegistry`.
 | `sidecar.datasources.resource`            | Should the sidecar looks into secrets, configmaps or both. | `both`                               |
 | `sidecar.datasources.reloadURL`           | Full url of datasource configuration reload API endpoint, to invoke after a config-map change | `"http://localhost:3000/api/admin/provisioning/datasources/reload"` |
 | `sidecar.datasources.skipReload`          | Enabling this omits defining the REQ_URL and REQ_METHOD environment variables | `false` |
-| `sidecar.datasources.initAlerts`     | Set to true to deploy the datasource sidecar as an initContaine. This is needed if skipReload is true, to load any datasources defined at startup time. | `false` |
+| `sidecar.datasources.initAlerts` | Set to true to deploy the datasource sidecar as an initContainer. This is needed if skipReload is true, to load any datasources defined at startup time. | `false` |
 | `sidecar.notifiers.enabled`               | Enables the cluster wide search for notifiers and adds/updates/deletes them in grafana | `false`        |
 | `sidecar.notifiers.label`                 | Label that config maps with notifiers should have to be added | `grafana_notifier`                               |
 | `sidecar.notifiers.labelValue`            | Label value that config maps with notifiers should have to be added | `""`                                |

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -295,19 +295,8 @@ initContainers:
       - name: sc-notifiers-volume
         mountPath: "/etc/grafana/provisioning/notifiers"
 {{- end}}
-{{- if .Values.extraInitContainers }}
-{{- range $eic := .Values.extraInitContainers }}
-  - name: {{ $eic.name }}
-    {{- $registry := $.Values.global.imageRegistry | default $eic.image.registry -}}
-    {{- if $eic.image.sha }}
-    image: "{{ $registry }}/{{ $eic.image.repository }}:{{ $eic.image.tag }}@sha256:{{ $eic.image.sha }}"
-    {{- else }}
-    image: "{{ $registry }}/{{ $eic.image.repository }}:{{ $eic.image.tag }}"
-    {{- end }}
-    imagePullPolicy: {{ $eic.image.pullPolicy }}
-    volumeMounts:
-{{ toYaml $eic.volumeMounts | indent 6 }}
-{{- end }}
+{{- with .Values.extraInitContainers }}
+  {{- tpl (toYaml .) $root | nindent 2 }}
 {{- end }}
 {{- if or .Values.image.pullSecrets .Values.global.imagePullSecrets }}
 imagePullSecrets:

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -17,7 +17,7 @@ hostAliases:
 {{- with .Values.priorityClassName }}
 priorityClassName: {{ . }}
 {{- end }}
-{{- if ( or .Values.persistence.enabled .Values.dashboards .Values.extraInitContainers (and .Values.sidecar.datasources.enabled .Values.sidecar.datasources.initDatasources) (and .Values.sidecar.notifiers.enabled .Values.sidecar.notifiers.initNotifiers)) }}
+{{- if ( or .Values.persistence.enabled .Values.dashboards .Values.extraInitContainers (and .Values.sidecar.alerts.enabled .Values.sidecar.alerts.initAlerts) (and .Values.sidecar.datasources.enabled .Values.sidecar.datasources.initDatasources) (and .Values.sidecar.notifiers.enabled .Values.sidecar.notifiers.initNotifiers)) }}
 initContainers:
 {{- end }}
 {{- if ( and .Values.persistence.enabled .Values.initChownData.enabled ) }}
@@ -97,6 +97,79 @@ initContainers:
         mountPath: {{ .mountPath }}
         readOnly: {{ .readOnly }}
       {{- end }}
+{{- end }}
+{{- if and .Values.sidecar.alerts.enabled .Values.sidecar.alerts.initAlerts }}
+  - name: {{ include "grafana.name" . }}-sc-alerts
+    {{- $registry := .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
+    {{- if .Values.sidecar.image.sha }}
+    image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
+    {{- else }}
+    image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}"
+    {{- end }}
+    imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+    env:
+      {{- range $key, $value := .Values.sidecar.alerts.env }}
+      - name: "{{ $key }}"
+        value: "{{ $value }}"
+      {{- end }}
+      {{- if .Values.sidecar.alerts.ignoreAlreadyProcessed }}
+      - name: IGNORE_ALREADY_PROCESSED
+        value: "true"
+      {{- end }}
+      - name: METHOD
+        value: {{ .Values.sidecar.alerts.watchMethod }}
+      - name: LABEL
+        value: "{{ .Values.sidecar.alerts.label }}"
+      {{- with .Values.sidecar.alerts.labelValue }}
+      - name: LABEL_VALUE
+        value: {{ quote . }}
+      {{- end }}
+      {{- if or .Values.sidecar.logLevel .Values.sidecar.alerts.logLevel }}
+      - name: LOG_LEVEL
+        value: {{ default .Values.sidecar.logLevel .Values.sidecar.alerts.logLevel }}
+      {{- end }}
+      - name: FOLDER
+        value: "/etc/grafana/provisioning/alerting"
+      - name: RESOURCE
+        value: {{ quote .Values.sidecar.alerts.resource }}
+      {{- with .Values.sidecar.enableUniqueFilenames }}
+      - name: UNIQUE_FILENAMES
+        value: "{{ . }}"
+      {{- end }}
+      {{- with .Values.sidecar.alerts.searchNamespace }}
+      - name: NAMESPACE
+        value: {{ . | join "," | quote }}
+      {{- end }}
+      {{- with .Values.sidecar.alerts.skipTlsVerify }}
+      - name: SKIP_TLS_VERIFY
+        value: {{ quote . }}
+      {{- end }}
+      {{- with .Values.sidecar.alerts.script }}
+      - name: SCRIPT
+        value: {{ quote . }}
+      {{- end }}
+    {{- with .Values.sidecar.livenessProbe }}
+    livenessProbe:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.readinessProbe }}
+    readinessProbe:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.securityContext }}
+    securityContext:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    volumeMounts:
+      - name: sc-alerts-volume
+        mountPath: "/etc/grafana/provisioning/alerting"
+      {{- with .Values.sidecar.alerts.extraMounts }}
+      {{- toYaml . | trim | nindent 6 }}
+      {{- end }}        
 {{- end }}
 {{- if and .Values.sidecar.datasources.enabled .Values.sidecar.datasources.initDatasources }}
   - name: {{ include "grafana.name" . }}-init-sc-datasources
@@ -244,7 +317,7 @@ imagePullSecrets:
 enableServiceLinks: {{ .Values.enableServiceLinks }}
 {{- end }}
 containers:
-{{- if .Values.sidecar.alerts.enabled }}
+{{- if and .Values.sidecar.alerts.enabled (not .Values.sidecar.alerts.initAlerts) }}
   - name: {{ include "grafana.name" . }}-sc-alerts
     {{- $registry := .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
     {{- if .Values.sidecar.image.sha }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -811,7 +811,7 @@ sidecar:
     # -- The Docker registry
     registry: quay.io
     repository: kiwigrid/k8s-sidecar
-    tag: 1.25.1
+    tag: 1.25.2
     sha: ""
   imagePullPolicy: IfNotPresent
   resources: {}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -871,7 +871,7 @@ sidecar:
     script: null
     skipReload: false
     # This is needed if skipReload is true, to load any alerts defined at startup time.
-    # Deploy the alert sidecar as an initContainer in addition to a container.
+    # Deploy the alert sidecar as an initContainer.
     initAlerts: false
     # Additional alert sidecar volume mounts
     extraMounts: []

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -870,7 +870,9 @@ sidecar:
     # Absolute path to shell script to execute after a alert got reloaded
     script: null
     skipReload: false
+    # This is needed if skipReload is true, to load any alerts defined at startup time.
     # Deploy the alert sidecar as an initContainer in addition to a container.
+    initAlerts: false
     # Additional alert sidecar volume mounts
     extraMounts: []
     # Sets the size limit of the alert sidecar emptyDir volume

--- a/charts/rollout-operator/Chart.yaml
+++ b/charts/rollout-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-operator
 description: "Grafana rollout-operator"
 type: application
-version: 0.9.1
-appVersion: v0.8.1
+version: 0.9.2
+appVersion: v0.8.3
 home: https://github.com/grafana/rollout-operator
 kubeVersion: ^1.10.0-0

--- a/charts/rollout-operator/README.md
+++ b/charts/rollout-operator/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana rollout-operator](https://github.com/grafana/r
 
 # rollout-operator
 
-![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.8.1](https://img.shields.io/badge/AppVersion-v0.8.1-informational?style=flat-square)
+![Version: 0.9.2](https://img.shields.io/badge/Version-0.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.8.3](https://img.shields.io/badge/AppVersion-v0.8.3-informational?style=flat-square)
 
 Grafana rollout-operator
 


### PR DESCRIPTION
Sidecar for datasources and notifiers are available, but not for alerts.  As values.yaml in line 873 suggested, the idea is to have it as init container as well.

This PR enables the possibility to use sidecar-alerts as init-container too.

Why do we want this as init-container? To get alerts loaded, when using Grafana in anonymous mode. For datasources we have a solution, but not for alerts.

Some kind of related (but this PR don't fix it): https://github.com/grafana/helm-charts/issues/981