### PR TITLE
[tempo] Fix tempo permissions after update to v1.9.0

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 1.10.2
+version: 1.10.3
 appVersion: 2.5.0
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 1.10.2](https://img.shields.io/badge/Version-1.10.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 1.10.3](https://img.shields.io/badge/Version-1.10.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 
@@ -36,7 +36,7 @@ Grafana Tempo Single Binary Mode
 | podLabels | object | `{}` | Pod (extra) Labels |
 | priorityClassName | string | `nil` | The name of the PriorityClass |
 | replicas | int | `1` | Define the amount of instances |
-| securityContext | object | `{}` | securityContext for container |
+| securityContext | object | `{"fsGroup":10001,"runAsGroup":10001,"runAsNonRoot":true,"runAsUser":10001}` | securityContext for container |
 | service.annotations | object | `{}` |  |
 | service.labels | object | `{}` |  |
 | service.targetPort | string | `""` |  |

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -235,11 +235,11 @@ tempoQuery:
     # readOnlyRootFilesystem: false # fails if true, do not enable
 
 # -- securityContext for container
-securityContext: {}
-  # runAsUser: 65532
-  # runAsGroup: 65532
-  # fsGroup: 65532
-  # runAsNonRoot: true
+securityContext:
+  runAsUser: 10001
+  runAsGroup: 10001
+  fsGroup: 10001
+  runAsNonRoot: true
 
 serviceAccount:
   # -- Specifies whether a ServiceAccount should be created


### PR DESCRIPTION
Tempo [v2.5.0-rc.0](https://github.com/grafana/tempo/releases/tag/v2.5.0-rc.0) is now being run as non-root, see https://github.com/grafana/tempo/pull/2265. Change default values.yaml to avoid having every user apply this to their configuration.