### PR TITLE
[agent-operator] Add override for test image

### DIFF
--- a/charts/agent-operator/Chart.yaml
+++ b/charts/agent-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: grafana-agent-operator
 description: A Helm chart for Grafana Agent Operator
 type: application
-version: 0.3.19
+version: 0.3.20
 appVersion: "0.40.3"
 home: https://grafana.com/docs/agent/v0.40/
 icon: https://raw.githubusercontent.com/grafana/agent/v0.40.3/docs/sources/assets/logo_and_name.png

--- a/charts/agent-operator/README.md
+++ b/charts/agent-operator/README.md
@@ -1,6 +1,6 @@
 # grafana-agent-operator
 
-![Version: 0.3.19](https://img.shields.io/badge/Version-0.3.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.3](https://img.shields.io/badge/AppVersion-0.40.3-informational?style=flat-square)
+![Version: 0.3.20](https://img.shields.io/badge/Version-0.3.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.3](https://img.shields.io/badge/AppVersion-0.40.3-informational?style=flat-square)
 
 A Helm chart for Grafana Agent Operator
 
@@ -64,9 +64,6 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 | image.registry | string | `"docker.io"` | Image registry |
 | image.repository | string | `"grafana/agent-operator"` | Image repo |
 | image.tag | string | `"v0.40.3"` | Image tag |
-| test.image.registry | string | `"docker.io"` | Test image registry |
-| test.image.repository | string | `"library/busybox"` | Test image repo |
-| test.image.tag | string | `"latest"` | Test image tag |
 | kubeletService | object | `{"namespace":"default","serviceName":"kubelet"}` | If both are set, Agent Operator will create and maintain a service for scraping kubelets https://grafana.com/docs/agent/latest/operator/getting-started/#monitor-kubelets |
 | nameOverride | string | `""` | Overrides the chart's name |
 | nodeSelector | object | `{}` | nodeSelector configuration |
@@ -78,4 +75,7 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 | resources | object | `{}` | Resource limits and requests config |
 | serviceAccount.create | bool | `true` | Toggle to create ServiceAccount |
 | serviceAccount.name | string | `nil` | Service account name |
+| test.image.registry | string | `"docker.io"` | Test image registry |
+| test.image.repository | string | `"library/busybox"` | Test image repo |
+| test.image.tag | string | `"latest"` | Test image tag |
 | tolerations | list | `[]` | Tolerations applied to Pods |

--- a/charts/agent-operator/README.md
+++ b/charts/agent-operator/README.md
@@ -64,6 +64,9 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 | image.registry | string | `"docker.io"` | Image registry |
 | image.repository | string | `"grafana/agent-operator"` | Image repo |
 | image.tag | string | `"v0.40.3"` | Image tag |
+| test.image.registry | string | `"docker.io"` | Test image registry |
+| test.image.repository | string | `"library/busybox"` | Test image repo |
+| test.image.tag | string | `"latest"` | Test image tag |
 | kubeletService | object | `{"namespace":"default","serviceName":"kubelet"}` | If both are set, Agent Operator will create and maintain a service for scraping kubelets https://grafana.com/docs/agent/latest/operator/getting-started/#monitor-kubelets |
 | nameOverride | string | `""` | Overrides the chart's name |
 | nodeSelector | object | `{}` | nodeSelector configuration |

--- a/charts/agent-operator/templates/tests/test-grafanaagent.yaml
+++ b/charts/agent-operator/templates/tests/test-grafanaagent.yaml
@@ -107,12 +107,12 @@ metadata:
 spec:
   containers:
   - name: busybox
-    image: busybox
+    image: "{{ .Values.test.image.registry }}/{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
     command: ['wget']
     args:  ['grafana-agent-test-operated:8080/-/healthy']
   # Wait for GrafanaAgent CR
   initContainers:
   - name: sleep
-    image: busybox
+    image: "{{ .Values.test.image.registry }}/{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
     command: ['sleep', '60']
   restartPolicy: Never

--- a/charts/agent-operator/values.yaml
+++ b/charts/agent-operator/values.yaml
@@ -43,6 +43,15 @@ image:
   # -- Image pull secrets
   pullSecrets: []
 
+test:
+  image:
+    # -- Test image registry
+    registry: docker.io
+    # -- Test image repo
+    repository: library/busybox
+    # -- Test image tag
+    tag: latest
+
 # -- hostAliases to add
 hostAliases: []
 #  - ip: 1.2.3.4


### PR DESCRIPTION
This PR adds the ability to override the default busybox image used in the test probe. This is useful in air-gapped environments where docker.io might not be accessible