### PR TITLE
[tempo-distributed] Upgrade to Tempo 2.4.0

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.8.5
-appVersion: 2.3.1
+version: 1.9.0
+appVersion: 2.4.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/
 icon: https://raw.githubusercontent.com/grafana/tempo/master/docs/tempo/website/logo_and_name.png

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.8.5](https://img.shields.io/badge/Version-1.8.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.1](https://img.shields.io/badge/AppVersion-2.3.1-informational?style=flat-square)
+![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.0](https://img.shields.io/badge/AppVersion-2.4.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -244,6 +244,13 @@ The memcached default args are removed and should be provided manually. The sett
 | adminApi.terminationGracePeriodSeconds | int | `60` |  |
 | adminApi.tolerations | list | `[]` |  |
 | adminApi.topologySpreadConstraints | string | Defaults to allow skew no more then 1 node per AZ | topologySpread for admin-api pods. Passed through `tpl` and, thus, to be configured as string |
+| cache.caches[0].memcached.consistent_hash | bool | `true` |  |
+| cache.caches[0].memcached.host | string | `"{{ include \"tempo.fullname\" . }}-memcached"` |  |
+| cache.caches[0].memcached.service | string | `"memcached-client"` |  |
+| cache.caches[0].memcached.timeout | string | `"500ms"` |  |
+| cache.caches[0].roles[0] | string | `"parquet-footer"` |  |
+| cache.caches[0].roles[1] | string | `"bloom"` |  |
+| cache.caches[0].roles[2] | string | `"frontend-search"` |  |
 | compactor.config.compaction.block_retention | string | `"48h"` | Duration to keep blocks |
 | compactor.config.compaction.compacted_block_retention | string | `"1h"` |  |
 | compactor.config.compaction.compaction_cycle | string | `"30s"` | The time between compaction cycles |

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -1270,6 +1270,7 @@ config: |
           - parquet-footer
           - parquet-column-idx
           - parquet-offset-idx
+          - bloom
           - frontend-search
         memcached:
           consistent_hash: true

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -1263,6 +1263,20 @@ config: |
     grpc_server_max_send_msg_size: {{ .Values.server.grpc_server_max_send_msg_size }}
     http_server_read_timeout: {{ .Values.server.http_server_read_timeout }}
     http_server_write_timeout: {{ .Values.server.http_server_write_timeout }}
+  {{- if .Values.memcached.enabled }}
+  cache:
+    caches:
+      - roles:
+          - parquet-footer
+          - parquet-column-idx
+          - parquet-offset-idx
+          - frontend-search
+        memcached:
+          consistent_hash: true
+          host: {{ include "tempo.fullname" . }}-memcached
+          service: memcached-client
+          timeout: 500ms
+  {{- end }}
   storage:
     trace:
       {{- if .Values.storage.trace.block.version }}
@@ -1294,14 +1308,6 @@ config: |
         path: /var/tempo/traces
       wal:
         path: /var/tempo/wal
-      {{- if .Values.memcached.enabled }}
-      cache: memcached
-      memcached:
-        consistent_hash: true
-        host: {{ include "tempo.fullname" . }}-memcached
-        service: memcached-client
-        timeout: 500ms
-      {{- end }}
 
 # Set Tempo server configuration
 # Refers to https://grafana.com/docs/tempo/latest/configuration/#server

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -1263,21 +1263,8 @@ config: |
     grpc_server_max_send_msg_size: {{ .Values.server.grpc_server_max_send_msg_size }}
     http_server_read_timeout: {{ .Values.server.http_server_read_timeout }}
     http_server_write_timeout: {{ .Values.server.http_server_write_timeout }}
-  {{- if .Values.memcached.enabled }}
   cache:
-    caches:
-      - roles:
-          - parquet-footer
-          - parquet-column-idx
-          - parquet-offset-idx
-          - bloom
-          - frontend-search
-        memcached:
-          consistent_hash: true
-          host: {{ include "tempo.fullname" . }}-memcached
-          service: memcached-client
-          timeout: 500ms
-  {{- end }}
+  {{- toYaml .Values.cache | nindent 2}}
   storage:
     trace:
       {{- if .Values.storage.trace.block.version }}
@@ -1327,6 +1314,21 @@ server:
   http_server_read_timeout: 30s
   # -- Write timeout for HTTP server
   http_server_write_timeout: 30s
+
+# Use this block to configure caches available throughout the application.
+# Multiple caches can be created and assigned roles which determine how they are used by Tempo.
+# https://grafana.com/docs/tempo/latest/configuration/#cache
+cache:
+  caches:
+    - memcached:
+        host: '{{ include "tempo.fullname" . }}-memcached'
+        service: memcached-client
+        consistent_hash: true
+        timeout: 500ms
+      roles:
+        - parquet-footer
+        - bloom
+        - frontend-search
 
 # To configure a different storage backend instead of local storage:
 # storage:


### PR DESCRIPTION
Upgrade Tempo to 2.4.0 and use the new multi-cache config. 

I have assigned the following roles to the memcache:
```yaml
- roles:
    - parquet-footer
    - parquet-column-idx
    - parquet-offset-idx
    - bloom
    - frontend-search
 ```