### PR TITLE
[grafana] Update Grafana to 11.0.0

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 7.3.11
-appVersion: 10.4.1
+version: 8.0.0
+appVersion: 11.0.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.com


### PR DESCRIPTION
This PR updates the helm version to the lastest Grafana version.

I have tested this changes inside kube-prometheus-stack which als deploy dashboards and datasources through sidecars.

Everything works here.

Note: I bumped the helm chart version to make end-users fully aware of the potential breaking changes (Grafana 11 itself has some)