### PR TITLE
[grafana] Docs: improve clarity of alert provisioning docs

### DIFF
--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -630,11 +630,12 @@ alerting:
 
 The two possibilities for static alerting resource provisioning are:
 
-* Inlining the file contents as described in the example `values.yaml` and the official [Grafana documentation](https://grafana.com/docs/grafana/next/alerting/set-up/provision-alerting-resources/file-provisioning/).
-* Importing a file using a relative path starting from the chart root directory.
+* Inlining the file contents as shown for contact points in the above example.
+* Importing a file using a relative path starting from the chart root directory as shown for the alert rules in the above example.
 
 ### Important notes on file provisioning
 
+* The format of the files is defined in the [Grafana documentation](https://grafana.com/docs/grafana/next/alerting/set-up/provision-alerting-resources/file-provisioning/) on file provisioning.
 * The chart supports importing YAML and JSON files.
 * The filename must be unique, otherwise one volume mount will overwrite the other.
 * In case of inlining, double curly braces that arise from the Grafana configuration format and are not intended as templates for the chart must be escaped.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -594,9 +594,11 @@ data:
         uid: 16624780-6564-45dc-825c-8bded4ad92d3
 ```
 
-## Provision alert rules, contact points, notification policies and notification templates
+## Statically provision alerting resources
+If you don't need to change alerting resources (alert rules, contact points, notification policies and notification templates) regularly you could use the `alerting` config option instead of the sidecar option above.
+This will grab the alerting config and apply it statically at build time for the helm file.
 
-There are two methods to provision alerting configuration in Grafana. Below are some examples and explanations as to how to use each method:
+There are two methods to statically provision alerting configuration in Grafana. Below are some examples and explanations as to how to use each method:
 
 ```yaml
 alerting:
@@ -626,7 +628,7 @@ alerting:
               title: '{{ `{{ template "default.title" . }}` }}'
 ```
 
-There are two possibilities:
+The two possibilities for static alerting resource provisioning are:
 
 * Inlining the file contents as described in the example `values.yaml` and the official [Grafana documentation](https://grafana.com/docs/grafana/next/alerting/set-up/provision-alerting-resources/file-provisioning/).
 * Importing a file using a relative path starting from the chart root directory.


### PR DESCRIPTION
There was some confusion around how alerts are provisioned for the Grafana helm chart in https://github.com/grafana/helm-charts/issues/1992. There are two methods for doing provisioned alerts:
 - `alerting` config (https://github.com/grafana/helm-charts/pull/1720), this is statically provisioned at point of helm build
 - `sidecar.alerts` (https://github.com/grafana/helm-charts/pull/1847), this allows for dynamically provisioning alert by using a sidecar which will load alerts into the folder structure based on configmaps in the cluster

This setup seems to be similar to how dashboards are available.

Given the above, I figured it would make sense to make the documentation a bit clearer on these two options, so people can choose the option that will work for them. With that in mind I have introduced some documentation about the alerting sidecar and slightly edited the static provisioning so it is a bit clearer.

Super happy to change any wording which you don't think aids clarity! 