### PR TITLE
[grafana] Adding jkroepke as maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 # Unless a later match takes precedence, they will be requested for review when someone opens a pull request.
 * @grafana/helm-charts-admins
 
-/charts/grafana/ @maorfr @torstenwalter @Xtigyro @zanhsieh
+/charts/grafana/ @jkroepke @maorfr @torstenwalter @Xtigyro @zanhsieh
 /charts/loki-distributed/ @grafana/loki-squad @unguiculus @Whyeasy
 /charts/loki-canary/ @grafana/loki-squad @unguiculus @Whyeasy
 /charts/promtail/ @grafana/loki-squad @unguiculus @Whyeasy

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 8.0.2
+version: 8.0.3
 appVersion: 11.0.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
@@ -27,6 +27,8 @@ maintainers:
     email: miroslav.hadzhiev@gmail.com
   - name: torstenwalter
     email: mail@torstenwalter.de
+  - name: jkroepke
+    email: github@jkroepke.de
 type: application
 keywords:
   - monitoring


### PR DESCRIPTION
I'm offering help as maintainer for the Grafana helm chart.

I contribute a lot to this [repository](https://github.com/grafana/helm-charts/pulls?q=is%3Apr+author%3Ajkroepke) and the [loki](https://github.com/grafana/loki/pulls?q=is%3Apr+author%3Ajkroepke) repository. 

Additionally, I'm kube-prometheus-stack chart maintainers and using the grafana helm chart in production.

In case the helm chart maintainer (@zanhsieh, @rtluckie, @maorfr, @Xtigyro, @torstenwalter) agree, I need a invite for that repository.