### PR TITLE
[rollout-operator] Remove default CPU limit for rollout-operator pod

### DIFF
--- a/charts/rollout-operator/Chart.yaml
+++ b/charts/rollout-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-operator
 description: "Grafana rollout-operator"
 type: application
-version: 0.10.0
+version: 0.11.0
 appVersion: v0.9.0
 home: https://github.com/grafana/rollout-operator
 kubeVersion: ^1.10.0-0

--- a/charts/rollout-operator/README.md
+++ b/charts/rollout-operator/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana rollout-operator](https://github.com/grafana/r
 
 # rollout-operator
 
-![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.9.0](https://img.shields.io/badge/AppVersion-v0.9.0-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.9.0](https://img.shields.io/badge/AppVersion-v0.9.0-informational?style=flat-square)
 
 Grafana rollout-operator
 
@@ -53,7 +53,6 @@ It is not a highly available application and runs as a single pod.
 | podLabels | object | `{}` | Pod (extra) Labels |
 | podSecurityContext | object | `{}` |  |
 | priorityClassName | string | `""` |  |
-| resources.limits.cpu | string | `"1"` |  |
 | resources.limits.memory | string | `"200Mi"` |  |
 | resources.requests.cpu | string | `"100m"` |  |
 | resources.requests.memory | string | `"100Mi"` |  |

--- a/charts/rollout-operator/values.yaml
+++ b/charts/rollout-operator/values.yaml
@@ -47,7 +47,7 @@ securityContext: {}
 
 resources:
   limits:
-    cpu: "1"
+    # cpu: "1"
     memory: 200Mi
   requests:
     cpu: 100m


### PR DESCRIPTION
This PR removes the CPU limit for rollout-operator pods.

This limit is not needed and unnecessarily limits the CPU utilisation of the rollout-operator under load.

Related: https://github.com/grafana/mimir/pull/7066