### PR TITLE
[loki-distributed] add extraObjects to loki-distributed helm chart

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.9.2
-version: 0.77.0
+version: 0.78.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -154,6 +154,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | distributor.serviceLabels | object | `{}` | Labels for distributor service |
 | distributor.terminationGracePeriodSeconds | int | `30` | Grace period to allow the distributor to shutdown before it is killed |
 | distributor.tolerations | list | `[]` | Tolerations for distributor pods |
+| extraOjbects | list | `[]` | Create extra manifests via values. |
 | fullnameOverride | string | `nil` | Overrides the chart's computed fullname |
 | gateway.affinity | string | Hard node and soft zone anti-affinity | Affinity for gateway pods. Passed through `tpl` and, thus, to be configured as string |
 | gateway.autoscaling.behavior.enabled | bool | `false` | Enable autoscaling behaviours |

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -154,7 +154,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | distributor.serviceLabels | object | `{}` | Labels for distributor service |
 | distributor.terminationGracePeriodSeconds | int | `30` | Grace period to allow the distributor to shutdown before it is killed |
 | distributor.tolerations | list | `[]` | Tolerations for distributor pods |
-| extraOjbects | list | `[]` | Create extra manifests via values. |
+| extraObjects | list | `[]` |  |
 | fullnameOverride | string | `nil` | Overrides the chart's computed fullname |
 | gateway.affinity | string | Hard node and soft zone anti-affinity | Affinity for gateway pods. Passed through `tpl` and, thus, to be configured as string |
 | gateway.autoscaling.behavior.enabled | bool | `false` | Enable autoscaling behaviours |

--- a/charts/loki-distributed/templates/extra-manifests.yaml
+++ b/charts/loki-distributed/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -2029,3 +2029,13 @@ networkPolicy:
     podSelector: {}
     # -- Specifies the namespace the discovery Pods are running in
     namespaceSelector: {}
+
+# Create a dynamic manifests via values:
+extraObjects: []
+  # - apiVersion: objectbucket.io/v1alpha1
+  #   kind: ObjectBucketClaim
+  #   metadata:
+  #     name: loki-storage
+  #   spec:
+  #     generateBucketName: loki-storage
+  #     storageClassName: rook-ceph-rgw-bucket


### PR DESCRIPTION
Add extraObjects section to loki-distributed helm chart in line with other charts (e.g. grafana, tempo-distributed)