### PR TITLE
[tempo-distributed] Use memberlistBindPort instead of hardcoded values

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.15.0
+version: 1.15.1
 appVersion: 2.5.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.15.0](https://img.shields.io/badge/Version-1.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 1.15.1](https://img.shields.io/badge/Version-1.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.15.1](https://img.shields.io/badge/Version-1.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 1.15.1](https://img.shields.io/badge/Version-1.15.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/compactor/deployment-compactor.yaml
+++ b/charts/tempo-distributed/templates/compactor/deployment-compactor.yaml
@@ -68,7 +68,7 @@ spec:
           ports:
             - containerPort: 3100
               name: http-metrics
-            - containerPort: 7946
+            - containerPort: {{ include "tempo.memberlistBindPort" . }}
               name: http-memberlist
           {{- with .Values.compactor.extraEnv }}
           env:

--- a/charts/tempo-distributed/templates/distributor/deployment-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/deployment-distributor.yaml
@@ -64,7 +64,7 @@ spec:
           imagePullPolicy: {{ .Values.tempo.image.pullPolicy }}
           name: distributor
           ports:
-            - containerPort: 7946
+            - containerPort: {{ include "tempo.memberlistBindPort" . }}
               name: http-memberlist
               protocol: TCP
             - containerPort: 3100

--- a/charts/tempo-distributed/templates/gossip-ring/service-gossip-ring.yaml
+++ b/charts/tempo-distributed/templates/gossip-ring/service-gossip-ring.yaml
@@ -10,9 +10,9 @@ spec:
   clusterIP: None
   ports:
     - name: gossip-ring
-      port: 7946
+      port: {{ include "tempo.memberlistBindPort" . }}
       protocol: TCP
-      targetPort: http-memberlist
+      targetPort: {{ include "tempo.memberlistBindPort" . }}
       {{- if .Values.tempo.memberlist.appProtocol }}
       appProtocol: {{ .Values.tempo.memberlist.appProtocol }}
       {{- end }}

--- a/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
@@ -85,7 +85,7 @@ spec:
             - name: grpc
               containerPort: 9095
             - name: http-memberlist
-              containerPort: 7946
+              containerPort: {{ include "tempo.memberlistBindPort" . }}
             - name: http-metrics
               containerPort: 3100
           {{- with .Values.ingester.extraEnv }}

--- a/charts/tempo-distributed/templates/querier/deployment-querier.yaml
+++ b/charts/tempo-distributed/templates/querier/deployment-querier.yaml
@@ -68,7 +68,7 @@ spec:
           imagePullPolicy: {{ .Values.tempo.image.pullPolicy }}
           name: querier
           ports:
-            - containerPort: 7946
+            - containerPort: {{ include "tempo.memberlistBindPort" . }}
               name: http-memberlist
               protocol: TCP
             - containerPort: 3100


### PR DESCRIPTION
We needed an easy way to set a different memberlist bind_port for Tempo to prevent gossip-ring collusion between our prod and stage deployment in k8s, because setting cluster_label didn't completely work for us.

```
memberlist:
  abort_if_cluster_join_fails: false
  bind_addr: []
  bind_port: 7947
  cluster_label: tempo-stage
  cluster_label_verification_disabled: false
  gossip_interval: 1s
  gossip_nodes: 2
  gossip_to_dead_nodes_time: 30s
  join_members:
  - dns+tempo-stage-deployment-gossip-ring:7947
  leave_timeout: 5s
  left_ingesters_timeout: 5m
  max_join_backoff: 1m
  max_join_retries: 10
  min_join_backoff: 1s
  node_name: ""
  packet_dial_timeout: 5s
  packet_write_timeout: 5s
  pull_push_interval: 30s
  randomize_node_name: true
  rejoin_interval: 0s
  retransmit_factor: 2
  stream_timeout: 10s
```