### PR TITLE
feat(grafana): make possible to globally override a specific image registry

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 7.3.11
+version: 7.4.0
 appVersion: 10.4.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -150,6 +150,7 @@ need to instead set `global.imageRegistry`.
 | `dashboardsConfigMaps`                    | ConfigMaps reference that contains dashboards | `{}`                                                    |
 | `grafana.ini`                             | Grafana's primary configuration               | `{}`                                                    |
 | `global.imageRegistry`                    | Global image pull registry for all images.    | `null`                                   |
+| `global.imageRegistries`                  | Overrides the Docker registries globally for all images based on their origin registry | `{}`                                     |
 | `global.imagePullSecrets`                 | Global image pull secrets (can be templated). Allows either an array of {name: pullSecret} maps (k8s-style), or an array of strings (more common helm-style).  | `[]`                                                    |
 | `ldap.enabled`                            | Enable LDAP authentication                    | `false`                                                 |
 | `ldap.existingSecret`                     | The name of an existing secret containing the `ldap.toml` file, this must have the key `ldap-toml`. | `""` |

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -29,7 +29,7 @@ initContainers:
 {{- end }}
 {{- if ( and .Values.persistence.enabled .Values.initChownData.enabled ) }}
   - name: init-chown-data
-    {{- $registry := .Values.global.imageRegistry | default .Values.initChownData.image.registry -}}
+    {{- $registry := index .Values.global.imageRegistries .Values.initChownData.image.registry | default .Values.global.imageRegistry | default .Values.initChownData.image.registry -}}
     {{- if .Values.initChownData.image.sha }}
     image: "{{ $registry }}/{{ .Values.initChownData.image.repository }}:{{ .Values.initChownData.image.tag }}@sha256:{{ .Values.initChownData.image.sha }}"
     {{- else }}
@@ -58,7 +58,7 @@ initContainers:
 {{- end }}
 {{- if .Values.dashboards }}
   - name: download-dashboards
-    {{- $registry := .Values.global.imageRegistry | default .Values.downloadDashboardsImage.registry -}}
+    {{- $registry := index .Values.global.imageRegistries .Values.downloadDashboardsImage.registry | default .Values.global.imageRegistry | default .Values.downloadDashboardsImage.registry -}}
     {{- if .Values.downloadDashboardsImage.sha }}
     image: "{{ $registry }}/{{ .Values.downloadDashboardsImage.repository }}:{{ .Values.downloadDashboardsImage.tag }}@sha256:{{ .Values.downloadDashboardsImage.sha }}"
     {{- else }}
@@ -107,7 +107,7 @@ initContainers:
 {{- end }}
 {{- if and .Values.sidecar.alerts.enabled .Values.sidecar.alerts.initAlerts }}
   - name: {{ include "grafana.name" . }}-init-sc-alerts
-    {{- $registry := .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
+    {{- $registry := index .Values.global.imageRegistries .Values.sidecar.image.registry | default .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
     {{- if .Values.sidecar.image.sha }}
     image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
     {{- else }}
@@ -180,7 +180,7 @@ initContainers:
 {{- end }}
 {{- if and .Values.sidecar.datasources.enabled .Values.sidecar.datasources.initDatasources }}
   - name: {{ include "grafana.name" . }}-init-sc-datasources
-    {{- $registry := .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
+    {{- $registry := index .Values.global.imageRegistries .Values.sidecar.image.registry | default .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
     {{- if .Values.sidecar.image.sha }}
     image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
     {{- else }}
@@ -238,7 +238,7 @@ initContainers:
 {{- end }}
 {{- if and .Values.sidecar.notifiers.enabled .Values.sidecar.notifiers.initNotifiers }}
   - name: {{ include "grafana.name" . }}-init-sc-notifiers
-    {{- $registry := .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
+    {{- $registry := index .Values.global.imageRegistries .Values.sidecar.image.registry | default .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
     {{- if .Values.sidecar.image.sha }}
     image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
     {{- else }}
@@ -315,7 +315,7 @@ enableServiceLinks: {{ .Values.enableServiceLinks }}
 containers:
 {{- if and .Values.sidecar.alerts.enabled (not .Values.sidecar.alerts.initAlerts) }}
   - name: {{ include "grafana.name" . }}-sc-alerts
-    {{- $registry := .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
+    {{- $registry := index .Values.global.imageRegistries .Values.sidecar.image.registry | default .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
     {{- if .Values.sidecar.image.sha }}
     image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
     {{- else }}
@@ -422,7 +422,7 @@ containers:
 {{- end}}
 {{- if .Values.sidecar.dashboards.enabled }}
   - name: {{ include "grafana.name" . }}-sc-dashboard
-    {{- $registry := .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
+    {{- $registry := index .Values.global.imageRegistries .Values.sidecar.image.registry | default .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
     {{- if .Values.sidecar.image.sha }}
     image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
     {{- else }}
@@ -538,7 +538,7 @@ containers:
 {{- end}}
 {{- if and .Values.sidecar.datasources.enabled (not .Values.sidecar.datasources.initDatasources) }}
   - name: {{ include "grafana.name" . }}-sc-datasources
-    {{- $registry := .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
+    {{- $registry := index .Values.global.imageRegistries .Values.sidecar.image.registry | default .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
     {{- if .Values.sidecar.image.sha }}
     image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
     {{- else }}
@@ -642,7 +642,7 @@ containers:
 {{- end}}
 {{- if .Values.sidecar.notifiers.enabled }}
   - name: {{ include "grafana.name" . }}-sc-notifiers
-    {{- $registry := .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
+    {{- $registry := index .Values.global.imageRegistries .Values.sidecar.image.registry | default .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
     {{- if .Values.sidecar.image.sha }}
     image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
     {{- else }}
@@ -746,7 +746,7 @@ containers:
 {{- end}}
 {{- if .Values.sidecar.plugins.enabled }}
   - name: {{ include "grafana.name" . }}-sc-plugins
-    {{- $registry := .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
+    {{- $registry := index .Values.global.imageRegistries .Values.sidecar.image.registry | default .Values.global.imageRegistry | default .Values.sidecar.image.registry -}}
     {{- if .Values.sidecar.image.sha }}
     image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
     {{- else }}
@@ -849,7 +849,7 @@ containers:
         mountPath: "/etc/grafana/provisioning/plugins"
 {{- end}}
   - name: {{ .Chart.Name }}
-    {{- $registry := .Values.global.imageRegistry | default .Values.image.registry -}}
+    {{- $registry := index .Values.global.imageRegistries .Values.image.registry | default .Values.global.imageRegistry | default .Values.image.registry -}}
     {{- if .Values.image.sha }}
     image: "{{ $registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}@sha256:{{ .Values.image.sha }}"
     {{- else }}

--- a/charts/grafana/templates/image-renderer-deployment.yaml
+++ b/charts/grafana/templates/image-renderer-deployment.yaml
@@ -65,7 +65,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}-image-renderer
-          {{- $registry := .Values.global.imageRegistry | default .Values.imageRenderer.image.registry -}}
+          {{- $registry := index .Values.global.imageRegistries .Values.imageRenderer.image.registry | default .Values.global.imageRegistry | default .Values.imageRenderer.image.registry -}}
           {{- if .Values.imageRenderer.image.sha }}
           image: "{{ $registry }}/{{ .Values.imageRenderer.image.repository }}:{{ .Values.imageRenderer.image.tag }}@sha256:{{ .Values.imageRenderer.image.sha }}"
           {{- else }}

--- a/charts/grafana/templates/tests/test.yaml
+++ b/charts/grafana/templates/tests/test.yaml
@@ -34,7 +34,7 @@ spec:
   {{- end }}
   containers:
     - name: {{ .Release.Name }}-test
-      image: "{{ .Values.global.imageRegistry | default .Values.testFramework.image.registry }}/{{ .Values.testFramework.image.repository }}:{{ .Values.testFramework.image.tag }}"
+      image: "{{ index .Values.global.imageRegistries .Values.testFramework.image.registry | default .Values.global.imageRegistry | default .Values.testFramework.image.registry }}/{{ .Values.testFramework.image.repository }}:{{ .Values.testFramework.image.tag }}"
       imagePullPolicy: "{{ .Values.testFramework.imagePullPolicy}}"
       command: ["/opt/bats/bin/bats", "-t", "/tests/run.sh"]
       volumeMounts:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -2,6 +2,11 @@ global:
   # -- Overrides the Docker registry globally for all images
   imageRegistry: null
 
+  # -- Overrides the Docker registries globally for all images based on their origin registry
+  imageRegistries: {}
+  # docker.io: "registry.example.com/docker"
+  # quay.io: "registry.example.com/quay"
+
   # To help compatibility with other charts which use global.imagePullSecrets.
   # Allow either an array of {name: pullSecret} maps (k8s-style), or an array of strings (more common helm-style).
   # Can be tempalted.


### PR DESCRIPTION
This feature is necessary in cases where repositories coming from different registries are stored in different namespaces in your registry. For example, this is the case with AWS ECR pull through cache feature, which uses the repository prefix to know where to fetch the image from.