### PR TITLE
fix tempo-distributed hpa selector

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.9.1
+version: 1.9.2
 appVersion: 2.4.1
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/templates/_helpers.tpl
+++ b/charts/tempo-distributed/templates/_helpers.tpl
@@ -163,11 +163,11 @@ Return the appropriate apiVersion for PodDisruptionBudget.
 Return the appropriate apiVersion for HorizontalPodAutoscaler.
 */}}
 {{- define "tempo.hpa.apiVersion" -}}
-  {{- if and (.Capabilities.APIVersions.Has "autoscaling/v2") (semverCompare ">=1.23-0" .Capabilities.KubeVersion.Version) -}}
-    {{- print "autoscaling/v2" -}}
-  {{- else -}}
-    {{- print "autoscaling/v2beta1" -}}
-  {{- end -}}
+ {{- if .Capabilities.APIVersions.Has "autoscaling/v2" }}
+    {{- "autoscaling/v2" }}
+  {{- else }}
+    {{- "autoscaling/v2beta2" }}
+  {{- end }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Previous PR try: <https://github.com/grafana/helm-charts/pull/3033>

related issues:

- #2558 
- #2493
- #1391 



Fix the helper to select the correct HPA on kubernetes >=v1.23.

This new select has tested in my local kubernetes development and the right version has selected!

![image](https://github.com/grafana/helm-charts/assets/10054367/0d777dea-6613-4b7e-9e45-58e324920f77)
![image](https://github.com/grafana/helm-charts/assets/10054367/7b0ec6f7-8b07-46f0-ada5-b811403eef3f)
![image](https://github.com/grafana/helm-charts/assets/10054367/afdfb9ee-6734-4cdf-9c64-cf47dd75f152)
[grafana-6.57.0.tgz](https://github.com/grafana/helm-charts/files/14649138/grafana-6.57.0.tgz)

___

I tested on version 6.57.0 in my local but the issue is the same on the latest version.
