### PR TITLE
[grafana] Clarify documentation for serviceMonitor.enabled

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 8.3.1
+version: 8.3.2
 appVersion: 11.1.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -242,7 +242,7 @@ service:
   appProtocol: ""
 
 serviceMonitor:
-  ## If true, a ServiceMonitor CRD is created for a prometheus operator
+  ## If true, a ServiceMonitor CR is created for a prometheus operator
   ## https://github.com/coreos/prometheus-operator
   ##
   enabled: false


### PR DESCRIPTION
This PR aims to clarify the documentation of the `serviceMonitor.enabled` setting which does not create a `CustomResourceDefinition` (CRD) but a `CustomResource` (CR) instead,
The CRD is like a class definition, the CR is an instance of that class.

I stumbled upon this and thought that this clarification might resolve some confusion for other users :)