### PR TITLE
[grafana] Add `serviceAccount.automountServiceAccountToken` and document `automountServiceAccountToken`

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 7.3.3
+version: 7.3.4
 appVersion: 10.3.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -137,6 +137,7 @@ need to instead set `global.imageRegistry`.
 | `extraSecretMounts`                       | Additional grafana server secret mounts       | `[]`                                                    |
 | `extraVolumeMounts`                       | Additional grafana server volume mounts       | `[]`                                                    |
 | `extraVolumes`                            | Additional Grafana server volumes             | `[]`                                                    |
+| `automountServiceAccountToken`            | Mounted the service account token on the grafana pod. Mandatory, if sidecars are enabled  | `true`      |
 | `createConfigmap`                         | Enable creating the grafana configmap         | `true`                                                  |
 | `extraConfigmapMounts`                    | Additional grafana server configMap volume mounts (values are templated) | `[]`                         |
 | `extraEmptyDirMounts`                     | Additional grafana server emptyDir volume mounts | `[]`                                                 |
@@ -223,7 +224,7 @@ need to instead set `global.imageRegistry`.
 | `admin.existingSecret`                    | The name of an existing secret containing the admin credentials (can be templated). | `""`                                 |
 | `admin.userKey`                           | The key in the existing admin secret containing the username. | `"admin-user"`                          |
 | `admin.passwordKey`                       | The key in the existing admin secret containing the password. | `"admin-password"`                      |
-| `serviceAccount.autoMount`                | Automount the service account token in the pod| `true`                                                  |
+| `serviceAccount.automountServiceAccountToken` | Automount the service account token on all pods where is service account is used | `false` |
 | `serviceAccount.annotations`              | ServiceAccount annotations                    |                                                         |
 | `serviceAccount.create`                   | Create service account                        | `true`                                                  |
 | `serviceAccount.labels`                   | ServiceAccount labels                         | `{}`                                                    |

--- a/charts/grafana/templates/serviceaccount.yaml
+++ b/charts/grafana/templates/serviceaccount.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.serviceAccount.create }}
-{{- $root := . -}}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.autoMount | default .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
@@ -10,7 +10,7 @@ metadata:
     {{- end }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
-    {{- tpl (toYaml . | nindent 4) $root }}
+    {{- tpl (toYaml . | nindent 4) $ }}
   {{- end }}
   name: {{ include "grafana.serviceAccountName" . }}
   namespace: {{ include "grafana.namespace" . }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -38,10 +38,13 @@ serviceAccount:
   nameTest:
   ## ServiceAccount labels.
   labels: {}
-## Service account annotations. Can be templated.
-#  annotations:
-#    eks.amazonaws.com/role-arn: arn:aws:iam::123456789000:role/iam-role-name-here
-  autoMount: false
+  ## Service account annotations. Can be templated.
+  #  annotations:
+  #    eks.amazonaws.com/role-arn: arn:aws:iam::123456789000:role/iam-role-name-here
+
+  ## autoMount is deprecated in favor of automountServiceAccountToken
+  # autoMount: false
+  automountServiceAccountToken: false
 
 replicas: 1
 


### PR DESCRIPTION
Follow-up PR from #2991 

* Document `automountServiceAccountToken`
* Replace `serviceAccount.autoMount` by `serviceAccount.automountServiceAccountToken` - other charts using the same naming, too (https://github.com/grafana/helm-charts/blob/df7ae36c21bce12712c04a91115c165a04b7cdbf/charts/tempo/templates/serviceaccount.yaml#L20) - `serviceAccount.autoMount` is still supported and preferred to avoid a breaking change here.