### PR TITLE
[grafana] Allow setting dns config for pod template

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 7.0.14
+version: 7.0.15
 appVersion: 10.2.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -14,6 +14,13 @@ securityContext:
 hostAliases:
   {{- toYaml . | nindent 2 }}
 {{- end }}
+{{- if .Values.dnsPolicy }}
+dnsPolicy: {{ .Values.dnsPolicy }}
+{{- end }}
+{{- with .Values.dnsConfig }}
+dnsConfig:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- with .Values.priorityClassName }}
 priorityClassName: {{ . }}
 {{- end }}
@@ -169,7 +176,7 @@ initContainers:
         mountPath: "/etc/grafana/provisioning/alerting"
       {{- with .Values.sidecar.alerts.extraMounts }}
       {{- toYaml . | trim | nindent 6 }}
-      {{- end }}        
+      {{- end }}
 {{- end }}
 {{- if and .Values.sidecar.datasources.enabled .Values.sidecar.datasources.initDatasources }}
   - name: {{ include "grafana.name" . }}-init-sc-datasources
@@ -411,7 +418,7 @@ containers:
         mountPath: "/etc/grafana/provisioning/alerting"
       {{- with .Values.sidecar.alerts.extraMounts }}
       {{- toYaml . | trim | nindent 6 }}
-      {{- end }}        
+      {{- end }}
 {{- end}}
 {{- if .Values.sidecar.dashboards.enabled }}
   - name: {{ include "grafana.name" . }}-sc-dashboard

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -116,6 +116,16 @@ testFramework:
   imagePullPolicy: IfNotPresent
   securityContext: {}
 
+# dns configuration for pod
+dnsPolicy: ~
+dnsConfig: {}
+  # nameservers:
+  #   - 8.8.8.8
+  #   options:
+  #   - name: ndots
+  #     value: "2"
+  #   - name: edns0
+
 securityContext:
   runAsNonRoot: true
   runAsUser: 472


### PR DESCRIPTION
This PR adds setting the [DNS policy and config](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) for the pod template.

Since the image is based on alpine, certain clusters continue to have issues with dns resolution due to `ndots: 5`. Allowing this to be set to `ndots: 1` usually fixes the issue.

Ref: #2826 