### PR TITLE
[loki-distributed] fix: force nginx gateway to resolve upstream hostname on missing locations

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.9.8
-version: 0.79.2
+version: 0.79.3
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.79.2](https://img.shields.io/badge/Version-0.79.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.8](https://img.shields.io/badge/AppVersion-2.9.8-informational?style=flat-square)
+![Version: 0.79.3](https://img.shields.io/badge/Version-0.79.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.8](https://img.shields.io/badge/AppVersion-2.9.8-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -1284,16 +1284,20 @@ gateway:
 
           # Ruler
           location ~ /prometheus/api/v1/alerts.* {
-            proxy_pass       http://{{ include "loki.rulerFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+            set $prometheus_api_v1_alerts_backend http://{{ include "loki.rulerFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+            proxy_pass       $prometheus_api_v1_alerts_backend:3100$request_uri;
           }
           location ~ /prometheus/api/v1/rules.* {
-            proxy_pass       http://{{ include "loki.rulerFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+            set $prometheus_api_v1_rules_backend http://{{ include "loki.rulerFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+            proxy_pass       $prometheus_api_v1_rules_backend:3100$request_uri;
           }
           location ~ /api/prom/rules.* {
-            proxy_pass       http://{{ include "loki.rulerFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+            set $api_prom_rules_backend http://{{ include "loki.rulerFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+            proxy_pass       $api_prom_rules_backend:3100$request_uri;
           }
           location ~ /api/prom/alerts.* {
-            proxy_pass       http://{{ include "loki.rulerFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+            set $api_prom_alerts_backend http://{{ include "loki.rulerFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+            proxy_pass       $api_prom_alerts_backend:3100$request_uri;
           }
 
           location ~ /api/prom/.* {


### PR DESCRIPTION
In order to force nginx to resolve hostnames in proxy_pass directive, we
need to set a variable and use it in proxy_pass. Otherswise nginx only
resolves hostnames at boot time.