### PR TITLE
[grafana] Quote hostname in ingress.yaml

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 7.0.19
+version: 7.0.20
 appVersion: 10.2.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 7.0.20
+version: 7.0.21
 appVersion: 10.2.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/ingress.yaml
+++ b/charts/grafana/templates/ingress.yaml
@@ -34,7 +34,7 @@ spec:
   rules:
   {{- if .Values.ingress.hosts  }}
   {{- range .Values.ingress.hosts }}
-    - host: {{ tpl . $ }}
+    - host: {{ tpl . $ | quote }}
       http:
         paths:
           {{- with $extraPaths }}


### PR DESCRIPTION
Ingress supports host starts with asterisk(*), but it has to be quoted.
With this PR adding quotes to host.
 
 Use this override values yaml to reproduce the issue.
 helm template --values override.yaml . --debug
```
ingress:
  enabled: true
  hosts:
  - "*.test.com"
``` 
Error: YAML parse error on grafana/templates/ingress.yaml: error converting YAML to JSON: yaml: line 14: did not find expected alphabetic or numeric character
helm.go:84: [debug] error converting YAML to JSON: yaml: line 14: did not find expected alphabetic or numeric character
