### PR TITLE
feat: templatise tempo-distributed chart services annoations

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.18.0
+version: 1.19.0
 appVersion: 2.6.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.18.0](https://img.shields.io/badge/Version-1.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.0](https://img.shields.io/badge/AppVersion-2.6.0-informational?style=flat-square)
+![Version: 1.19.0](https://img.shields.io/badge/Version-1.19.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.0](https://img.shields.io/badge/AppVersion-2.6.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/compactor/service-compactor.yaml
+++ b/charts/tempo-distributed/templates/compactor/service-compactor.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "tempo.labels" (dict "ctx" . "component" "compactor") | nindent 4 }}
   {{- with .Values.compactor.service.annotations }}
   annotations:
-  {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml . | nindent 4) $ }}
   {{- end }}
 spec:
   type: ClusterIP

--- a/charts/tempo-distributed/templates/distributor/service-distributor-discovery.yaml
+++ b/charts/tempo-distributed/templates/distributor/service-distributor-discovery.yaml
@@ -12,7 +12,7 @@ metadata:
     prometheus.io/service-monitor: "false"
   {{- with .Values.distributor.serviceDiscovery.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml . | nindent 4) $ }}
   {{- end }}
 spec:
   type: ClusterIP

--- a/charts/tempo-distributed/templates/distributor/service-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/service-distributor.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end }}
   {{- with .Values.distributor.service.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml . | nindent 4) $ }}
   {{- end }}
 spec:
   type: {{ .Values.distributor.service.type }}

--- a/charts/tempo-distributed/templates/enterprise-federation-frontend/service-federation-frontend.yaml
+++ b/charts/tempo-distributed/templates/enterprise-federation-frontend/service-federation-frontend.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "tempo.labels" (dict "ctx" . "component" "enterprise-federation-frontend") | nindent 4 }}
   {{- with .Values.enterpriseFederationFrontend.service.annotations }}
   annotations:
-  {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml . | nindent 4) $ }}
   {{- end }}
 spec:
   type: {{ .Values.enterpriseFederationFrontend.service.type }}

--- a/charts/tempo-distributed/templates/gateway/service-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/service-gateway.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end }}
   {{- with .Values.gateway.service.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml . | nindent 4) $ }}
   {{- end }}
 spec:
   type: {{ .Values.gateway.service.type }}

--- a/charts/tempo-distributed/templates/ingester/service-ingester-discovery.yaml
+++ b/charts/tempo-distributed/templates/ingester/service-ingester-discovery.yaml
@@ -9,7 +9,7 @@ metadata:
     prometheus.io/service-monitor: "false"
   {{- with .Values.ingester.service.annotations }}
   annotations:
-  {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml . | nindent 4) $ }}
   {{- end }}
 spec:
   type: ClusterIP

--- a/charts/tempo-distributed/templates/ingester/service-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/service-ingester.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "tempo.labels" $dict | nindent 4 }}
   {{- with .Values.ingester.service.annotations }}
   annotations:
-  {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml . | nindent 4) $ }}
   {{- end }}
 spec:
   ports:

--- a/charts/tempo-distributed/templates/memcached/service-memcached.yaml
+++ b/charts/tempo-distributed/templates/memcached/service-memcached.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- include "tempo.labels" (dict "ctx" . "component" "memcached") | nindent 4 }}
   {{- with .Values.memcached.service.annotations }}
   annotations:
-  {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml . | nindent 4) $ }}
   {{- end }}
 spec:
   ports:

--- a/charts/tempo-distributed/templates/metrics-generator/service-metrics-generator-discovery.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/service-metrics-generator-discovery.yaml
@@ -10,7 +10,7 @@ metadata:
     prometheus.io/service-monitor: "false"
   {{- with .Values.metricsGenerator.service.annotations }}
   annotations:
-  {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml . | nindent 4) $ }}
   {{- end }}
 spec:
   type: ClusterIP

--- a/charts/tempo-distributed/templates/metrics-generator/service-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/service-metrics-generator.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "tempo.labels" $dict | nindent 4 }}
   {{- with .Values.metricsGenerator.service.annotations }}
   annotations:
-  {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml . | nindent 4) $ }}
   {{- end }}
 spec:
   ports:

--- a/charts/tempo-distributed/templates/querier/service-querier.yaml
+++ b/charts/tempo-distributed/templates/querier/service-querier.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "tempo.labels" (dict "ctx" . "component" "querier") | nindent 4 }}
   {{- with .Values.querier.service.annotations }}
   annotations:
-  {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml . | nindent 4) $ }}
   {{- end }}
 spec:
   ports:

--- a/charts/tempo-distributed/templates/query-frontend/service-query-frontend-discovery.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/service-query-frontend-discovery.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- end }}
   {{- with .Values.queryFrontend.serviceDiscovery.annotations }}
   annotations:
-    {{ toYaml . | nindent 4 }}
+    {{- tpl (toYaml . | nindent 4) $ }}
   {{- end }}
 spec:
   type: ClusterIP

--- a/charts/tempo-distributed/templates/query-frontend/service-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/service-query-frontend.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- end }}
   {{- with .Values.queryFrontend.service.annotations }}
   annotations:
-  {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml . | nindent 4) $ }}
   {{- end }}
 spec:
   type: {{ .Values.queryFrontend.service.type }}


### PR DESCRIPTION
Allow templating in tempo-distributed chart services annotations

Making possible cool stuff like : 
```
annotations:
  my.domain.tld/param1: {{ .Release.Name }}
```