### PR TITLE
[grafana] Allow to customize empty dir volume

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 7.2.2
+version: 7.2.3
 appVersion: 10.2.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -1273,6 +1273,9 @@ volumes:
     {{- else if .configMap }}
     configMap:
       {{- toYaml .configMap | nindent 6 }}
+    {{- else if .emptyDir }}
+    emptyDir:
+      {{- toYaml .emptyDir | nindent 6 }}
     {{- else }}
     emptyDir: {}
     {{- end }}


### PR DESCRIPTION
## Grafana  - allow to customise empty dir volume

Template should support custom properties for emptyDir
```
extraVolumes:
  - name: ephemeral-tmp
    emptyDir:
      sizeLimit: 50Mi
```

Before this PR, volume properties was ignored, now =>

Values
```
extraVolumes:
  - name: ephemeral-tmp
```
Generate 
```
  - name: ephemeral-tmp
    emptyDir: {}
```
Values
```
extraVolumes:
  - name: ephemeral-tmp
    emptyDir:
      sizeLimit: 50Mi
```
Generate 
```
        - name: ephemeral-tmp
          emptyDir:
            sizeLimit: 50Mi
```


