### PR TITLE
[tempo-distributed] Adds service specific features for enterprise gateway inline with gateway.

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.9.1
+version: 1.9.2
 appVersion: 2.4.1
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.9.1](https://img.shields.io/badge/Version-1.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.1](https://img.shields.io/badge/AppVersion-2.4.1-informational?style=flat-square)
+![Version: 1.9.2](https://img.shields.io/badge/Version-1.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.1](https://img.shields.io/badge/AppVersion-2.4.1-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -387,9 +387,12 @@ The memcached default args are removed and should be provided manually. The sett
 | enterpriseGateway.resources.requests.cpu | string | `"10m"` |  |
 | enterpriseGateway.resources.requests.memory | string | `"32Mi"` |  |
 | enterpriseGateway.securityContext | object | `{}` |  |
-| enterpriseGateway.service.annotations | object | `{}` |  |
-| enterpriseGateway.service.labels | object | `{}` |  |
-| enterpriseGateway.service.port | string | `nil` | If the port is left undefined, the service will listen on the same port as the pod |
+| enterpriseGateway.service.annotations | object | `{}` | Annotations for the enterprise gateway service |
+| enterpriseGateway.service.clusterIP | string | `nil` | ClusterIP of the enterprise gateway service |
+| enterpriseGateway.service.labels | object | `{}` | Labels for enterprise gateway service |
+| enterpriseGateway.service.loadBalancerIP | string | `nil` | Load balancer IPO address if service type is LoadBalancer for enterprise gateway service |
+| enterpriseGateway.service.port | string | `nil` | Port of the enterprise gateway service; if left undefined, the service will listen on the same port as the pod |
+| enterpriseGateway.service.type | string | `"ClusterIP"` | Type of the enterprise gateway service |
 | enterpriseGateway.strategy.rollingUpdate.maxSurge | int | `0` |  |
 | enterpriseGateway.strategy.rollingUpdate.maxUnavailable | int | `1` |  |
 | enterpriseGateway.strategy.type | string | `"RollingUpdate"` |  |

--- a/charts/tempo-distributed/templates/enterprise-gateway/gateway-svc.yaml
+++ b/charts/tempo-distributed/templates/enterprise-gateway/gateway-svc.yaml
@@ -13,7 +13,13 @@ metadata:
     {{- toYaml .Values.enterpriseGateway.service.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.enterpriseGateway.service.type }}
+  {{- with .Values.enterpriseGateway.service.clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
+  {{- if and (eq "LoadBalancer" .Values.enterpriseGateway.service.type) .Values.enterpriseGateway.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.enterpriseGateway.service.loadBalancerIP }}
+  {{- end }}
   ports:
     - port: {{ .Values.enterpriseGateway.service.port | default (include "tempo.serverHttpListenPort" . ) }}
       protocol: TCP

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -2009,10 +2009,18 @@ enterpriseGateway:
 
   annotations: {}
   service:
-    annotations: {}
-    labels: {}
-    # -- If the port is left undefined, the service will listen on the same port as the pod
+    # -- Port of the enterprise gateway service; if left undefined, the service will listen on the same port as the pod
     port: null
+    # -- Type of the enterprise gateway service
+    type: ClusterIP
+    # -- ClusterIP of the enterprise gateway service
+    clusterIP: null
+    # -- Load balancer IPO address if service type is LoadBalancer for enterprise gateway service
+    loadBalancerIP: null
+    # -- Annotations for the enterprise gateway service
+    annotations: {}
+    # -- Labels for enterprise gateway service
+    labels: {}
 
   strategy:
     type: RollingUpdate


### PR DESCRIPTION
Namely:
* Service type
* Service port
* Cluster IP address (if type is ClusterIP)
* Loadbalancer IP address (if type is LoadBalancer)

The gateway component already supports these, inline with similar config options in Mimir and Loki. The enterprise gateway component does not.

Can help in situations where specific cluster/loadbalancer port mappings are required for external IPs for a cluster.