### PR TITLE
[grafana] add value to make extraConfigmapMounts and extraSecretMounts optional

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 8.3.7
+version: 8.4.0
 appVersion: 11.1.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -1156,6 +1156,9 @@ volumes:
   - name: {{ tpl .name $root }}
     configMap:
       name: {{ tpl .configMap $root }}
+      {{- with .optional }}
+      optional: {{ . }}
+      {{- end }}
       {{- with .items }}
       items:
         {{- toYaml . | nindent 8 }}
@@ -1261,6 +1264,9 @@ volumes:
     secret:
       secretName: {{ .secretName }}
       defaultMode: {{ .defaultMode }}
+      {{- with .optional }}
+      optional: {{ . }}
+      {{- end }}
       {{- with .items }}
       items:
         {{- toYaml . | nindent 8 }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -164,6 +164,7 @@ extraConfigmapMounts: []
   #   subPath: certificates.crt # (optional)
   #   configMap: certs-configmap
   #   readOnly: true
+  #   optional: false
 
 
 extraEmptyDirMounts: []
@@ -539,6 +540,7 @@ extraSecretMounts: []
   #   mountPath: /etc/secrets
   #   secretName: grafana-secret-files
   #   readOnly: true
+  #   optional: false
   #   subPath: ""
   #
   # for AWS EKS (cloudwatch) use the following (see also instruction in env: above)


### PR DESCRIPTION
Hi there, we are using that feature a lot but recently ran into some kind of race condition because a referenced ConfigMap wasn't existing yet. I noticed that there is now also an alerting sidecar which will probably improve our situation, but I still wanted to contribute this small changes which gives one the option to make the extraConfigmapMounts optional.