### PR TITLE
[tempo-distributed] Set ingester availability_zone when zoneAwareReplication is enabled.

### DIFF
--- a/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
@@ -73,6 +73,9 @@ spec:
       containers:
         - args:
             - -target=ingester
+            {{- if .Values.ingester.zoneAwareReplication.enabled }}
+            - -config.expand-env=true
+            {{- end }}
             - -config.file=/conf/tempo.yaml
             - -mem-ballast-size-mbs=1024
             {{- with .Values.ingester.extraArgs }}
@@ -88,9 +91,19 @@ spec:
               containerPort: {{ include "tempo.memberlistBindPort" . }}
             - name: http-metrics
               containerPort: 3100
+          {{- if .Values.ingester.zoneAwareReplication.enabled }}
+          env:
+            - name: AVAILABILITY_ZONE
+              value: {{ $zoneName }}
+          {{- end }}
+          {{- with .Values.ingester.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- else }}
           {{- with .Values.ingester.extraEnv }}
           env:
             {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- with .Values.ingester.extraEnvFrom }}
           envFrom:

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -1332,6 +1332,7 @@ config: |
       ring:
         replication_factor: {{ .Values.ingester.config.replication_factor }}
         {{- if .Values.ingester.zoneAwareReplication.enabled }}
+        availability_zone: ${AVAILABILITY_ZONE}
         zone_awareness_enabled: true
         {{- end }}
         kvstore:


### PR DESCRIPTION
This PR updates the config template and statefulset to ensure the `availability_zone` is set for the ingester when zoneAwareReplication is enabled.

This resolves issue: https://github.com/grafana/helm-charts/issues/3264