### PR TITLE
[grafana] feat: fail when users store secrets in plaintext

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 7.0.19
+version: 7.1.0
 appVersion: 10.2.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_config.tpl
+++ b/charts/grafana/templates/_config.tpl
@@ -2,6 +2,7 @@
  Generate config map data
  */}}
 {{- define "grafana.configData" -}}
+{{ include "grafana.assertNoLeakedSecrets" . }}
 {{- $files := .Files }}
 {{- $root := . -}}
 {{- with .Values.plugins }}

--- a/charts/grafana/templates/_helpers.tpl
+++ b/charts/grafana/templates/_helpers.tpl
@@ -225,3 +225,52 @@ Formats imagePullSecrets. Input is (dict "root" . "imagePullSecrets" .{specific 
 {{- end }}
 {{- $secretFound}}
 {{- end -}}
+
+{{/*
+    Checks whether the user is attempting to store secrets in plaintext
+    in the grafana.ini configmap
+*/}}
+{{/* grafana.assertNoLeakedSecrets checks for sensitive keys in values */}}
+{{- define "grafana.assertNoLeakedSecrets" -}}
+      {{- $sensitiveKeysYaml := `
+sensitiveKeys:
+- path: ["database", "password"]
+- path: ["smtp", "password"]
+- path: ["security", "secret_key"]
+- path: ["security", "admin_password"]
+- path: ["auth.basic", "password"]
+- path: ["auth.ldap", "bind_password"]
+- path: ["auth.google", "client_secret"]
+- path: ["auth.github", "client_secret"]
+- path: ["auth.gitlab", "client_secret"]
+- path: ["auth.generic_oauth", "client_secret"]
+- path: ["auth.okta", "client_secret"]
+- path: ["auth.azuread", "client_secret"]
+- path: ["auth.grafana_com", "client_secret"]
+- path: ["auth.grafananet", "client_secret"]
+- path: ["azure", "user_identity_client_secret"]
+- path: ["unified_alerting", "ha_redis_password"]
+- path: ["metrics", "basic_auth_password"]
+- path: ["external_image_storage.s3", "secret_key"]
+- path: ["external_image_storage.webdav", "password"]
+- path: ["external_image_storage.azure_blob", "account_key"]
+` | fromYaml -}}
+  {{- if $.Values.assertNoLeakedSecrets -}}
+      {{- $grafanaIni := index .Values "grafana.ini" -}}
+      {{- range $_, $secret := $sensitiveKeysYaml.sensitiveKeys -}}
+        {{- $currentMap := $grafanaIni -}}
+        {{- $shouldContinue := true -}}
+        {{- range $index, $elem := $secret.path -}}
+          {{- if and $shouldContinue (hasKey $currentMap $elem) -}}
+            {{- if eq (len $secret.path) (add1 $index) -}}
+              {{- fail (printf "Sensitive key '%s' should not be defined explicitly in values. Use variable expansion instead." (join "." $secret.path)) -}}
+            {{- else -}}
+              {{- $currentMap = index $currentMap $elem -}}
+            {{- end -}}
+          {{- else -}}
+              {{- $shouldContinue = false -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1297,3 +1297,13 @@ extraObjects: []
   #     data:
   #       - key: grafana-admin-password
   #         name: adminPassword
+
+# assertNoLeakedSecrets is a helper function defined in _helpers.tpl that checks if secret
+# values are not exposed in the rendered grafana.ini configmap. It is enabled by default.
+#
+# To pass values into grafana.ini without exposing them in a configmap, use variable expansion:
+# https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#variable-expansion
+#
+# Alternatively, if you wish to allow secret values to be exposed in the rendered grafana.ini configmap,
+# you can disable this check by setting assertNoLeakedSecrets to false.
+assertNoLeakedSecrets: true


### PR DESCRIPTION
## What does this PR do?
- There are numerous properties within `grafana.ini` that should be secret. 
- Users might try to provide these properties by setting them in helm `values`. This would result in secrets being leaked, since the contents of `grafana.ini` is stored as a configmap.
- This PR adds assertions that users do not provide explicit secrets into the `grafana.ini` configmap.

## Alternates considered:
- We could "pluck" these values out of the configmap and store them in a secret.  We could then use `envFrom` or some other mechanism to inject them into `grafana.ini`. However, this might lead to confusion on the part of users, who may expect all the values to be put into the `grafana.ini` verbatim.