### PR TITLE
[loki-distributed] adding otlp ingress for loki distributed chart

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.9.6
-version: 0.79.0
+version: 0.79.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -324,6 +324,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | ingress.hosts[0] | string | `"loki.example.com"` |  |
 | ingress.paths.distributor[0] | string | `"/api/prom/push"` |  |
 | ingress.paths.distributor[1] | string | `"/loki/api/v1/push"` |  |
+| ingress.paths.distributor[2] | string | `"/otlp/v1/logs"` |  |
 | ingress.paths.querier[0] | string | `"/api/prom/tail"` |  |
 | ingress.paths.querier[1] | string | `"/loki/api/v1/tail"` |  |
 | ingress.paths.query-frontend[0] | string | `"/loki/api"` |  |

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -989,6 +989,7 @@ ingress:
     distributor:
       - /api/prom/push
       - /loki/api/v1/push
+      - /otlp/v1/logs
     querier:
       - /api/prom/tail
       - /loki/api/v1/tail
@@ -1303,6 +1304,12 @@ gateway:
           }
 
           location = /loki/api/v1/push {
+            set $loki_api_v1_push_backend http://{{ include "loki.distributorFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+            proxy_pass       $loki_api_v1_push_backend:3100$request_uri;
+            proxy_http_version 1.1;
+          }
+
+          location = /otlp/v1/logs {
             set $loki_api_v1_push_backend http://{{ include "loki.distributorFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
             proxy_pass       $loki_api_v1_push_backend:3100$request_uri;
             proxy_http_version 1.1;


### PR DESCRIPTION
Adding OTLP path for the gateway and ingress configs.
This will allow pushing logs from opentelemetry collectors referencing the [docs](https://grafana.com/docs/loki/next/send-data/otel/).