### PR TITLE
[rollout-operator] update for v0.10.1

### DIFF
--- a/charts/rollout-operator/Chart.yaml
+++ b/charts/rollout-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-operator
 description: "Grafana rollout-operator"
 type: application
-version: 0.11.0
-appVersion: v0.9.0
+version: 0.12.0
+appVersion: v0.10.1
 home: https://github.com/grafana/rollout-operator
 kubeVersion: ^1.10.0-0

--- a/charts/rollout-operator/README.md
+++ b/charts/rollout-operator/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana rollout-operator](https://github.com/grafana/r
 
 # rollout-operator
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.9.0](https://img.shields.io/badge/AppVersion-v0.9.0-informational?style=flat-square)
+![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.10.1](https://img.shields.io/badge/AppVersion-v0.10.1-informational?style=flat-square)
 
 Grafana rollout-operator
 


### PR DESCRIPTION
Helm chart for rollout-operator v.0.10.1

Note: there's another [open (conflicting) PR](https://github.com/grafana/helm-charts/pull/2903) which upgrades to rollout-operator v0.11.0, but we don't have an Helm chart for v0.10.1. I think we can get this PR (v0.10) merged and then rebase https://github.com/grafana/helm-charts/pull/2903, updating the Helm Chart version there.