### PR TITLE
[loki-distributed] set unique cluster_label for loki-distributed memberlist

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.9.10
-version: 0.79.4
+version: 0.80.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.80.0](https://img.shields.io/badge/Version-0.79.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.10](https://img.shields.io/badge/AppVersion-2.9.10-informational?style=flat-square)
+![Version: 0.80.0](https://img.shields.io/badge/Version-0.80.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.10](https://img.shields.io/badge/AppVersion-2.9.10-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -25,7 +25,8 @@ helm repo add grafana https://grafana.github.io/helm-charts
 Major version upgrades listed here indicate that there is an incompatible breaking change needing manual actions.
 
 ### To 0.80.0
-Introduces a default `cluster_label` for the ring memberlist, which will temporarily disrupt ingestion as it rolls out, unless you temporarily set `cluster_label_verification_disabled`.
+
+Upgrading to chart 0.80.0 will set the memberlist cluster_label config option. During rollout your cluster will temporarilly be split into two memberlist clusters until all components are rolled out. This will interrupt reads and writes. This config option is set to prevent cross talk between Loki and other memberlist clusters.
 
 ### From 0.78.x to 0.79.0
 Removed the hardcoded, deprecated `boltdb.shipper.compactor.working-directory` flag in the Compactor Deployment template, so that it can be set with `.Values.compactor.extraArgs` and the `compactor.working-directory` flag if necessary.

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.79.4](https://img.shields.io/badge/Version-0.79.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.10](https://img.shields.io/badge/AppVersion-2.9.10-informational?style=flat-square)
+![Version: 0.80.0](https://img.shields.io/badge/Version-0.79.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.10](https://img.shields.io/badge/AppVersion-2.9.10-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 
@@ -23,6 +23,9 @@ helm repo add grafana https://grafana.github.io/helm-charts
 ### Upgrading an existing Release to a new major version
 
 Major version upgrades listed here indicate that there is an incompatible breaking change needing manual actions.
+
+### To 0.80.0
+Introduces a default `cluster_label` for the ring memberlist, which will temporarily disrupt ingestion as it rolls out, unless you temporarily set `cluster_label_verification_disabled`.
 
 ### From 0.78.x to 0.79.0
 Removed the hardcoded, deprecated `boltdb.shipper.compactor.working-directory` flag in the Compactor Deployment template, so that it can be set with `.Values.compactor.extraArgs` and the `compactor.working-directory` flag if necessary.

--- a/charts/loki-distributed/README.md.gotmpl
+++ b/charts/loki-distributed/README.md.gotmpl
@@ -22,6 +22,9 @@ helm repo add grafana https://grafana.github.io/helm-charts
 
 Major version upgrades listed here indicate that there is an incompatible breaking change needing manual actions.
 
+### To 0.80.0
+Introduces a default `cluster_label` for the ring memberlist, which will temporarily disrupt ingestion as it rolls out, unless you temporarily set `cluster_label_verification_disabled`.
+
 ### From 0.78.x to 0.79.0
 Removed the hardcoded, deprecated `boltdb.shipper.compactor.working-directory` flag in the Compactor Deployment template, so that it can be set with `.Values.compactor.extraArgs` and the `compactor.working-directory` flag if necessary.
 

--- a/charts/loki-distributed/README.md.gotmpl
+++ b/charts/loki-distributed/README.md.gotmpl
@@ -23,7 +23,8 @@ helm repo add grafana https://grafana.github.io/helm-charts
 Major version upgrades listed here indicate that there is an incompatible breaking change needing manual actions.
 
 ### To 0.80.0
-Introduces a default `cluster_label` for the ring memberlist, which will temporarily disrupt ingestion as it rolls out, unless you temporarily set `cluster_label_verification_disabled`.
+
+Upgrading to chart 0.80.0 will set the memberlist cluster_label config option. During rollout your cluster will temporarilly be split into two memberlist clusters until all components are rolled out. This will interrupt reads and writes. This config option is set to prevent cross talk between Loki and other memberlist clusters.
 
 ### From 0.78.x to 0.79.0
 Removed the hardcoded, deprecated `boltdb.shipper.compactor.working-directory` flag in the Compactor Deployment template, so that it can be set with `.Values.compactor.extraArgs` and the `compactor.working-directory` flag if necessary.

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -108,6 +108,7 @@ loki:
           store: memberlist
 
     memberlist:
+      cluster_label: "{{ .Release.Name }}.{{ .Release.Namespace }}"
       join_members:
         - {{ include "loki.fullname" . }}-memberlist
 


### PR DESCRIPTION
Addressing https://github.com/grafana/tempo/issues/2766 where Loki/Tempo ingesters can join each other's ring because cluster_label seems to be defaulted to something common to both components. This change should mitigate the issue in the future.