### PR TITLE
[tempo-distributed] fix invalid selector configuration for tokengenjob

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.9.5
+version: 1.9.6
 appVersion: 2.4.1
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.9.5](https://img.shields.io/badge/Version-1.9.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.1](https://img.shields.io/badge/AppVersion-2.4.1-informational?style=flat-square)
+![Version: 1.9.6](https://img.shields.io/badge/Version-1.9.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.1](https://img.shields.io/badge/AppVersion-2.4.1-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/tokengen/tokengen-job.yaml
+++ b/charts/tempo-distributed/templates/tokengen/tokengen-job.yaml
@@ -18,6 +18,8 @@ spec:
   completions: 1
   parallelism: 1
   selector:
+    matchLabels:
+      {{- include "tempo.selectorLabels" $dict | nindent 6 }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
I've run into an error when trying to deploy the helm chart via ArgoCD which is getting stuck on trying to execute the `tokengen-job`.

The error is as follows:

```
  PostSync  Job.batch "tempo-tokengen-job" is invalid: [spec.selector: Required value, spec.template.metadata.labels: Invalid value: map[string]string{"app.kubernetes.io/component":"tokengen-job", "app.kubernetes.io/instance":"tempo", "app.kubernetes.io/managed-by":"Helm", "app.kubernetes.io/name":"tempo", "app.kubernetes.io/version":"2.4.1", "batch.kubernetes.io/controller-uid":"1aef82a1-1901-4360-a92d-bfd2b8ac568c", "batch.kubernetes.io/job-name":"tempo-tokengen-job", "controller-uid":"1aef82a1-1901-4360-a92d-bfd2b8ac568c", "helm.sh/chart":"tempo-distributed-1.9.5", "job-name":"tempo-tokengen-job"}: `selector` does not match template `labels`, spec.selector: Invalid value: "null": field is immutable]
2024-05-03T15:07:55+10:00  batch         Job       tempo    tempo-tokengen-job   Running  SyncFailed    PostSync  job.batch/tempo-tokengen-job created
```

After a bit of investigation, the potential culprit has been found to be the `selector:` which is evaluating to a null value.