### PR TITLE
[grafana] feat(network policy): extend Ingress

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 8.4.8
+version: 8.4.9
 appVersion: 11.1.4
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/networkpolicy.yaml
+++ b/charts/grafana/templates/networkpolicy.yaml
@@ -57,5 +57,8 @@ spec:
               {{- include "grafana.labels" . | nindent 14 }}
               role: read
       {{- end }}
+    {{- if .Values.networkPolicy.extraIngress }}
+    {{- toYaml .Values.networkPolicy.extraIngress | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1320,6 +1320,22 @@ networkPolicy:
   ##    - {key: role, operator: In, values: [frontend]}
   ##
   explicitNamespacesSelector: {}
+  extraIngress: {}
+  ## Example:
+  ## extraIngress:
+  ##   - from:
+  ##     - podSelector:
+  ##         matchLabels:
+  ##           app.kubernetes.io/name: ingress-nginx
+  ##           app.kubernetes.io/component: controller
+  ##           app.kubernetes.io/instance: ingress-nginx
+  ##       namespaceSelector:
+  ##         matchLabels:
+  ##           kubernetes.io/metadata.name: ingress-nginx
+  ##     ports:
+  ##     - protocol: TCP
+  ##       port: 3000
+  ##
   ##
   ##
   ##


### PR DESCRIPTION
Add extraIngress parameter to network policy since it does not allow to specify additional sources from the grafana helm chart . For example, I can not set up  load balancer in the cluster.