### PR TITLE
[tempo-vulture] bump tempo version to 2.3.1

### DIFF
--- a/charts/tempo-vulture/Chart.yaml
+++ b/charts/tempo-vulture/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tempo-vulture
 description: Grafana Tempo Vulture - A tool to monitor Tempo performance.
 type: application
-version: 0.4.1
-appVersion: 2.2.3
+version: 0.5.0
+appVersion: 2.3.1
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/
 icon: https://raw.githubusercontent.com/grafana/tempo/master/docs/tempo/website/logo_and_name.png

--- a/charts/tempo-vulture/README.md
+++ b/charts/tempo-vulture/README.md
@@ -1,6 +1,6 @@
 # tempo-vulture
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.3](https://img.shields.io/badge/AppVersion-2.2.3-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.1](https://img.shields.io/badge/AppVersion-2.3.1-informational?style=flat-square)
 
 Grafana Tempo Vulture - A tool to monitor Tempo performance.
 


### PR DESCRIPTION
There are breaking changes: https://github.com/grafana/tempo/releases/tag/v2.3.0
bug fixes: https://github.com/grafana/tempo/releases/tag/v2.3.1

Even with the breaking changes I don't believe the values are being used in the existing helm chart. It appears `distributor.log_received_traces` wasn't configurable to begin with. 