### PR TITLE
[loki-distributed] Fix compactor statefulset

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.9.2
-version: 0.78.0
+version: 0.78.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/templates/compactor/statefulset-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/statefulset-compactor.yaml
@@ -82,6 +82,7 @@ spec:
           args:
             - -config.file=/etc/loki/config/config.yaml
             - -target=compactor
+            - -boltdb.shipper.compactor.working-directory=/var/loki/compactor
             {{- with .Values.compactor.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
Adds missing argument `- -boltdb.shipper.compactor.working-directory=/var/loki/compactor` to the new statefulset manifest for Loki Compactor to fix the directory not found error which resulted in the pod going into `CrashLoopBackoff`