### PR TITLE
[tempo-distributed] Fix tempo-distributed gateway, metrics-generator and distributor rollout getting stuck when replicas==node count

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.14.0
+version: 1.14.1
 appVersion: 2.5.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/templates/distributor/deployment-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/deployment-distributor.yaml
@@ -19,6 +19,10 @@ spec:
   selector:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6 }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/charts/tempo-distributed/templates/gateway/deployment-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/deployment-gateway.yaml
@@ -16,6 +16,10 @@ spec:
   selector:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6 }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   template:
     metadata:
       annotations:

--- a/charts/tempo-distributed/templates/metrics-generator/deployment-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/deployment-metrics-generator.yaml
@@ -18,6 +18,10 @@ spec:
   selector:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6 }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   template:
     metadata:
       labels:


### PR DESCRIPTION
This PR adds a rollout strategy to the gateway, metrics-generator and distributor component deployments in order to fix rollouts getting stuck when the number of nodes is equal to the number of replicas

The same rollout strategy is already present on querier, query-frontend and compactor