### PR TITLE
[tempo-distributed] Removing Job Selector Config

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.9.8
+version: 1.9.9
 appVersion: 2.4.1
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.9.8](https://img.shields.io/badge/Version-1.9.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.1](https://img.shields.io/badge/AppVersion-2.4.1-informational?style=flat-square)
+![Version: 1.9.9](https://img.shields.io/badge/Version-1.9.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.1](https://img.shields.io/badge/AppVersion-2.4.1-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/tokengen/tokengen-job.yaml
+++ b/charts/tempo-distributed/templates/tokengen/tokengen-job.yaml
@@ -17,9 +17,6 @@ spec:
   backoffLimit: 6
   completions: 1
   parallelism: 1
-  selector:
-    matchLabels:
-      {{- include "tempo.selectorLabels" $dict | nindent 6 }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
Many apologies! This is on me for not properly verifying the [Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/) prior to raising my previous PR.

Templating with a config like the following 

```
  selector:
  template:
    metadata:
      labels:
        app.kubernetes.io/component: tokengen-job-2
```

will throw the error: 

```
selector` does not match template `labels`, spec.selector: Invalid value: "null": field is immutable
```

On the other hand, adding in the selector labels will also fail as Kubernetes will throw the following error:

```
 `selector` not auto-generated
```

I've given this a much more rigorous test, and apologies for my previous bad change 🙏 

The Selector should not be manually specified unless otherwise configured in spec. Removing the selector altogether ensures the job configuration is valid, while also allowing for templating without null values causing errors.