### PR TITLE
[tempo-distributed] FIX serviceName for Statefulset

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.8.2
+version: 1.8.3
 appVersion: 2.3.1
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.8.2](https://img.shields.io/badge/Version-1.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.1](https://img.shields.io/badge/AppVersion-2.3.1-informational?style=flat-square)
+![Version: 1.8.3](https://img.shields.io/badge/Version-1.8.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.1](https://img.shields.io/badge/AppVersion-2.3.1-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
@@ -17,7 +17,7 @@ spec:
   selector:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6}}
-  serviceName: ingester
+  serviceName: {{ template "tempo.resourceName" $dict }}
   podManagementPolicy: Parallel
   updateStrategy:
     rollingUpdate:

--- a/charts/tempo-distributed/templates/memcached/statefulset-memcached.yaml
+++ b/charts/tempo-distributed/templates/memcached/statefulset-memcached.yaml
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6 }}
-  serviceName: memcached
+  serviceName: {{ include "tempo.resourceName" (dict "ctx" . "component" "memcached") }}
   template:
     metadata:
       {{- if or .Values.tempo.podAnnotations .Values.memcached.podAnnotations }}


### PR DESCRIPTION
In the Ingester statefulset manifest, `serviceName` is set to `ingester`. But i haven't got any service named like that:

```
$ kubectl -n tracing get sts
NAME              READY   AGE
tempo-ingester    3/3     26d
tempo-memcached   1/1     76d
```

This PR fixes Statefulset serviceName entry for Ingester et Memcached