### PR TITLE
[loki-distributed] migrate to tsdb store

### DIFF
--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -248,7 +248,7 @@ loki:
 
   # -- Check https://grafana.com/docs/loki/latest/configuration/#storage_config for more info on how to configure storages
   storageConfig:
-  # Old boltdb-shipper configuration. Included in example for reference but does not need changing.
+    # Old boltdb-shipper configuration. Included in example for reference but does not need changing.
     boltdb_shipper:
       shared_store: filesystem
       active_index_directory: /var/loki/index


### PR DESCRIPTION
Migrate to the TSDB due to BoltDB deprecation:
- https://grafana.com/docs/loki/latest/operations/storage/boltdb-shipper/
- https://grafana.com/docs/loki/latest/configure/storage/#boltdb-deprecated