### PR TITLE
[promtail] prefer image.tag for app.kubernetes.io/version

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 3.0.0
-version: 6.16.2
+version: 6.16.3
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 6.16.2](https://img.shields.io/badge/Version-6.16.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 6.16.3](https://img.shields.io/badge/Version-6.16.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 
@@ -119,7 +119,7 @@ The new release which will pick up again from the existing `positions.yaml`.
 | image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | image.registry | string | `"docker.io"` | The Docker registry |
 | image.repository | string | `"grafana/promtail"` | Docker image repository |
-| image.tag | string | `nil` | Overrides the image tag whose default is the chart's appVersion |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart's appVersion |
 | imagePullSecrets | list | `[]` | Image pull secrets for Docker images |
 | initContainer | list | `[]` |  |
 | livenessProbe | object | `{}` | Liveness probe |

--- a/charts/promtail/templates/_helpers.tpl
+++ b/charts/promtail/templates/_helpers.tpl
@@ -36,8 +36,8 @@ Common labels
 {{- define "promtail.labels" -}}
 helm.sh/chart: {{ include "promtail.chart" . }}
 {{ include "promtail.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- if or .Chart.AppVersion .Values.image.tag }}
+app.kubernetes.io/version: {{ mustRegexReplaceAllLiteral "@sha.*" .Values.image.tag "" | default .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -100,7 +100,7 @@ image:
   # -- Docker image repository
   repository: grafana/promtail
   # -- Overrides the image tag whose default is the chart's appVersion
-  tag: null
+  tag: ""
   # -- Docker image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
For example, when I set `image.tag=2.9.8`, I'd like the resulting annotation to be `app.kubernetes.io/version: 2.9.8` instead of the current `app.kubernets.io/version: 2.9.3` which uses the `.Chart.AppVersion`. I've copied from the grafana chart, which already has the correct behaviour.