### PR TITLE
[loki-canary] Add relabelings/metricRelabelings to servicemonitor

### DIFF
--- a/charts/loki-canary/Chart.yaml
+++ b/charts/loki-canary/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-canary
 description: Helm chart for Grafana Loki Canary
 type: application
 appVersion: 2.9.1
-version: 0.14.0
+version: 0.14.1
 home: https://github.com/grafana/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-canary/README.md
+++ b/charts/loki-canary/README.md
@@ -1,6 +1,6 @@
 # loki-canary
 
-![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.1](https://img.shields.io/badge/AppVersion-2.9.1-informational?style=flat-square)
+![Version: 0.14.1](https://img.shields.io/badge/Version-0.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.1](https://img.shields.io/badge/AppVersion-2.9.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki Canary
 
@@ -57,7 +57,9 @@ helm repo add grafana https://grafana.github.io/helm-charts
 | serviceMonitor.enabled | bool | `false` | If enabled, ServiceMonitor resources for Prometheus Operator are created |
 | serviceMonitor.interval | string | `nil` | ServiceMonitor scrape interval |
 | serviceMonitor.labels | object | `{}` | Additional ServiceMonitor labels |
+| serviceMonitor.metricRelabelings | list | `[]` | ServiceMonitor metric relabel configs to apply to samples before ingestion https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint |
 | serviceMonitor.namespace | string | `nil` | Alternative namespace for ServiceMonitor resources |
 | serviceMonitor.namespaceSelector | object | `{}` | Namespace selector for ServiceMonitor resources |
+| serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint |
 | serviceMonitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | tolerations | list | `[]` | Tolerations for canary pods |

--- a/charts/loki-canary/templates/servicemonitor.yaml
+++ b/charts/loki-canary/templates/servicemonitor.yaml
@@ -32,5 +32,13 @@ spec:
       {{- with .scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+      {{- with .relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/loki-canary/values.yaml
+++ b/charts/loki-canary/values.yaml
@@ -81,6 +81,12 @@ serviceMonitor:
   interval: null
   # -- ServiceMonitor scrape timeout in Go duration format (e.g. 15s)
   scrapeTimeout: null
+  # -- ServiceMonitor relabel configs to apply to samples before scraping
+  # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint
+  relabelings: []
+  # -- ServiceMonitor metric relabel configs to apply to samples before ingestion
+  # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint
+  metricRelabelings: []
 
 # -- Additional CLI args for the canary
 extraArgs:


### PR DESCRIPTION
Add `relabelings`/`metricRelabelings` to `ServiceMonitor` configuration