### PR TITLE
[tempo-distributed]Missing memcached.nodeSelector in values.yaml

### DIFF
--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -511,6 +511,7 @@ The memcached default args are removed and should be provided manually. The sett
 | memcached.image.registry | string | `nil` | The Docker registry for the Memcached image. Overrides `global.image.registry` |
 | memcached.image.repository | string | `"memcached"` | Memcached Docker image repository |
 | memcached.image.tag | string | `"1.6.23-alpine"` | Memcached Docker image tag |
+| memcached.nodeSelector | object | `{}` |  |
 | memcached.podAnnotations | object | `{}` | Annotations for memcached pods |
 | memcached.podLabels | object | `{}` | Labels for memcached pods |
 | memcached.replicas | int | `1` |  |

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -1422,6 +1422,7 @@ memcached:
               matchLabels:
                 {{- include "tempo.selectorLabels" (dict "ctx" . "component" "memcached") | nindent 12 }}
             topologyKey: topology.kubernetes.io/zone
+  nodeSelector: {}
   service:
     # -- Annotations for memcached service
     annotations: {}


### PR DESCRIPTION
tempo-distributed allows you to specify memcached.nodeSelector.
https://github.com/grafana/helm-charts/blob/81cf325568458d5e92f0acb5cddb4aff0b5c440f/charts/tempo-distributed/templates/memcached/statefulset-memcached.yaml#L107
However, there was no description in values.yaml and README.

README is generated according to ["Generate README"](https://github.com/grafana/helm-charts/blob/main/CONTRIBUTING.md#generate-readme)