### PR TITLE
[loki-distributed] Allow maxUnavailable to be set as 0

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.9.2
-version: 0.78.1
+version: 0.78.2
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.9.2
-version: 0.78.0
+version: 0.78.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.78.0](https://img.shields.io/badge/Version-0.78.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.2](https://img.shields.io/badge/AppVersion-2.9.2-informational?style=flat-square)
+![Version: 0.78.1](https://img.shields.io/badge/Version-0.78.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.2](https://img.shields.io/badge/AppVersion-2.9.2-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.78.1](https://img.shields.io/badge/Version-0.78.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.2](https://img.shields.io/badge/AppVersion-2.9.2-informational?style=flat-square)
+![Version: 0.78.2](https://img.shields.io/badge/Version-0.78.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.2](https://img.shields.io/badge/AppVersion-2.9.2-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
+++ b/charts/loki-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
@@ -1,5 +1,5 @@
 {{- if gt (int .Values.distributor.replicas) 1 }}
-{{- if not .Values.distributor.maxUnavailable }}
+{{- if kindIs "invalid" .Values.distributor.maxUnavailable }}
 {{- fail "`.Values.distributor.maxUnavailable` must be set when `.Values.distributor.replicas` is greater than 1." }}
 {{- else }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}

--- a/charts/loki-distributed/templates/gateway/poddisruptionbudget-gateway.yaml
+++ b/charts/loki-distributed/templates/gateway/poddisruptionbudget-gateway.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.gateway.enabled (gt (int .Values.gateway.replicas) 1) }}
-{{- if not .Values.gateway.maxUnavailable }}
+{{- if kindIs "invalid" .Values.gateway.maxUnavailable }}
 {{- fail "`.Values.gateway.maxUnavailable` must be set when `.Values.gateway.replicas` is greater than 1." }}
 {{- else }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}

--- a/charts/loki-distributed/templates/index-gateway/poddisruptionbudget-index-gateway.yaml
+++ b/charts/loki-distributed/templates/index-gateway/poddisruptionbudget-index-gateway.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.indexGateway.enabled (gt (int .Values.indexGateway.replicas) 1) }}
-{{- if not .Values.indexGateway.maxUnavailable }}
+{{- if kindIs "invalid" .Values.indexGateway.maxUnavailable }}
 {{- fail "`.Values.indexGateway.maxUnavailable` must be set when `.Values.indexGateway.replicas` is greater than 1." }}
 {{- else }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}

--- a/charts/loki-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
@@ -1,5 +1,5 @@
 {{- if gt (int .Values.ingester.replicas) 1 }}
-{{- if not .Values.ingester.maxUnavailable }}
+{{- if kindIs "invalid" .Values.ingester.maxUnavailable }}
 {{- fail "`.Values.ingester.maxUnavailable` must be set when `.Values.ingester.replicas` is greater than 1." }}
 {{- else }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}

--- a/charts/loki-distributed/templates/memcached-chunks/poddisruptionbudget-memcached-chunks.yaml
+++ b/charts/loki-distributed/templates/memcached-chunks/poddisruptionbudget-memcached-chunks.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.memcachedChunks.enabled (gt (int .Values.memcachedChunks.replicas) 1) }}
-{{- if not .Values.memcachedChunks.maxUnavailable }}
+{{- if kindIs "invalid" .Values.memcachedChunks.maxUnavailable }}
 {{- fail "`.Values.memcachedChunks.maxUnavailable` must be set when `.Values.memcachedChunks.replicas` is greater than 1." }}
 {{- else }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}

--- a/charts/loki-distributed/templates/memcached-frontend/poddisruptionbudget-memcached-frontend.yaml
+++ b/charts/loki-distributed/templates/memcached-frontend/poddisruptionbudget-memcached-frontend.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.memcachedFrontend.enabled (gt (int .Values.memcachedFrontend.replicas) 1) }}
-{{- if not .Values.memcachedFrontend.maxUnavailable }}
+{{- if kindIs "invalid" .Values.memcachedFrontend.maxUnavailable }}
 {{- fail "`.Values.memcachedFrontend.maxUnavailable` must be set when `.Values.memcachedFrontend.replicas` is greater than 1." }}
 {{- else }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}

--- a/charts/loki-distributed/templates/memcached-index-queries/poddisruptionbudget-memcached-index-queries.yaml
+++ b/charts/loki-distributed/templates/memcached-index-queries/poddisruptionbudget-memcached-index-queries.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.memcachedIndexQueries.enabled (gt (int .Values.memcachedIndexQueries.replicas) 1) }}
-{{- if not .Values.memcachedIndexQueries.maxUnavailable }}
+{{- if kindIs "invalid" .Values.memcachedIndexQueries.maxUnavailable }}
 {{- fail "`.Values.memcachedIndexQueries.maxUnavailable` must be set when `.Values.memcachedIndexQueries.replicas` is greater than 1." }}
 {{- else }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}

--- a/charts/loki-distributed/templates/memcached-index-writes/poddisruptionbudget-memcached-index-writes.yaml
+++ b/charts/loki-distributed/templates/memcached-index-writes/poddisruptionbudget-memcached-index-writes.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.memcachedIndexWrites.enabled (gt (int .Values.memcachedIndexWrites.replicas) 1) }}
-{{- if not .Values.memcachedIndexWrites.maxUnavailable }}
+{{- if kindIs "invalid" .Values.memcachedIndexWrites.maxUnavailable }}
 {{- fail "`.Values.memcachedIndexWrites.maxUnavailable` must be set when `.Values.memcachedIndexWrites.replicas` is greater than 1." }}
 {{- else }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}

--- a/charts/loki-distributed/templates/querier/poddisruptionbudget-querier.yaml
+++ b/charts/loki-distributed/templates/querier/poddisruptionbudget-querier.yaml
@@ -1,5 +1,5 @@
 {{- if gt (int .Values.querier.replicas) 1 }}
-{{- if not .Values.querier.maxUnavailable }}
+{{- if kindIs "invalid" .Values.querier.maxUnavailable }}
 {{- fail "`.Values.querier.maxUnavailable` must be set when `.Values.querier.replicas` is greater than 1." }}
 {{- else }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}

--- a/charts/loki-distributed/templates/query-frontend/poddisruptionbudget-query-frontent.yaml
+++ b/charts/loki-distributed/templates/query-frontend/poddisruptionbudget-query-frontent.yaml
@@ -1,5 +1,5 @@
 {{- if gt (int .Values.queryFrontend.replicas) 1 }}
-{{- if not .Values.queryFrontend.maxUnavailable }}
+{{- if kindIs "invalid" .Values.queryFrontend.maxUnavailable }}
 {{- fail "`.Values.queryFrontend.maxUnavailable` must be set when `.Values.queryFrontend.replicas` is greater than 1." }}
 {{- else }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}

--- a/charts/loki-distributed/templates/query-scheduler/poddisruptionbudget-query-scheduler.yaml
+++ b/charts/loki-distributed/templates/query-scheduler/poddisruptionbudget-query-scheduler.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.queryScheduler.enabled (gt (int .Values.queryScheduler.replicas) 1) }}
-{{- if not .Values.queryScheduler.maxUnavailable }}
+{{- if kindIs "invalid" .Values.queryScheduler.maxUnavailable }}
 {{- fail "`.Values.queryScheduler.maxUnavailable` must be set when `.Values.queryScheduler.replicas` is greater than 1." }}
 {{- else }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}

--- a/charts/loki-distributed/templates/ruler/poddisruptionbudget-ruler.yaml
+++ b/charts/loki-distributed/templates/ruler/poddisruptionbudget-ruler.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.ruler.enabled (gt (int .Values.ruler.replicas) 1) }}
-{{- if not .Values.ruler.maxUnavailable }}
+{{- if kindIs "invalid" .Values.ruler.maxUnavailable }}
 {{- fail "`.Values.ruler.maxUnavailable` must be set when `.Values.ruler.replicas` is greater than 1." }}
 {{- else }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}


### PR DESCRIPTION
Fixes: #2848

Whenever the PDB maxUnavailable is set to 0, the following condition fails (i.e. for indexGateway):
```
{{- if not .Values.indexGateway.maxUnavailable }}
```

---

To fix it, I used [one of the solutions](https://github.com/helm/helm/issues/3164#issuecomment-709537506) given by the helm issue that seems to be backwards compatible.

Note: I believe this issue might be happening in more implementations of this chart or other charts.