### PR TITLE
chore: set unique cluster label for each release

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.9.2
-version: 0.76.1
+version: 0.76.2
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -104,6 +104,7 @@ loki:
           store: memberlist
 
     memberlist:
+      cluster_label: "{{ .Release.Name }}.{{ .Release.Namespace }}"
       join_members:
         - {{ include "loki.fullname" . }}-memberlist
 

--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.7.1
+version: 1.7.2
 appVersion: 2.3.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -970,6 +970,7 @@ traces:
 # -- Memberlist configuration. Please refer to https://grafana.com/docs/tempo/latest/configuration/#memberlist
 memberlist:
   node_name: ""
+  cluster_label: "{{ .Release.Name }}.{{ .Release.Namespace }}"
   randomize_node_name: true
   stream_timeout: "10s"
   retransmit_factor: 2

--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 1.7.1
+version: 1.7.2
 appVersion: 2.3.0
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -119,6 +119,8 @@ tempo:
 # -- Tempo configuration file contents
 # @default -- Dynamically generated tempo configmap
 config: |
+    memberlist:
+      cluster_label: "{{ .Release.Name }}.{{ .Release.Namespace }}"
     multitenancy_enabled: {{ .Values.tempo.multitenancyEnabled }}
     usage_report:
       reporting_enabled: {{ .Values.tempo.reportingEnabled }}


### PR DESCRIPTION
Addressing [this issue](https://github.com/grafana/tempo/issues/2766) where Loki/Tempo ingesters can join each other's ring because `cluster_label` seems to be defaulted to something common to both components. This change should mitigate the issue in the future.