### PR TITLE
Fix network policy always applying to ingress

### DIFF
--- a/charts/grafana/templates/networkpolicy.yaml
+++ b/charts/grafana/templates/networkpolicy.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- end }}
 spec:
   policyTypes:
-    {{- if .Values.networkPolicy.ingress }}
+    {{- if .Values.networkPolicy.ingress.enabled }}
     - Ingress
     {{- end }}
     {{- if .Values.networkPolicy.egress.enabled }}


### PR DESCRIPTION
The if statement does not target the 'enabled' property, but the whole map of attributes. This leads to the network policy always listing the 'Ingress' policy type, which disrupts legitimate traffic.

fixes: https://github.com/grafana/helm-charts/issues/3268