### PR TITLE
[loki-distributed] bump loki version to 2.9.3

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
-appVersion: 2.9.2
-version: 0.77.0
+appVersion: 2.9.3
+version: 0.77.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki


### PR DESCRIPTION
Looks like bug/CVE fixes: https://github.com/grafana/loki/releases/tag/v2.9.3