### PR TITLE
tempo-vulture: fix yaml indentation error

### DIFF
--- a/charts/tempo-vulture/templates/deployment.yaml
+++ b/charts/tempo-vulture/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "tempo-vulture.labels" . | nindent 4 }}
   {{- with .Values.annotations }}
   annotations:
-    {{- toYaml . | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   minReadySeconds: 10

--- a/charts/tempo-vulture/templates/service.yaml
+++ b/charts/tempo-vulture/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "tempo-vulture.labels" . | nindent 4 }}
   {{- with .Values.annotations }}
   annotations:
-    {{- toYaml . | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   type: ClusterIP


### PR DESCRIPTION
Using the following values:

	tempoAddress:
	  push: "http://p"
	  query: "http://q"
	annotations:
	  foo: bar
	  baz: fop

helm template produced yaml that looked like:

	  annotations:    baz: fop
	    foo: bar

Thye reason was that it was using indent, instead of nindent.