### PR TITLE
add support for zipkin receiver

### DIFF
--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -91,6 +91,8 @@ tempo:
         thrift_http:
           endpoint: 0.0.0.0:14268
     opencensus:
+    zipkin:
+      endpoint: 0.0.0.0:9411
     otlp:
       protocols:
         grpc:


### PR DESCRIPTION
Currently the tempo chart expoes a port for zipkin but does not configure
zipkin as an ingester. This simply changes the config template to use the port it exposes. Without this, I was seeing incoming zipkin traffic getting their TCP connections dropped, and with this change it works fine.