### PR TITLE
[promtail] Fix YAML parsing error

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 3.0.0
-version: 6.16.0
+version: 6.16.1
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 6.16.0](https://img.shields.io/badge/Version-6.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 6.16.1](https://img.shields.io/badge/Version-6.16.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/templates/service-metrics.yaml
+++ b/charts/promtail/templates/service-metrics.yaml
@@ -6,7 +6,9 @@ metadata:
   namespace: {{ include "promtail.namespaceName" . }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
-    {{- toYaml .Values.service.labels | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     {{- toYaml .Values.service.annotations | nindent 4 }}
 spec:


### PR DESCRIPTION
Re-procedure this issue:
```
$ helm pull --untar grafana/promtail --version 6.16.0
$ helm template --set serviceMonitor.enabled=true promtail/
Error: YAML parse error on promtail/templates/service-metrics.yaml: error converting YAML to JSON: yaml: line 11: did not find expected key

Use --debug flag to render out invalid YAML
```