### PR TITLE
Remove the deprecated minio chart from the call-update-helm-repo GH action

### DIFF
--- a/.github/workflows/update-helm-repo.yaml
+++ b/.github/workflows/update-helm-repo.yaml
@@ -154,7 +154,6 @@ jobs:
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add bitnami-pre-2022 https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
           helm repo add hashicorp https://helm.releases.hashicorp.com
-          helm repo add minio https://helm.min.io
           helm repo add minio-new https://charts.min.io
           helm repo add jetstack https://charts.jetstack.io
           helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx


### PR DESCRIPTION
The old min.io helm is no longer available. This is blocking Loki Helm chart releases: see https://github.com/grafana/loki/actions/runs/7059033470/job/19281713160 for an example.