### PR TITLE
[agent-operator] Bump version of Grafana Agent to v0.40.2

### DIFF
--- a/charts/agent-operator/Chart.yaml
+++ b/charts/agent-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: grafana-agent-operator
 description: A Helm chart for Grafana Agent Operator
 type: application
-version: 0.3.17
-appVersion: "0.40.1"
+version: 0.3.18
+appVersion: "0.40.2"
 home: https://grafana.com/docs/agent/v0.40/
 icon: https://raw.githubusercontent.com/grafana/agent/v0.40.0/docs/sources/assets/logo_and_name.png
 sources:

--- a/charts/agent-operator/README.md
+++ b/charts/agent-operator/README.md
@@ -1,6 +1,6 @@
 # grafana-agent-operator
 
-![Version: 0.3.17](https://img.shields.io/badge/Version-0.3.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.1](https://img.shields.io/badge/AppVersion-0.40.1-informational?style=flat-square)
+![Version: 0.3.18](https://img.shields.io/badge/Version-0.3.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.2](https://img.shields.io/badge/AppVersion-0.40.2-informational?style=flat-square)
 
 A Helm chart for Grafana Agent Operator
 
@@ -63,7 +63,7 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 | image.pullSecrets | list | `[]` | Image pull secrets |
 | image.registry | string | `"docker.io"` | Image registry |
 | image.repository | string | `"grafana/agent-operator"` | Image repo |
-| image.tag | string | `"v0.40.1"` | Image tag |
+| image.tag | string | `"v0.40.2"` | Image tag |
 | kubeletService | object | `{"namespace":"default","serviceName":"kubelet"}` | If both are set, Agent Operator will create and maintain a service for scraping kubelets https://grafana.com/docs/agent/latest/operator/getting-started/#monitor-kubelets |
 | nameOverride | string | `""` | Overrides the chart's name |
 | nodeSelector | object | `{}` | nodeSelector configuration |

--- a/charts/agent-operator/values.yaml
+++ b/charts/agent-operator/values.yaml
@@ -37,7 +37,7 @@ image:
   # -- Image repo
   repository: grafana/agent-operator
   # -- Image tag
-  tag: v0.40.1
+  tag: v0.40.2
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Image pull secrets


### PR DESCRIPTION
This is pending the v0.40.2 release to finish, but given how it's close to EOD I'm preparing the PR now so we can merge as soon as the release is out there
