### PR TITLE
[grafana] Introduce toggle for volumeName lookup

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 8.0.2
+version: 8.0.3
 appVersion: 11.0.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 8.2.1
-appVersion: 11.1.1
+version: 8.2.2
+appVersion: 11.1.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.com

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 8.0.1
+version: 8.0.2
 appVersion: 11.0.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/pvc.yaml
+++ b/charts/grafana/templates/pvc.yaml
@@ -25,7 +25,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
-  {{- if (lookup "v1" "PersistentVolumeClaim" (include "grafana.namespace" .) (include "grafana.fullname" .)) }}
+  {{- if and (.Values.persistence.lookupVolumeName) (lookup "v1" "PersistentVolumeClaim" (include "grafana.namespace" .) (include "grafana.fullname" .)) }}
   volumeName: {{ (lookup "v1" "PersistentVolumeClaim" (include "grafana.namespace" .) (include "grafana.fullname" .)).spec.volumeName }}
   {{- end }}
   {{- with .Values.persistence.storageClassName }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -389,6 +389,10 @@ persistence:
     ##
     # sizeLimit: 300Mi
 
+  ## If 'lookupVolumeName' is set to true, Helm will attempt to retrieve
+  ## the current value of 'spec.volumeName' and incorporate it into the template.
+  lookupVolumeName: true
+
 initChownData:
   ## If false, data ownership will not be reset at startup
   ## This allows the grafana-server to be run with an arbitrary user


### PR DESCRIPTION
Fixes #3125

#3041 was introduced without a real problem to mention. 

However, with the lookup function, helm-diff shows always an diff, since the lookup function does not work together with `helm template`.

Since the change is merged, it's very to cut out. In conclusion, I add an toggle to turn off that feature. The toggle is enabled by default to avoid any breaking changes. Power users can decided to turn off that feature if they wish.