### PR TITLE
fix: Push charts to GHCR requires login

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,14 +47,19 @@ jobs:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: "true"
 
+      - name: Login to GHCR
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push charts to GHCR
         run: |
           shopt -s nullglob
-          for pkg in .cr-release-packages/*; do
+          for pkg in .cr-release-packages/*.tgz; do
             if [ -z "${pkg:-}" ]; then
               break
             fi
-            if ! helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts"; then
-              echo '::warning:: helm push failed!'
-            fi
+            helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/helm-charts"
           done


### PR DESCRIPTION
Resolves #2481

OCI chart push was introduced by @jkroepke here:
- https://github.com/grafana/helm-charts/issues/2395
- https://github.com/grafana/helm-charts/pull/2443
- https://github.com/grafana/helm-charts/pull/2474

But it fails due to missing docker login to GHCR.

I am a Argo helm maintainer and we use almost the identical code:
https://github.com/argoproj/argo-helm/blob/fa85e824f014ef7bf19163d4ecf7e9b8eb01f6b9/.github/workflows/publish.yml#L67C15-L82

/cc: @zanhsieh as you merged @jkroepke PRs in the past