### PR TITLE
[grafana]: allow alerts sidecar as init container

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 7.0.3
+version: 7.0.4
 appVersion: 10.1.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -174,7 +174,7 @@ need to instead set `global.imageRegistry`.
 | `sidecar.alerts.resource`            | Should the sidecar looks into secrets, configmaps or both. | `both`                               |
 | `sidecar.alerts.reloadURL`           | Full url of datasource configuration reload API endpoint, to invoke after a config-map change | `"http://localhost:3000/api/admin/provisioning/alerting/reload"` |
 | `sidecar.alerts.skipReload`          | Enabling this omits defining the REQ_URL and REQ_METHOD environment variables | `false` |
-| `sidecar.alerts.initDatasources`     | Set to true to deploy the datasource sidecar as an initContainer in addition to a container. This is needed if skipReload is true, to load any alerts defined at startup time. | `false` |
+| `sidecar.alerts.initAlers` | Set to true to deploy the alerts sidecar as an initContainer. This is needed if skipReload is true, to load any alerts defined at startup time. | `false` |
 | `sidecar.alerts.extraMounts`         | Additional alerts sidecar volume mounts. | `[]`                               |
 | `sidecar.dashboards.enabled`              | Enables the cluster wide search for dashboards and adds/updates/deletes them in grafana | `false`       |
 | `sidecar.dashboards.SCProvider`           | Enables creation of sidecar provider          | `true`                                                  |

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -870,7 +870,9 @@ sidecar:
     # Absolute path to shell script to execute after a alert got reloaded
     script: null
     skipReload: false
-    # Deploy the alert sidecar as an initContainer in addition to a container.
+    # This is needed if skipReload is true, to load any alerts defined at startup time.
+    # Deploy the alert sidecar as an initContainer.
+    initAlerts: false
     # Additional alert sidecar volume mounts
     extraMounts: []
     # Sets the size limit of the alert sidecar emptyDir volume


### PR DESCRIPTION
Sidecar for datasources and notifiers are available, but not for alerts. As values.yaml in line 873 suggested, the idea is to have it as init container as well.

This PR enables the possibility to use sidecar-alerts as init-container too.

Why do we want this as init-container? To get alerts loaded, when using Grafana in anonymous mode. For datasources we have a solution, but not for alerts.

Some kind of related (but this PR don't fix it): https://github.com/grafana/helm-charts/issues/981

This PR was created, but I endet up in git rebase hell, so this is successor of https://github.com/grafana/helm-charts/pull/2761