### PR TITLE
Bump the Grafana chart to the latest version (7.3.7).

### DIFF
--- a/charts/loki-stack/requirements.yaml
+++ b/charts/loki-stack/requirements.yaml
@@ -13,7 +13,7 @@ dependencies:
   version: "^2.3.0"
 - name: "grafana"
   condition: grafana.enabled
-  version: "~6.43.0"
+  version: "~7.3.0"
   repository:  "https://grafana.github.io/helm-charts"
 - name: "prometheus"
   condition: prometheus.enabled


### PR DESCRIPTION
This PR bumps the chart that loki-stack relies on for Grafana to the latest version.