### PR TITLE
[grafana] fix Chart.yaml - fix incorrect license #2882

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 7.2.1
+version: 7.2.2
 appVersion: 10.2.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
@@ -10,7 +10,7 @@ sources:
   - https://github.com/grafana/grafana
   - https://github.com/grafana/helm-charts
 annotations:
-  "artifacthub.io/license": AGPL-3.0-only
+  "artifacthub.io/license": Apache-2.0
   "artifacthub.io/links": |
     - name: Chart Source
       url: https://github.com/grafana/helm-charts


### PR DESCRIPTION
- fix Chart.yaml - incorrect license
  - chart license is Apache-2.0

## see:

- relates #2810 
- fixes #2882