### PR TITLE
fixing imagePullSecrets for enterprise components

### DIFF
--- a/charts/tempo-distributed/templates/admin-api/_helpers.tpl
+++ b/charts/tempo-distributed/templates/admin-api/_helpers.tpl
@@ -1,0 +1,7 @@
+{{/*
+adminApi imagePullSecrets
+*/}}
+{{- define "tempo.adminApiImagePullSecrets" -}}
+{{- $dict := dict "tempo" .Values.tempo.image "component" .Values.adminApi.image "global" .Values.global.image -}}
+{{- include "tempo.adminApiImagePullSecrets" $dict -}}
+{{- end }}

--- a/charts/tempo-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/charts/tempo-distributed/templates/admin-api/admin-api-dep.yaml
@@ -37,12 +37,7 @@ spec:
         {{- with .Values.adminApi.initContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- if .Values.tempo.image.pullSecrets }}
-      imagePullSecrets:
-      {{- range .Values.image.pullSecrets }}
-        - name: {{ . }}
-      {{- end }}
-      {{- end }}
+      {{- include "tempo.adminApiImagePullSecrets" . | nindent 6 -}}
       {{- with .Values.adminApi.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}

--- a/charts/tempo-distributed/templates/enterprise-gateway/_helpers.tpl
+++ b/charts/tempo-distributed/templates/enterprise-gateway/_helpers.tpl
@@ -31,3 +31,11 @@ Return if ingress supports pathType.
 {{- define "tempo.ingress.supportsPathType" -}}
   {{- or (eq (include "tempo.ingress.isStable" .) "true") (and (eq (include "tempo.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
 {{- end -}}
+
+{{/*
+enterpriseGateway imagePullSecrets
+*/}}
+{{- define "tempo.enterpriseGatewayImagePullSecrets" -}}
+{{- $dict := dict "tempo" .Values.tempo.image "component" .Values.enterpriseGateway.image "global" .Values.global.image -}}
+{{- include "tempo.enterpriseGatewayImagePullSecrets" $dict -}}
+{{- end }}

--- a/charts/tempo-distributed/templates/enterprise-gateway/gateway-dep.yaml
+++ b/charts/tempo-distributed/templates/enterprise-gateway/gateway-dep.yaml
@@ -35,12 +35,7 @@ spec:
         {{- toYaml .Values.enterpriseGateway.securityContext | nindent 8 }}
       initContainers:
         {{- toYaml .Values.enterpriseGateway.initContainers | nindent 8 }}
-      {{- if .Values.tempo.image.pullSecrets }}
-      imagePullSecrets:
-      {{- range .Values.image.pullSecrets }}
-        - name: {{ . }}
-      {{- end }}
-      {{- end }}
+      {{- include "tempo.enterpriseGatewayImagePullSecrets" . | nindent 6 -}}
       {{- with .Values.enterpriseGateway.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -1920,6 +1920,16 @@ adminApi:
     annotations: {}
     labels: {}
 
+  image:
+    # -- The Docker registry for the adminApi image. Overrides `tempo.image.registry`
+    registry: null
+    # -- Optional list of imagePullSecrets. Overrides `tempo.image.pullSecrets`
+    pullSecrets: []
+    # -- Docker image repository for the adminApi image. Overrides `tempo.image.repository`
+    repository: null
+    # -- Docker image tag for the adminApi image. Overrides `tempo.image.tag`
+    tag: null
+
   initContainers: []
 
   strategy:
@@ -2006,6 +2016,16 @@ enterpriseGateway:
   #  - ip: 1.2.3.4
   #    hostnames:
   #      - domain.tld
+
+  image:
+    # -- The Docker registry for the enterpriseGateway image. Overrides `tempo.image.registry`
+    registry: null
+    # -- Optional list of imagePullSecrets. Overrides `tempo.image.pullSecrets`
+    pullSecrets: []
+    # -- Docker image repository for the enterpriseGateway image. Overrides `tempo.image.repository`
+    repository: null
+    # -- Docker image tag for the enterpriseGateway image. Overrides `tempo.image.tag`
+    tag: null
 
   annotations: {}
   service:


### PR DESCRIPTION
Running into a few issues with trying to get these enterprise components working via Helm deploy.

The following error has been coming up when trying to deploy these via ArgoCD:

```
Error: template: tempo-distributed/templates/enterprise-gateway/gateway-dep.yaml:40:23: executing "tempo-distributed/templates/enterprise-gateway/gateway-dep.yaml" at <.Values.image.pullSecrets>: nil pointer evaluating interface {}.pullSecrets Use --debug flag to render out invalid YAML
```

I've ended up standardising how pullSecrets are defined in both the `adminApi` and the `enterpriseGateway`