### PR TITLE
[grafana] Removed dashboard labels from dashboard-json-configmap

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 8.3.3
+version: 8.3.4
 appVersion: 11.1.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,10 +1,6 @@
 apiVersion: v2
 name: grafana
-<<<<<<< HEAD
-version: 8.3.4
-=======
-version: 8.3.5
->>>>>>> upstream/main
+version: 8.3.6
 appVersion: 11.1.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 8.3.2
+version: 8.3.3
 appVersion: 11.1.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/dashboards-json-configmap.yaml
+++ b/charts/grafana/templates/dashboards-json-configmap.yaml
@@ -9,9 +9,6 @@ metadata:
   labels:
     {{- include "grafana.labels" $ | nindent 4 }}
     dashboard-provider: {{ $provider }}
-    {{- if $.Values.sidecar.dashboards.enabled }}
-    {{ $.Values.sidecar.dashboards.label }}: {{ $.Values.sidecar.dashboards.labelValue | quote }}
-    {{- end }}
 {{- if $dashboards }}
 data:
 {{- $dashboardFound := false }}


### PR DESCRIPTION
Remove the dashboard labels from dashboard-json-configmaps, as these are loaded seperately. 
This fixes: #3072
