### PR TITLE
[tempo-distributed] Default value for gateway.service.additionalPorts  set to an array

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.7.5
+version: 1.7.6
 appVersion: 2.3.1
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.7.5](https://img.shields.io/badge/Version-1.7.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.1](https://img.shields.io/badge/AppVersion-2.3.1-informational?style=flat-square)
+![Version: 1.7.6](https://img.shields.io/badge/Version-1.7.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.1](https://img.shields.io/badge/AppVersion-2.3.1-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -1677,7 +1677,7 @@ gateway:
     # -- Labels for gateway service
     labels: {}
     # -- Additional ports to be opneed on gateway service (e.g. for RPC connections)
-    additionalPorts: {}
+    additionalPorts: []
   # Gateway ingress configuration
   ingress:
     # -- Specifies whether an ingress for the gateway should be created


### PR DESCRIPTION
Fixes#2801

## When gateway.service.additionalPorts is set to map:

```sheikhabubaker@DESKTOP-TFVM3PT:~$ helm install my-tempo ./tempo-distributed-1.6.3.tgz -f my_values.yaml
coalesce.go:286: warning: cannot overwrite table with non table for tempo-distributed.gateway.service.additionalPorts (map[])
coalesce.go:286: warning: cannot overwrite table with non table for tempo-distributed.gateway.service.additionalPorts (map[])
NAME: my-tempo
LAST DEPLOYED: Fri Jan 12 04:25:36 2024
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

## When gateway.service.additionalPorts is set to an array:
```
sheikhabubaker@DESKTOP-TFVM3PT:~$ helm install my-tempo ./tempo-distributed-1.6.4.tgz -f my_values.yaml
NAME: my-tempo
LAST DEPLOYED: Fri Jan 12 04:28:51 2024
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
```

## Deployed and tested, resolves the above mentioned warnings successfully!!