### PR TITLE
Make Grafana Agent maintainers to be owners of the agent operator chart

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,3 +17,4 @@
 /charts/enterprise-logs/ @grafana/loki-squad
 /charts/tempo-vulture/ @grafana/tempo @Whyeasy @dgzlopes
 /charts/synthetic-monitoring-agent/ @torstenwalter @zanhsieh
+/charts/agent-operator/ @grafana/grafana-agent-maintainers


### PR DESCRIPTION
If there are no codeowners, then approval will be up to a core group of default reviewers, neither of whom is part of the Agent group.