### PR TITLE
[grafana] fix secret datasources/notifiers rendering 

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 7.1.0
+version: 7.1.1
 appVersion: 10.2.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 7.0.22
+version: 7.1.0
 appVersion: 10.2.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/configSecret.yaml
+++ b/charts/grafana/templates/configSecret.yaml
@@ -25,13 +25,13 @@ stringData:
 {{- range $key, $value := .Values.datasources }}
 {{- if (hasKey $value "secret") }}
 {{- $key | nindent 2 }}: |
-  {{- tpl (toYaml $value | nindent 4) $root }}
+  {{- tpl (toYaml $value.secret | nindent 4) $root }}
 {{- end }}
 {{- end }}
 {{- range $key, $value := .Values.notifiers }}
 {{- if (hasKey $value "secret") }}
 {{- $key | nindent 2 }}: |
-  {{- tpl (toYaml $value | nindent 4) $root }}
+  {{- tpl (toYaml $value.secret | nindent 4) $root }}
 {{- end }}
 {{- end }}
 {{- range $key, $value := .Values.alerting }}


### PR DESCRIPTION
My current values to test this scenario is the following one to be able to generate my datasources inside a secret instead of a configmap:
```
datasources:
  datasources.yaml:
    secret:
      apiVersion: 1
      datasources:
      - name: xxx
```

Before this commit I was rendering this kind of secret:
```
# Source: grafana/templates/configSecret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: "grafana-config-secret"
  namespace: xxx
  labels:
    helm.sh/chart: grafana-xxx
    app.kubernetes.io/name: grafana
    app.kubernetes.io/instance: grafana
    app.kubernetes.io/version: "xxx"
    app.kubernetes.io/managed-by: Helm
data:
stringData:
  
  datasources.yaml: |
    secret:
      apiVersion: 1
      datasources:
```

We can see the `secret:` is inside the datasources.yaml and on the grafana log i've had this error:
```
"[Deprecated] the datasource provisioning config is outdated. please upgrade"
``` 

Now with this commit, the rendered secret is correct:
```
# Source: grafana/templates/configSecret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: "grafana-config-secret"
  namespace: xxx
  labels:
    helm.sh/chart: grafana-xxx
    app.kubernetes.io/name: grafana
    app.kubernetes.io/instance: grafana
    app.kubernetes.io/version: "xxx"
    app.kubernetes.io/managed-by: Helm
data:
stringData:
  
  datasources.yaml: |
    apiVersion: 1
    datasources:
```

No more `secret:` inside the datasources, and so no more deprecated error in log