### PR TITLE
[grafana-sampling] upgrade to grafana alloy

### DIFF
--- a/charts/grafana-sampling/Chart.lock
+++ b/charts/grafana-sampling/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
-- name: grafana-agent
+- name: alloy
   repository: https://grafana.github.io/helm-charts
-  version: 0.36.0
-- name: grafana-agent
+  version: 0.6.0
+- name: alloy
   repository: https://grafana.github.io/helm-charts
-  version: 0.36.0
-digest: sha256:6d04a55dce2c09c4c250c6453e0d58f7280750bf04fce51027b4e235062413e5
-generated: "2024-03-11T15:41:30.921516-07:00"
+  version: 0.6.0
+digest: sha256:e9dbff0d3707c403c1fb645eb33920a2219cc3156358134537e89caf39c588a5
+generated: "2024-08-14T10:41:47.606272-07:00"

--- a/charts/grafana-sampling/Chart.yaml
+++ b/charts/grafana-sampling/Chart.yaml
@@ -2,17 +2,17 @@ apiVersion: v2
 name: grafana-sampling
 description: A Helm chart for a layered OTLP tail sampling and metrics generation pipeline.
 type: application
-version: 0.1.1
-appVersion: "v0.40.2"
+version: 1.0.0
+appVersion: "v1.3.0"
 sources:
-  - https://github.com/grafana/agent
+  - https://github.com/grafana/alloy
   - https://grafana.com/docs/grafana-cloud/monitor-applications/application-observability/setup/sampling/tail/
 dependencies:
-  - name: grafana-agent
-    version: 0.36.0
+  - name: alloy
+    version: 0.6.0
     repository: https://grafana.github.io/helm-charts
-    alias: grafana-agent-deployment
-  - name: grafana-agent
-    version: 0.36.0
+    alias: alloy-deployment
+  - name: alloy
+    version: 0.6.0
     repository: https://grafana.github.io/helm-charts
-    alias: grafana-agent-statefulset
+    alias: alloy-statefulset

--- a/charts/grafana-sampling/README.md
+++ b/charts/grafana-sampling/README.md
@@ -1,10 +1,37 @@
 # grafana-sampling
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.40.2](https://img.shields.io/badge/AppVersion-v0.40.2-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
 
 A Helm chart for a layered OTLP tail sampling and metrics generation pipeline.
 
-This chart deploys the following architecture to your environment:
+## Breaking change announcements
+
+### **v1.0.0**
+
+Grafana Agent has been replaced with [Grafana Alloy](https://grafana.com/oss/alloy-opentelemetry-collector/)!
+
+These sections in your values file will need to be renamed:
+
+| Old                         | New                 | Purpose                                        |
+|-----------------------------|---------------------|------------------------------------------------|
+| `grafana-agent-deployment`  | `alloy-deployment`  | Settings for the Alloy load balancing instance |
+| `grafana-agent-statefulset` | `alloy-statefulset` | Settings for the Alloy tail sampling instance  |
+
+For example, if you have something like this:
+
+```yaml
+grafana-agent-statefulset:
+  agent:
+```
+
+you will need to change it to this:
+
+```yaml
+alloy-statefulset:
+  alloy:
+`````
+
+This chart deploys the following architecture to your environment (note the agents have been replaced with Alloy):
 ![Photo of sampling architecture](./sampling-architecture.png)
 
 Note: by default, only OTLP traces are accepted at the load balancing layer.
@@ -22,13 +49,13 @@ Use the following command to install the chart with the release name `my-release
 
 ```console
 helm install my-release grafana/grafana-sampling --values - <<EOF | less
-grafana-agent-statefulset:
-  agent:
+alloy-statefulset:
+  alloy:
     extraEnv:
       - name: GRAFANA_CLOUD_API_KEY
         value: <REQUIRED>
       - name: GRAFANA_CLOUD_PROMETHEUS_URL
-        value: <REQUIRED>
+        value: <REQUIRED> # This should include /api/prom/push uri
       - name: GRAFANA_CLOUD_PROMETHEUS_USERNAME
         value: <REQUIRED>
       - name: GRAFANA_CLOUD_TEMPO_ENDPOINT
@@ -62,61 +89,62 @@ A major chart version change indicates that there is an incompatible breaking ch
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| grafana-agent-deployment.agent.configMap.create | bool | `false` |  |
-| grafana-agent-deployment.agent.extraPorts[0].name | string | `"otlp-grpc"` |  |
-| grafana-agent-deployment.agent.extraPorts[0].port | int | `4317` |  |
-| grafana-agent-deployment.agent.extraPorts[0].protocol | string | `"TCP"` |  |
-| grafana-agent-deployment.agent.extraPorts[0].targetPort | int | `4317` |  |
-| grafana-agent-deployment.agent.extraPorts[1].name | string | `"otlp-http"` |  |
-| grafana-agent-deployment.agent.extraPorts[1].port | int | `4318` |  |
-| grafana-agent-deployment.agent.extraPorts[1].protocol | string | `"TCP"` |  |
-| grafana-agent-deployment.agent.extraPorts[1].targetPort | int | `4318` |  |
-| grafana-agent-deployment.agent.resources.requests.cpu | string | `"1"` |  |
-| grafana-agent-deployment.agent.resources.requests.memory | string | `"2G"` |  |
-| grafana-agent-deployment.controller.autoscaling.enabled | bool | `false` | Creates a HorizontalPodAutoscaler for controller type deployment. |
-| grafana-agent-deployment.controller.autoscaling.maxReplicas | int | `5` | The upper limit for the number of replicas to which the autoscaler can scale up. |
-| grafana-agent-deployment.controller.autoscaling.minReplicas | int | `2` | The lower limit for the number of replicas to which the autoscaler can scale down. |
-| grafana-agent-deployment.controller.autoscaling.targetCPUUtilizationPercentage | int | `0` | Average CPU utilization across all relevant pods, a percentage of the requested value of the resource for the pods. Setting `targetCPUUtilizationPercentage` to 0 will disable CPU scaling. |
-| grafana-agent-deployment.controller.autoscaling.targetMemoryUtilizationPercentage | int | `80` | Average Memory utilization across all relevant pods, a percentage of the requested value of the resource for the pods. Setting `targetMemoryUtilizationPercentage` to 0 will disable Memory scaling. |
-| grafana-agent-deployment.controller.replicas | int | `1` |  |
-| grafana-agent-deployment.controller.type | string | `"deployment"` |  |
-| grafana-agent-deployment.nameOverride | string | `"deployment"` | Do not change this. |
-| grafana-agent-statefulset.agent.configMap.create | bool | `false` |  |
-| grafana-agent-statefulset.agent.extraEnv[0].name | string | `"GRAFANA_CLOUD_API_KEY"` |  |
-| grafana-agent-statefulset.agent.extraEnv[0].value | string | `"<REQUIRED>"` |  |
-| grafana-agent-statefulset.agent.extraEnv[1].name | string | `"GRAFANA_CLOUD_PROMETHEUS_URL"` |  |
-| grafana-agent-statefulset.agent.extraEnv[1].value | string | `"<REQUIRED>"` |  |
-| grafana-agent-statefulset.agent.extraEnv[2].name | string | `"GRAFANA_CLOUD_PROMETHEUS_USERNAME"` |  |
-| grafana-agent-statefulset.agent.extraEnv[2].value | string | `"<REQUIRED>"` |  |
-| grafana-agent-statefulset.agent.extraEnv[3].name | string | `"GRAFANA_CLOUD_TEMPO_ENDPOINT"` |  |
-| grafana-agent-statefulset.agent.extraEnv[3].value | string | `"<REQUIRED>"` |  |
-| grafana-agent-statefulset.agent.extraEnv[4].name | string | `"GRAFANA_CLOUD_TEMPO_USERNAME"` |  |
-| grafana-agent-statefulset.agent.extraEnv[4].value | string | `"<REQUIRED>"` |  |
-| grafana-agent-statefulset.agent.extraEnv[5].name | string | `"POD_UID"` |  |
-| grafana-agent-statefulset.agent.extraEnv[5].valueFrom.fieldRef.apiVersion | string | `"v1"` |  |
-| grafana-agent-statefulset.agent.extraEnv[5].valueFrom.fieldRef.fieldPath | string | `"metadata.uid"` |  |
-| grafana-agent-statefulset.agent.extraPorts[0].name | string | `"otlp-grpc"` |  |
-| grafana-agent-statefulset.agent.extraPorts[0].port | int | `4317` |  |
-| grafana-agent-statefulset.agent.extraPorts[0].protocol | string | `"TCP"` |  |
-| grafana-agent-statefulset.agent.extraPorts[0].targetPort | int | `4317` |  |
-| grafana-agent-statefulset.agent.resources.requests.cpu | string | `"1"` |  |
-| grafana-agent-statefulset.agent.resources.requests.memory | string | `"2G"` |  |
-| grafana-agent-statefulset.controller.autoscaling.enabled | bool | `false` | Creates a HorizontalPodAutoscaler for controller type deployment. |
-| grafana-agent-statefulset.controller.autoscaling.maxReplicas | int | `5` | The upper limit for the number of replicas to which the autoscaler can scale up. |
-| grafana-agent-statefulset.controller.autoscaling.minReplicas | int | `2` | The lower limit for the number of replicas to which the autoscaler can scale down. |
-| grafana-agent-statefulset.controller.autoscaling.targetCPUUtilizationPercentage | int | `0` | Average CPU utilization across all relevant pods, a percentage of the requested value of the resource for the pods. Setting `targetCPUUtilizationPercentage` to 0 will disable CPU scaling. |
-| grafana-agent-statefulset.controller.autoscaling.targetMemoryUtilizationPercentage | int | `80` | Average Memory utilization across all relevant pods, a percentage of the requested value of the resource for the pods. Setting `targetMemoryUtilizationPercentage` to 0 will disable Memory scaling. |
-| grafana-agent-statefulset.controller.replicas | int | `1` |  |
-| grafana-agent-statefulset.controller.type | string | `"statefulset"` |  |
-| grafana-agent-statefulset.nameOverride | string | `"statefulset"` | Do not change this. |
-| grafana-agent-statefulset.rbac.create | bool | `false` |  |
-| grafana-agent-statefulset.service.clusterIP | string | `"None"` |  |
-| grafana-agent-statefulset.serviceAccount.create | bool | `false` |  |
+| alloy-deployment.alloy.configMap.create | bool | `false` |  |
+| alloy-deployment.alloy.extraPorts[0].name | string | `"otlp-grpc"` |  |
+| alloy-deployment.alloy.extraPorts[0].port | int | `4317` |  |
+| alloy-deployment.alloy.extraPorts[0].protocol | string | `"TCP"` |  |
+| alloy-deployment.alloy.extraPorts[0].targetPort | int | `4317` |  |
+| alloy-deployment.alloy.extraPorts[1].name | string | `"otlp-http"` |  |
+| alloy-deployment.alloy.extraPorts[1].port | int | `4318` |  |
+| alloy-deployment.alloy.extraPorts[1].protocol | string | `"TCP"` |  |
+| alloy-deployment.alloy.extraPorts[1].targetPort | int | `4318` |  |
+| alloy-deployment.alloy.resources.requests.cpu | string | `"1"` |  |
+| alloy-deployment.alloy.resources.requests.memory | string | `"2G"` |  |
+| alloy-deployment.controller.autoscaling.enabled | bool | `false` | Creates a HorizontalPodAutoscaler for controller type deployment. |
+| alloy-deployment.controller.autoscaling.maxReplicas | int | `5` | The upper limit for the number of replicas to which the autoscaler can scale up. |
+| alloy-deployment.controller.autoscaling.minReplicas | int | `2` | The lower limit for the number of replicas to which the autoscaler can scale down. |
+| alloy-deployment.controller.autoscaling.targetCPUUtilizationPercentage | int | `0` | Average CPU utilization across all relevant pods, a percentage of the requested value of the resource for the pods. Setting `targetCPUUtilizationPercentage` to 0 will disable CPU scaling. |
+| alloy-deployment.controller.autoscaling.targetMemoryUtilizationPercentage | int | `80` | Average Memory utilization across all relevant pods, a percentage of the requested value of the resource for the pods. Setting `targetMemoryUtilizationPercentage` to 0 will disable Memory scaling. |
+| alloy-deployment.controller.replicas | int | `1` |  |
+| alloy-deployment.controller.type | string | `"deployment"` |  |
+| alloy-deployment.nameOverride | string | `"deployment"` | Do not change this. |
+| alloy-statefulset.alloy.configMap.create | bool | `false` |  |
+| alloy-statefulset.alloy.extraEnv[0].name | string | `"GRAFANA_CLOUD_API_KEY"` |  |
+| alloy-statefulset.alloy.extraEnv[0].value | string | `"<REQUIRED>"` |  |
+| alloy-statefulset.alloy.extraEnv[1].name | string | `"GRAFANA_CLOUD_PROMETHEUS_URL"` |  |
+| alloy-statefulset.alloy.extraEnv[1].value | string | `"<REQUIRED>"` |  |
+| alloy-statefulset.alloy.extraEnv[2].name | string | `"GRAFANA_CLOUD_PROMETHEUS_USERNAME"` |  |
+| alloy-statefulset.alloy.extraEnv[2].value | string | `"<REQUIRED>"` |  |
+| alloy-statefulset.alloy.extraEnv[3].name | string | `"GRAFANA_CLOUD_TEMPO_ENDPOINT"` |  |
+| alloy-statefulset.alloy.extraEnv[3].value | string | `"<REQUIRED>"` |  |
+| alloy-statefulset.alloy.extraEnv[4].name | string | `"GRAFANA_CLOUD_TEMPO_USERNAME"` |  |
+| alloy-statefulset.alloy.extraEnv[4].value | string | `"<REQUIRED>"` |  |
+| alloy-statefulset.alloy.extraEnv[5].name | string | `"POD_UID"` |  |
+| alloy-statefulset.alloy.extraEnv[5].valueFrom.fieldRef.apiVersion | string | `"v1"` |  |
+| alloy-statefulset.alloy.extraEnv[5].valueFrom.fieldRef.fieldPath | string | `"metadata.uid"` |  |
+| alloy-statefulset.alloy.extraPorts[0].name | string | `"otlp-grpc"` |  |
+| alloy-statefulset.alloy.extraPorts[0].port | int | `4317` |  |
+| alloy-statefulset.alloy.extraPorts[0].protocol | string | `"TCP"` |  |
+| alloy-statefulset.alloy.extraPorts[0].targetPort | int | `4317` |  |
+| alloy-statefulset.alloy.resources.requests.cpu | string | `"1"` |  |
+| alloy-statefulset.alloy.resources.requests.memory | string | `"2G"` |  |
+| alloy-statefulset.controller.autoscaling.enabled | bool | `false` | Creates a HorizontalPodAutoscaler for controller type deployment. |
+| alloy-statefulset.controller.autoscaling.maxReplicas | int | `5` | The upper limit for the number of replicas to which the autoscaler can scale up. |
+| alloy-statefulset.controller.autoscaling.minReplicas | int | `2` | The lower limit for the number of replicas to which the autoscaler can scale down. |
+| alloy-statefulset.controller.autoscaling.targetCPUUtilizationPercentage | int | `0` | Average CPU utilization across all relevant pods, a percentage of the requested value of the resource for the pods. Setting `targetCPUUtilizationPercentage` to 0 will disable CPU scaling. |
+| alloy-statefulset.controller.autoscaling.targetMemoryUtilizationPercentage | int | `80` | Average Memory utilization across all relevant pods, a percentage of the requested value of the resource for the pods. Setting `targetMemoryUtilizationPercentage` to 0 will disable Memory scaling. |
+| alloy-statefulset.controller.replicas | int | `1` |  |
+| alloy-statefulset.controller.type | string | `"statefulset"` |  |
+| alloy-statefulset.nameOverride | string | `"statefulset"` | Do not change this. |
+| alloy-statefulset.rbac.create | bool | `false` |  |
+| alloy-statefulset.service.clusterIP | string | `"None"` |  |
+| alloy-statefulset.serviceAccount.create | bool | `false` |  |
 | metricsGeneration.dimensions | list | `["service.namespace","service.version","deployment.environment","k8s.cluster.name"]` | Additional dimensions to add to generated metrics. |
 | metricsGeneration.enabled | bool | `true` | Toggle generation of spanmetrics and servicegraph metrics. |
+| metricsGeneration.legacy | bool | `false` | Use legacy metric names that match those used by the Tempo metrics generator. |
 | sampling.decisionWait | string | `"15s"` | Wait time since the first span of a trace before making a sampling decision. |
 | sampling.enabled | bool | `true` | Toggle tail sampling. |
-| sampling.extraPolicies | string | A policy to sample long requests is added by default. | User-defined policies in river format. |
+| sampling.extraPolicies | string | A policy to sample long requests is added by default. | User-defined policies in alloy format. |
 | sampling.failedRequests.percentage | int | `50` | Percentage of failed requests to sample. |
 | sampling.failedRequests.sample | bool | `false` | Toggle sampling failed requests. |
 | sampling.successfulRequests.percentage | int | `10` | Percentage of successful requests to sample. |

--- a/charts/grafana-sampling/README.md
+++ b/charts/grafana-sampling/README.md
@@ -141,7 +141,7 @@ A major chart version change indicates that there is an incompatible breaking ch
 | alloy-statefulset.serviceAccount.create | bool | `false` |  |
 | metricsGeneration.dimensions | list | `["service.namespace","service.version","deployment.environment","k8s.cluster.name"]` | Additional dimensions to add to generated metrics. |
 | metricsGeneration.enabled | bool | `true` | Toggle generation of spanmetrics and servicegraph metrics. |
-| metricsGeneration.legacy | bool | `false` | Use legacy metric names that match those used by the Tempo metrics generator. |
+| metricsGeneration.legacy | bool | `true` | Use legacy metric names that match those used by the Tempo metrics generator. |
 | sampling.decisionWait | string | `"15s"` | Wait time since the first span of a trace before making a sampling decision. |
 | sampling.enabled | bool | `true` | Toggle tail sampling. |
 | sampling.extraPolicies | string | A policy to sample long requests is added by default. | User-defined policies in alloy format. |

--- a/charts/grafana-sampling/README.md.gotmpl
+++ b/charts/grafana-sampling/README.md.gotmpl
@@ -4,11 +4,37 @@
 
 {{ template "chart.description" . }}
 
-This chart deploys the following architecture to your environment:
+## Breaking change announcements
+
+### **v1.0.0**
+
+Grafana Agent has been replaced with [Grafana Alloy](https://grafana.com/oss/alloy-opentelemetry-collector/)!
+
+These sections in your values file will need to be renamed:
+
+| Old                         | New                 | Purpose                                        |
+|-----------------------------|---------------------|------------------------------------------------|
+| `grafana-agent-deployment`  | `alloy-deployment`  | Settings for the Alloy load balancing instance |
+| `grafana-agent-statefulset` | `alloy-statefulset` | Settings for the Alloy tail sampling instance  |
+
+For example, if you have something like this:
+
+```yaml
+grafana-agent-statefulset:
+  agent:
+```
+
+you will need to change it to this:
+
+```yaml
+alloy-statefulset:
+  alloy:
+`````
+
+This chart deploys the following architecture to your environment (note the agents have been replaced with Alloy):
 ![Photo of sampling architecture](./sampling-architecture.png)
 
 Note: by default, only OTLP traces are accepted at the load balancing layer.
-
 
 ## Chart Repo
 
@@ -23,13 +49,13 @@ Use the following command to install the chart with the release name `my-release
 
 ```console
 helm install my-release grafana/grafana-sampling --values - <<EOF | less
-grafana-agent-statefulset:
-  agent:
+alloy-statefulset:
+  alloy:
     extraEnv:
       - name: GRAFANA_CLOUD_API_KEY
         value: <REQUIRED>
       - name: GRAFANA_CLOUD_PROMETHEUS_URL
-        value: <REQUIRED>
+        value: <REQUIRED> # This should include /api/prom/push uri
       - name: GRAFANA_CLOUD_PROMETHEUS_USERNAME
         value: <REQUIRED>
       - name: GRAFANA_CLOUD_TEMPO_ENDPOINT

--- a/charts/grafana-sampling/templates/_alloy_config_deployment.alloy.txt
+++ b/charts/grafana-sampling/templates/_alloy_config_deployment.alloy.txt
@@ -1,4 +1,4 @@
-{{- define "agent.config.deployment" -}}
+{{- define "alloy.config.deployment" -}}
   {{- include "deployment.receiver.otlp" . }}
   {{- include "deployment.processor.batch" . }}
   {{- include "deployment.exporter.loadbalancing" . }}

--- a/charts/grafana-sampling/templates/_alloy_config_statefulset.alloy.txt
+++ b/charts/grafana-sampling/templates/_alloy_config_statefulset.alloy.txt
@@ -1,9 +1,11 @@
-{{- define "agent.config.statefulset" -}}
+{{- define "alloy.config.statefulset" -}}
   {{- include "statefulset.receiver.otlp" . }}
   {{- if .Values.metricsGeneration.enabled -}}
     {{- include "statefulset.connector.spanmetrics" . }}
     {{- include "statefulset.processor.transform.drop_unneeded_resource_attributes" . }}
-    {{- include "statefulset.processor.transform.use_grafana_metric_names" . }}
+    {{- if .Values.metricsGeneration.legacy -}}
+        {{- include "statefulset.processor.transform.use_grafana_metric_names" . }}
+    {{- end -}}
     {{- include "statefulset.processor.filter" . }}
     {{- include "statefulset.connector.servicegraph" . }}
     {{- include "statefulset.exporter.prometheus" . }}

--- a/charts/grafana-sampling/templates/_helpers.tpl
+++ b/charts/grafana-sampling/templates/_helpers.tpl
@@ -1,9 +1,9 @@
-{{/* use the release name as the serviceAccount name for deployment and statefulset agents */}}
-{{- define "grafana-agent.serviceAccountName" -}}
+{{/* use the release name as the serviceAccount name for deployment and statefulset collectors */}}
+{{- define "alloy.serviceAccountName" -}}
 {{- default .Release.Name }}
 {{- end }}
 
-{{/* Calculate name of image ID to use for "grafana-agent". */}}
-{{- define "grafana-agent.imageId" -}}
+{{/* Calculate name of image ID to use for "alloy". */}}
+{{- define "alloy.imageId" -}}
 {{- printf ":%s" .Chart.AppVersion }}
 {{- end }}

--- a/charts/grafana-sampling/templates/_otelcol_auth_basic.alloy.txt
+++ b/charts/grafana-sampling/templates/_otelcol_auth_basic.alloy.txt
@@ -1,6 +1,6 @@
 {{- define "auth.basic" -}}
 otelcol.auth.basic "grafana_cloud_tempo" {
-  // https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.auth.basic/
+  // https://grafana.com/docs/alloy/latest/reference/components/otelcol.auth.basic/
   username = env("GRAFANA_CLOUD_TEMPO_USERNAME")
   password = env("GRAFANA_CLOUD_API_KEY")
 }

--- a/charts/grafana-sampling/templates/_otelcol_connector_servicegraph.alloy.txt
+++ b/charts/grafana-sampling/templates/_otelcol_connector_servicegraph.alloy.txt
@@ -1,6 +1,6 @@
 {{- define "statefulset.connector.servicegraph" -}}
 otelcol.connector.servicegraph "default" {
-  // https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.connector.servicegraph/
+  // https://grafana.com/docs/alloy/latest/reference/components/otelcol.connector.servicegraph/
   dimensions = [
     {{- range $.Values.metricsGeneration.dimensions }}
     {{ . | quote }},

--- a/charts/grafana-sampling/templates/_otelcol_connector_spanmetrics.alloy.txt
+++ b/charts/grafana-sampling/templates/_otelcol_connector_spanmetrics.alloy.txt
@@ -1,13 +1,15 @@
 {{- define "statefulset.connector.spanmetrics" -}}
 otelcol.connector.spanmetrics "default" {
-  // https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.connector.spanmetrics/
+  // https://grafana.com/docs/alloy/latest/reference/components/otelcol.connector.spanmetrics/
   {{- range $.Values.metricsGeneration.dimensions }}
   dimension {
     name = {{ . | quote }}
   }
   {{- end }}
 
+  {{ if .Values.metricsGeneration.legacy }}
   namespace = "traces.spanmetrics"
+  {{- end }}
 
   histogram {
     unit = "s"

--- a/charts/grafana-sampling/templates/_otelcol_exporter_loadbalancing.alloy.txt
+++ b/charts/grafana-sampling/templates/_otelcol_exporter_loadbalancing.alloy.txt
@@ -1,6 +1,6 @@
 {{- define "deployment.exporter.loadbalancing" -}}
 otelcol.exporter.loadbalancing "default" {
-  // https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.exporter.loadbalancing/
+  // https://grafana.com/docs/alloy/latest/reference/components/otelcol.exporter.loadbalancing/
   resolver {
 
     kubernetes {

--- a/charts/grafana-sampling/templates/_otelcol_exporter_otlp.alloy.txt
+++ b/charts/grafana-sampling/templates/_otelcol_exporter_otlp.alloy.txt
@@ -1,6 +1,6 @@
 {{- define "exporter.otlp" -}}
 otelcol.exporter.otlp "grafana_cloud_tempo" {
-  // https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.exporter.otlp/
+  // https://grafana.com/docs/alloy/latest/reference/components/otelcol.exporter.otlp/
   client {
     endpoint = env("GRAFANA_CLOUD_TEMPO_ENDPOINT")
     auth     = otelcol.auth.basic.grafana_cloud_tempo.handler

--- a/charts/grafana-sampling/templates/_otelcol_exporter_prometheus.alloy.txt
+++ b/charts/grafana-sampling/templates/_otelcol_exporter_prometheus.alloy.txt
@@ -1,7 +1,7 @@
 {{- define "statefulset.exporter.prometheus" -}}
 otelcol.exporter.prometheus "grafana_cloud_prometheus" {
-  // https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.exporter.prometheus/
-  add_metric_suffixes = false
+  // https://grafana.com/docs/alloy/latest/reference/components/otelcol.exporter.prometheus/
+  add_metric_suffixes = {{ not .Values.metricsGeneration.legacy }}
   forward_to          = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
 }
 

--- a/charts/grafana-sampling/templates/_otelcol_processor_batch.alloy.txt
+++ b/charts/grafana-sampling/templates/_otelcol_processor_batch.alloy.txt
@@ -1,6 +1,6 @@
 {{- define "deployment.processor.batch" -}}
 otelcol.processor.batch "default" {
-  // https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.batch/
+  // https://grafana.com/docs/alloy/latest/reference/components/otelcol.processor.batch/
   output {
     traces = [otelcol.exporter.loadbalancing.default.input]
   }
@@ -10,7 +10,7 @@ otelcol.processor.batch "default" {
 
 {{- define "statefulset.processor.batch" -}}
 otelcol.processor.batch "default" {
-  // https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.batch/
+  // https://grafana.com/docs/alloy/latest/reference/components/otelcol.processor.batch/
   output {
     {{ if .Values.metricsGeneration.enabled }}
     metrics = [otelcol.exporter.prometheus.grafana_cloud_prometheus.input]

--- a/charts/grafana-sampling/templates/_otelcol_processor_filter.alloy.txt
+++ b/charts/grafana-sampling/templates/_otelcol_processor_filter.alloy.txt
@@ -1,6 +1,6 @@
 {{- define "statefulset.processor.filter" -}}
 otelcol.processor.filter "drop_unneeded_span_metrics" {
-  // https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.filter/
+  // https://grafana.com/docs/alloy/latest/reference/components/otelcol.processor.filter/
   error_mode = "ignore"
 
   metrics {
@@ -10,7 +10,12 @@ otelcol.processor.filter "drop_unneeded_span_metrics" {
   }
 
   output {
-    metrics = [otelcol.processor.transform.use_grafana_metric_names.input]
+    // TODO: only use grafana_metric_names is legacy is enabled.
+    {{ if .Values.metricsGeneration.legacy }}
+        metrics = [otelcol.processor.transform.use_grafana_metric_names.input]
+    {{ else }}
+        metrics = [otelcol.processor.batch.default.input]
+    {{- end }}
   }
 }
 

--- a/charts/grafana-sampling/templates/_otelcol_processor_tail_sampling.alloy.txt
+++ b/charts/grafana-sampling/templates/_otelcol_processor_tail_sampling.alloy.txt
@@ -1,6 +1,6 @@
 {{- define "statefulset.processor.tail_sampling" -}}
 otelcol.processor.tail_sampling "default" {
-  // https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.tail_sampling/
+  // https://grafana.com/docs/alloy/latest/reference/components/otelcol.processor.tail_sampling/
 
   decision_wait = {{ .Values.sampling.decisionWait | quote  }}
 

--- a/charts/grafana-sampling/templates/_otelcol_processor_transform.alloy.txt
+++ b/charts/grafana-sampling/templates/_otelcol_processor_transform.alloy.txt
@@ -1,6 +1,6 @@
 {{- define "statefulset.processor.transform.use_grafana_metric_names" -}}
 otelcol.processor.transform "use_grafana_metric_names" {
-  // https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.transform/
+  // https://grafana.com/docs/alloy/latest/reference/components/otelcol.processor.transform/
   error_mode = "ignore"
 
   metric_statements {
@@ -20,7 +20,7 @@ otelcol.processor.transform "use_grafana_metric_names" {
 
 {{- define "statefulset.processor.transform.drop_unneeded_resource_attributes"}}
 otelcol.processor.transform "drop_unneeded_resource_attributes" {
-    // https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.transform/
+    // https://grafana.com/docs/alloy/latest/reference/components/otelcol.processor.transform/
     error_mode = "ignore"
 
     trace_statements {

--- a/charts/grafana-sampling/templates/_otelcol_receiver_otlp.alloy.txt
+++ b/charts/grafana-sampling/templates/_otelcol_receiver_otlp.alloy.txt
@@ -1,6 +1,6 @@
 {{- define "deployment.receiver.otlp" -}}
 otelcol.receiver.otlp "default" {
-  // https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.receiver.otlp/
+  // https://grafana.com/docs/alloy/latest/reference/components/otelcol.receiver.otlp/
 
   // configures the default grpc endpoint "0.0.0.0:4317"
   grpc { }
@@ -16,7 +16,7 @@ otelcol.receiver.otlp "default" {
 
 {{- define "statefulset.receiver.otlp" -}}
 otelcol.receiver.otlp "default" {
-  // https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.receiver.otlp/
+  // https://grafana.com/docs/alloy/latest/reference/components/otelcol.receiver.otlp/
 
   // configures the default grpc endpoint "0.0.0.0:4317"
   grpc { }

--- a/charts/grafana-sampling/templates/_prometheus_remote_write.alloy.txt
+++ b/charts/grafana-sampling/templates/_prometheus_remote_write.alloy.txt
@@ -1,6 +1,6 @@
 {{- define "statefulset.prometheus.remote_write" -}}
 prometheus.remote_write "grafana_cloud_prometheus" {
-  // https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.remote_write/
+  // https://grafana.com/docs/alloy/latest/reference/components/prometheus.remote_write/
   endpoint {
     url = env("GRAFANA_CLOUD_PROMETHEUS_URL")
 

--- a/charts/grafana-sampling/templates/configmap_deployment.yaml
+++ b/charts/grafana-sampling/templates/configmap_deployment.yaml
@@ -3,6 +3,6 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-deployment
   labels:
-    {{- include "grafana-agent.labels" . | nindent 4 }}
+    {{- include "alloy.labels" . | nindent 4 }}
 data:
-  config.river: |- {{- (include "agent.config.deployment" .) | nindent 4 }}
+  config.alloy: |- {{- (include "alloy.config.deployment" .) | nindent 4 }}

--- a/charts/grafana-sampling/templates/configmap_statefulset.yaml
+++ b/charts/grafana-sampling/templates/configmap_statefulset.yaml
@@ -3,6 +3,6 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-statefulset
   labels:
-    {{- include "grafana-agent.labels" . | nindent 4 }}
+    {{- include "alloy.labels" . | nindent 4 }}
 data:
-   config.river: |- {{- (include "agent.config.statefulset" .) | nindent 4 }}
+   config.alloy: |- {{- (include "alloy.config.statefulset" .) | nindent 4 }}

--- a/charts/grafana-sampling/values.yaml
+++ b/charts/grafana-sampling/values.yaml
@@ -1,6 +1,8 @@
 metricsGeneration:
   # -- Toggle generation of spanmetrics and servicegraph metrics.
   enabled: true
+  # -- Use legacy metric names that match those used by the Tempo metrics generator.
+  legacy: true
   # -- Additional dimensions to add to generated metrics.
   dimensions:
     - service.namespace
@@ -23,7 +25,7 @@ sampling:
     sample: false
     # -- Percentage of failed requests to sample.
     percentage: 50
-  # -- User-defined policies in river format.
+  # -- User-defined policies in alloy format.
   # @default -- A policy to sample long requests is added by default.
   extraPolicies: |-
     policy {
@@ -47,8 +49,8 @@ sampling:
       }
     }
 
-# @ignored Ignore agent deployment
-grafana-agent-deployment:
+# @ignored Ignore alloy deployment
+alloy-deployment:
   # -- Do not change this.
   nameOverride: deployment
   controller:
@@ -65,7 +67,7 @@ grafana-agent-deployment:
       targetCPUUtilizationPercentage: 0
       # -- Average Memory utilization across all relevant pods, a percentage of the requested value of the resource for the pods. Setting `targetMemoryUtilizationPercentage` to 0 will disable Memory scaling.
       targetMemoryUtilizationPercentage: 80
-  agent:
+  alloy:
     # This chart creates the configmaps
     configMap:
       create: false
@@ -83,8 +85,8 @@ grafana-agent-deployment:
         targetPort: 4318
         protocol: TCP
 
-# @ignored Ignore agent statefulset
-grafana-agent-statefulset:
+# @ignored Ignore alloy statefulset
+alloy-statefulset:
   # -- Do not change this.
   nameOverride: statefulset
   controller:
@@ -103,7 +105,7 @@ grafana-agent-statefulset:
       targetMemoryUtilizationPercentage: 80
   service:
     clusterIP: None
-  agent:
+  alloy:
     extraEnv:
       - name: GRAFANA_CLOUD_API_KEY
         value: <REQUIRED>


### PR DESCRIPTION
This PR upgrades the tail sampling helm chart to use Grafana Alloy. This introduces breaking changes. See the README.md file.

In addition, it introduces a `metricsGeneration.legacy` configuration option set to `true` by default. In future releases, this will default to `false`. Using legacy metric names will align the spanmetrics generated by the `otelcol.spanmetrics.connector` component to match the metric names generated by the Tempo metrics generator. Setting  `metricsGeneration.legacy` set to `false` will use the default metric names. See https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.connector.spanmetrics/#otelcolconnectorspanmetrics for more info.