### PR TITLE
[grafana] feat: adds multi-org support to sidecar dashboards

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 7.2.5
+version: 7.3.0
 appVersion: 10.2.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 7.3.0
+version: 7.4.0
 appVersion: 10.3.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_config.tpl
+++ b/charts/grafana/templates/_config.tpl
@@ -162,15 +162,15 @@ provider.yaml: |-
     {{- if .Values.sidecar.dashboards.providers }}
     {{- range .Values.sidecar.dashboards.providers }}
     - name: '{{ .name }}'
-      orgId: {{ .orgid }}
-      folder: '{{ .folder }}'
-      type: {{ .type }}
-      disableDeletion: {{ .disableDelete }}
-      allowUiUpdates: {{ .allowUiUpdates }}
+      orgId: {{ .orgid | default 1 }}
+      folder: '{{ .folder | default null }}'
+      type: {{ .type | default "file" }}
+      disableDeletion: {{ .disableDelete | default "false" }}
+      allowUiUpdates: {{ .allowUiUpdates | default "false"}}
       updateIntervalSeconds: {{ .updateIntervalSeconds | default 30 }}
       options:
-        foldersFromFilesStructure: {{ .foldersFromFilesStructure }}
-        path: {{ $values.sidecar.dashboards.folder }}{{- with $values.sidecar.dashboards.defaultFolderName }}/{{ . }}{{- end }}/{{ .folder }}
+        foldersFromFilesStructure: {{ .foldersFromFilesStructure | default false}}
+        path: {{ $values.sidecar.dashboards.folder }}{{- with $values.sidecar.dashboards.defaultFolderName }}/{{ . }}{{- end }}{{- with .folder }}/{{ . }}{{- end }}
     {{- end }}
     {{- end }}
 {{- end -}}

--- a/charts/grafana/templates/_config.tpl
+++ b/charts/grafana/templates/_config.tpl
@@ -163,7 +163,7 @@ provider.yaml: |-
     {{- range .Values.sidecar.dashboards.providers }}
     - name: '{{ .name }}'
       orgId: {{ .orgid | default 1 }}
-      folder: '{{ .folder | default null }}'
+      folder: '{{ .folder | default .name }}'
       type: {{ .type | default "file" }}
       disableDeletion: {{ .disableDelete | default "false" }}
       allowUiUpdates: {{ .allowUiUpdates | default "false"}}

--- a/charts/grafana/templates/_config.tpl
+++ b/charts/grafana/templates/_config.tpl
@@ -139,21 +139,40 @@ download_dashboards.sh: |
  Generate dashboard json config map data
  */}}
 {{- define "grafana.configDashboardProviderData" -}}
+{{- $values := .Values -}}
 provider.yaml: |-
   apiVersion: 1
   providers:
-    - name: '{{ .Values.sidecar.dashboards.provider.name }}'
-      orgId: {{ .Values.sidecar.dashboards.provider.orgid }}
-      {{- if not .Values.sidecar.dashboards.provider.foldersFromFilesStructure }}
-      folder: '{{ .Values.sidecar.dashboards.provider.folder }}'
+    {{- if .Values.sidecar.dashboards.provider }}
+    {{- with .Values.sidecar.dashboards.provider }} 
+        - name: '{{ .name }}'
+      orgId: {{ .orgid }}
+      {{- if not .foldersFromFilesStructure }}
+      folder: '{{ .folder }}'
       {{- end }}
-      type: {{ .Values.sidecar.dashboards.provider.type }}
-      disableDeletion: {{ .Values.sidecar.dashboards.provider.disableDelete }}
-      allowUiUpdates: {{ .Values.sidecar.dashboards.provider.allowUiUpdates }}
-      updateIntervalSeconds: {{ .Values.sidecar.dashboards.provider.updateIntervalSeconds | default 30 }}
+      type: {{ .type }}
+      disableDeletion: {{ .disableDelete }}
+      allowUiUpdates: {{ .allowUiUpdates }}
+      updateIntervalSeconds: {{ .updateIntervalSeconds | default 30 }}
       options:
-        foldersFromFilesStructure: {{ .Values.sidecar.dashboards.provider.foldersFromFilesStructure }}
-        path: {{ .Values.sidecar.dashboards.folder }}{{- with .Values.sidecar.dashboards.defaultFolderName }}/{{ . }}{{- end }}
+        foldersFromFilesStructure: {{ .foldersFromFilesStructure }}
+        path: {{ $values.sidecar.dashboards.folder }}{{- with $values.sidecar.dashboards.defaultFolderName }}/{{ . }}{{- end }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.sidecar.dashboards.providers }}
+    {{- range .Values.sidecar.dashboards.providers }}
+    - name: '{{ .name }}'
+      orgId: {{ .orgid }}
+      folder: '{{ .folder }}'
+      type: {{ .type }}
+      disableDeletion: {{ .disableDelete }}
+      allowUiUpdates: {{ .allowUiUpdates }}
+      updateIntervalSeconds: {{ .updateIntervalSeconds | default 30 }}
+      options:
+        foldersFromFilesStructure: {{ .foldersFromFilesStructure }}
+        path: {{ $values.sidecar.dashboards.folder }}{{- with $values.sidecar.dashboards.defaultFolderName }}/{{ . }}{{- end }}/{{ .folder }}
+    {{- end }}
+    {{- end }}
 {{- end -}}
 
 {{- define "grafana.secretsData" -}}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -946,16 +946,16 @@ sidecar:
         name: sidecarProvider
         # orgid as configured in grafana
         orgid: 1
-        # folder in which the dashboards should be imported in grafana
-        folder: ''
-        # type of the provider
-        type: file
-        # disableDelete to activate a import-only behaviour
-        disableDelete: false
-        # allow updating provisioned dashboards from the UI
-        allowUiUpdates: false
-        # allow Grafana to replicate dashboard structure from filesystem
-        foldersFromFilesStructure: false
+        # optional: folder in which the dashboards should be imported in grafana defaults to 'name' of provider
+        # folder: ''
+        # optional: type of the provider, defaults to "file"
+        # type: file
+        # optional disableDelete to activate a import-only behaviour, defaults to false
+        # disableDelete: false
+        # optional: allow updating provisioned dashboards from the UI, defaults to false
+        # allowUiUpdates: false
+        # optional allow Grafana to replicate dashboard structure from filesystem, defaults to false
+        # foldersFromFilesStructure: false
     # Additional dashboard sidecar volume mounts
     extraMounts: []
     # Sets the size limit of the dashboard sidecar emptyDir volume

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -944,10 +944,8 @@ sidecar:
     #
     # providers configuration that lets grafana manage the dashboards
     providers:
-      - # name of the provider, should be unique
-        name: sidecarProvider
-        # orgid as configured in grafana
-        orgid: 1
+      - name: sidecarProvider  # name of the provider, should be unique
+        orgid: 1  # orgid as configured in grafana
         # optional: folder in which the dashboards should be imported in grafana defaults to 'name' of provider
         # folder: ''
         # optional: type of the provider, defaults to "file"

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -940,22 +940,22 @@ sidecar:
     # defaults to 66sec (sic!)
     # watchClientTimeout: 60
     #
-    # provider configuration that lets grafana manage the dashboards
-    provider:
-      # name of the provider, should be unique
-      name: sidecarProvider
-      # orgid as configured in grafana
-      orgid: 1
-      # folder in which the dashboards should be imported in grafana
-      folder: ''
-      # type of the provider
-      type: file
-      # disableDelete to activate a import-only behaviour
-      disableDelete: false
-      # allow updating provisioned dashboards from the UI
-      allowUiUpdates: false
-      # allow Grafana to replicate dashboard structure from filesystem
-      foldersFromFilesStructure: false
+    # providers configuration that lets grafana manage the dashboards
+    providers:
+      - # name of the provider, should be unique
+        name: sidecarProvider
+        # orgid as configured in grafana
+        orgid: 1
+        # folder in which the dashboards should be imported in grafana
+        folder: ''
+        # type of the provider
+        type: file
+        # disableDelete to activate a import-only behaviour
+        disableDelete: false
+        # allow updating provisioned dashboards from the UI
+        allowUiUpdates: false
+        # allow Grafana to replicate dashboard structure from filesystem
+        foldersFromFilesStructure: false
     # Additional dashboard sidecar volume mounts
     extraMounts: []
     # Sets the size limit of the dashboard sidecar emptyDir volume


### PR DESCRIPTION
 converts `sidecar.dashboards.provider` to a list at
`sidecar.dashboards.providers` allowing the definition of multiple
providers that can be mappped to orgs as required.

still supports the singular variant to retain backwards compatibility
and will prepend it to any configured `providers`

Results in multi-org support defining providers like the example below which 

```
sidecar:
    dashboards:
      enabled: true
      providers:
        - name: prod
          orgid: 1
        - name: nonprod
          orgid: 2
        - name: ops
          orgid: 3
```

This then allows dashboard configmaps to be define the annotation `k8s-sidecar-target-directory: /tmp/dashboards/ops` instructing the sidecar to put the dashboard in the folder that's been specific in our configuration above. 

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: my-dashboard
  namespace: monitoring
  labels:
    grafana_dashboard: '1'
  annotations:
    k8s-sidecar-target-directory: /tmp/dashboards/ops/
data:
  my-dashboard.json: |-
   {}
```