### PR TITLE
[grafana] Set `GOMEMLIMIT` environment variable based on container resources

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 9.3.6
+version: 9.4.0
 appVersion: 12.1.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -1196,12 +1196,6 @@ containers:
         value: {{ (get .Values "grafana.ini").paths.plugins }}
       - name: GF_PATHS_PROVISIONING
         value: {{ (get .Values "grafana.ini").paths.provisioning }}
-      {{- if (.Values.resources.limits).cpu }}
-      - name: GOMAXPROCS
-        valueFrom:
-          resourceFieldRef:
-            resource: limits.cpu
-      {{- end }}
       {{- if (.Values.resources.limits).memory }}
       - name: GOMEMLIMIT
         valueFrom:

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -1196,6 +1196,18 @@ containers:
         value: {{ (get .Values "grafana.ini").paths.plugins }}
       - name: GF_PATHS_PROVISIONING
         value: {{ (get .Values "grafana.ini").paths.provisioning }}
+      {{- if (.Values.resources.limits).cpu }}
+      - name: GOMAXPROCS
+        valueFrom:
+          resourceFieldRef:
+            resource: limits.cpu
+      {{- end }}
+      {{- if (.Values.resources.limits).memory }}
+      - name: GOMEMLIMIT
+        valueFrom:
+          resourceFieldRef:
+            resource: limits.memory
+      {{- end }}
       {{- range $key, $value := .Values.envValueFrom }}
       - name: {{ $key | quote }}
         valueFrom:


### PR DESCRIPTION
Set ~~`GOMAXPROCS` and~~ `GOMEMLIMIT` environment variables based on container resources. This should reduce potential CPU throttling and OOMKills on containers.

The [`resourceFieldRef`](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/#downwardapi-resourceFieldRef) is a very specific Kubernetes directive that is created specifically for passing resource-related values, which rounds up the CPU value to the nearest whole number (e.g. 250m to 1) and passes the memory as a numeric value; so `64Mi` would result in the environment variable being set to `67108864`. This by design makes it completely compatible with Go's API.

An example is documented within Kubernetes documentation itself: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#use-container-fields-as-values-for-environment-variables.

Inspired by https://github.com/traefik/traefik-helm-chart/pull/1029.

Implementation notes:
- This was only added to the "main" Grafana container, given it's only relevant for Go-based applications
- This idea can probably be applied to other charts within this repository; I currently have no intention of following-up with this myself, but anyone coming across this, feel free to do so!
