### PR TITLE
[grafana] Use `.Values.podLabels` in service definition.

### DIFF
--- a/charts/grafana/templates/service.yaml
+++ b/charts/grafana/templates/service.yaml
@@ -58,4 +58,7 @@ spec:
       {{- end }}
   selector:
     {{- include "grafana.selectorLabels" . | nindent 4 }}
+    {{- with .Values.podLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
Currently, if you set `.Values.podLabels` in your `values.yaml`, they are not reflected in the service selectors so traffic does not reach Grafana pods.

This simply adds `.Values.podLabels`  to the service selectors.