### PR TITLE
[grafana] Don't fail assertNoLeakedSecrets check if a variable expansion operator is found

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 7.2.1
+version: 7.2.2
 appVersion: 10.2.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_helpers.tpl
+++ b/charts/grafana/templates/_helpers.tpl
@@ -263,7 +263,9 @@ sensitiveKeys:
         {{- range $index, $elem := $secret.path -}}
           {{- if and $shouldContinue (hasKey $currentMap $elem) -}}
             {{- if eq (len $secret.path) (add1 $index) -}}
-              {{- fail (printf "Sensitive key '%s' should not be defined explicitly in values. Use variable expansion instead." (join "." $secret.path)) -}}
+              {{- if not (regexMatch "\\$(?:__(?:env|file|value))?{[^}]+}" (index $currentMap $elem)) -}}
+                {{- fail (printf "Sensitive key '%s' should not be defined explicitly in values. Use variable expansion instead." (join "." $secret.path)) -}}
+              {{- end -}}
             {{- else -}}
               {{- $currentMap = index $currentMap $elem -}}
             {{- end -}}

--- a/charts/grafana/templates/_helpers.tpl
+++ b/charts/grafana/templates/_helpers.tpl
@@ -263,7 +263,7 @@ sensitiveKeys:
         {{- range $index, $elem := $secret.path -}}
           {{- if and $shouldContinue (hasKey $currentMap $elem) -}}
             {{- if eq (len $secret.path) (add1 $index) -}}
-              {{- if not (regexMatch "\\$(?:__(?:env|file|value))?{[^}]+}" (index $currentMap $elem)) -}}
+              {{- if not (regexMatch "\\$(?:__(?:env|file|vault))?{[^}]+}" (index $currentMap $elem)) -}}
                 {{- fail (printf "Sensitive key '%s' should not be defined explicitly in values. Use variable expansion instead." (join "." $secret.path)) -}}
               {{- end -}}
             {{- else -}}

--- a/charts/grafana/templates/_helpers.tpl
+++ b/charts/grafana/templates/_helpers.tpl
@@ -264,7 +264,7 @@ sensitiveKeys:
           {{- if and $shouldContinue (hasKey $currentMap $elem) -}}
             {{- if eq (len $secret.path) (add1 $index) -}}
               {{- if not (regexMatch "\\$(?:__(?:env|file|vault))?{[^}]+}" (index $currentMap $elem)) -}}
-                {{- fail (printf "Sensitive key '%s' should not be defined explicitly in values. Use variable expansion instead." (join "." $secret.path)) -}}
+                {{- fail (printf "Sensitive key '%s' should not be defined explicitly in values. Use variable expansion instead. You can disable this client-side validation by changing the value of assertNoLeakedSecrets." (join "." $secret.path)) -}}
               {{- end -}}
             {{- else -}}
               {{- $currentMap = index $currentMap $elem -}}


### PR DESCRIPTION
Checks for the presence of the following syntax anywhere in the setting (based on the documentation here: https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#variable-expansion):

`${whatever}` or `$__<provider>{whatever}`

If these are found, validation passes.

Fixes #2899