### PR TITLE
[loki-distributed] config: expose "auth_enabled" and extra properties for "common"

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.9.2
-version: 0.76.1
+version: 0.76.2
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.76.1](https://img.shields.io/badge/Version-0.76.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.2](https://img.shields.io/badge/AppVersion-2.9.2-informational?style=flat-square)
+![Version: 0.76.2](https://img.shields.io/badge/Version-0.76.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.2](https://img.shields.io/badge/AppVersion-2.9.2-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -328,6 +328,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | loki.configAsSecret | bool | `false` | Store the loki configuration as a secret. |
 | loki.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The SecurityContext for Loki containers |
 | loki.existingSecretForConfig | string | `""` | Specify an existing secret containing loki configuration. If non-empty, overrides `loki.config` |
+| loki.extraCommonConfig | string | `""` | Allows appending custom YAML configuration to the "common" Loki block |
 | loki.image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | loki.image.registry | string | `"docker.io"` | The Docker registry |
 | loki.image.repository | string | `"grafana/loki"` | Docker image repository |

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -322,6 +322,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | ingress.paths.ruler[3] | string | `"/prometheus/api/v1/alerts"` |  |
 | loki.annotations | object | `{}` | If set, these annotations are added to all of the Kubernetes controllers (Deployments, StatefulSets, etc) that this chart launches. Use this to implement something like the "Wave" controller or another controller that is monitoring top level deployment resources. |
 | loki.appProtocol | string | `""` | Adds the appProtocol field to the memberlist service. This allows memberlist to work with istio protocol selection. Ex: "http" or "tcp" |
+| loki.authEnabled | bool | `false` | Enables authentication through the X-Scope-OrgID header, which must be present if true. If false, the OrgID will always be set to 'fake'. |
 | loki.command | string | `nil` | Common command override for all pods (except gateway) |
 | loki.config | string | See values.yaml | Config file contents for Loki |
 | loki.configAsSecret | bool | `false` | Store the loki configuration as a secret. |

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -87,10 +87,12 @@ loki:
   server:
     # -- HTTP server listen port
     http_listen_port: 3100
+  # -- Enables authentication through the X-Scope-OrgID header, which must be present if true. If false, the OrgID will always be set to 'fake'.
+  authEnabled: false
   # -- Config file contents for Loki
   # @default -- See values.yaml
   config: |
-    auth_enabled: false
+    auth_enabled: {{ .Values.loki.authEnabled }}
 
     server:
       {{- toYaml .Values.loki.server | nindent 6 }}

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -89,6 +89,8 @@ loki:
     http_listen_port: 3100
   # -- Enables authentication through the X-Scope-OrgID header, which must be present if true. If false, the OrgID will always be set to 'fake'.
   authEnabled: false
+  # -- Allows appending custom YAML configuration to the "common" Loki block
+  extraCommonConfig: ""
   # -- Config file contents for Loki
   # @default -- See values.yaml
   config: |
@@ -99,6 +101,9 @@ loki:
 
     common:
       compactor_address: http://{{ include "loki.compactorFullname" . }}:3100
+    {{- with .Values.loki.extraCommonConfig }}
+    {{ . | nindent 2 }}
+    {{- end }}
 
     distributor:
       ring:


### PR DESCRIPTION
As we're testing migration from the [loki](https://github.com/grafana/helm-charts/tree/main/charts/loki) chart to loki-distributed, we found that we were missing a couple of properties. This PR introduces support for toggling whether `auth_enabled` is enabled or not. In addition it lets us plug in extra configuration to the `common` block of the configuration file.

I'm open to relocating these properties to other sections of the values structure if it makes more sense or if they need to be renamed.