### PR TITLE
Fix YAML Parsing Error in Promtail Helm Template for Service Metrics

### DIFF
--- a/charts/promtail/templates/service-metrics.yaml
+++ b/charts/promtail/templates/service-metrics.yaml
@@ -6,7 +6,9 @@ metadata:
   namespace: {{ include "promtail.namespaceName" . }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
-    {{- toYaml .Values.service.labels | nindent 4 }}
+    {{- with .labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     {{- toYaml .Values.service.annotations | nindent 4 }}
 spec:


### PR DESCRIPTION
This PR fixes a YAML parse error in the Helm template for the Promtail service metrics. The error occurred due to incorrect indentation and improper handling of labels and annotations.

`Error: YAML parse error on promtail/templates/service-metrics.yaml: error converting YAML to JSON: yaml: line 11: did not find expected key`

**Changes Made**

- Properly indented the labels and annotations sections using the with directive and toYaml function.