### PR TITLE
[promtail] allow to inject templates

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 3.0.0
-version: 6.17.0
+version: 6.16.6
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 3.0.0
-version: 6.16.4
+version: 6.17.0
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 6.17.0](https://img.shields.io/badge/Version-6.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 6.16.6](https://img.shields.io/badge/Version-6.16.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 6.16.4](https://img.shields.io/badge/Version-6.16.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 6.17.0](https://img.shields.io/badge/Version-6.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 

--- a/charts/promtail/templates/_pod.tpl
+++ b/charts/promtail/templates/_pod.tpl
@@ -26,7 +26,7 @@ spec:
   {{- end }}
   {{- with .Values.initContainer }}
   initContainers:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
   {{- with .Values.global.imagePullSecrets | default .Values.imagePullSecrets }}
   imagePullSecrets:
@@ -166,6 +166,6 @@ spec:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- with .Values.extraVolumes }}
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
In this PR the `extraVolumes` and `initContainers` can be filled in with templates in a parent chart.

For the `initContainers` it allows to for example inject a container that waits until kafka is ready. From the context of a parent chart, a service would be created where the name for example is `{{ .Release.Name }}-kafka`. This could for example be injected in `kcat` to check if kafka is ready.

It's also possible now to include a secret that's created in a parent chart (with the release name included in the name). This could be useful to inject a password using `password_file` with a file coming from a volume made with that secret.

This could for example look like the following in a values file of a parent chart.
Note that `{{ $.Release.Name }}-loki-gateway-auth` is a secret here with usernames as keys and the corresponding password as a value within it.

```yaml
promtail:
  config:
    enabled: true
    clients:
      - url: http://{{ .Release.Name }}-loki-gateway.{{ .Release.Namespace }}:80/loki/api/v1/push
        tenant_id: logs
        basic_auth:
          username: promtail
          password_file: /etc/promtail/secrets/password
  
  extraVolumeMounts:
    - name: loki-gateway-password
      mountPath: /etc/promtail/secrets

  extraVolumes:
    - name: loki-gateway-password
      secret:
        secretName: "{{ $.Release.Name }}-loki-gateway-auth"
        items:
          - key: promtail
            path: password
```
