### PR TITLE
[grafana]: Fix: Assert "no leaked secrets" must allow secret refer…

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 7.2.1
+version: 7.2.2
 appVersion: 10.2.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_helpers.tpl
+++ b/charts/grafana/templates/_helpers.tpl
@@ -262,7 +262,7 @@ sensitiveKeys:
         {{- $shouldContinue := true -}}
         {{- range $index, $elem := $secret.path -}}
           {{- if and $shouldContinue (hasKey $currentMap $elem) -}}
-            {{- if eq (len $secret.path) (add1 $index) -}}
+            {{- if and (eq (len $secret.path) (add1 $index)) (not (regexMatch "^\\$__file\\{.*\\}" (index $currentMap $elem) )) -}}
               {{- fail (printf "Sensitive key '%s' should not be defined explicitly in values. Use variable expansion instead." (join "." $secret.path)) -}}
             {{- else -}}
               {{- $currentMap = index $currentMap $elem -}}


### PR DESCRIPTION
### What does this PR do?

Fix regression on Grafana Chart introduce last week by https://github.com/grafana/helm-charts/pull/2867

The **assert no leaked secrets** must allow secret reference as documented in Grafana =>

https://github.com/grafana/helm-charts/blob/main/charts/grafana/README.md#how-to-securely-reference-secrets-in-grafanaini

```
  auth.google:
    client_id: $__file{/etc/secrets/auth_google/client_id}
    client_secret: $__file{/etc/secrets/auth_google/client_secret}
``` 