### PR TITLE
Add required name label to ingesters

### DIFF
--- a/charts/tempo-distributed/templates/ingester/_helpers-ingester.tpl
+++ b/charts/tempo-distributed/templates/ingester/_helpers-ingester.tpl
@@ -176,6 +176,7 @@ app.kubernetes.io/part-of: memberlist
 {{-   if not .component }}
 {{-     printf "Component name cannot be empty if rolloutZoneName (%s) is set" .rolloutZoneName | fail }}
 {{-   end }}
+name: "{{ .component }}-{{ .rolloutZoneName }}" {{- /* Currently required for rollout-operator. https://github.com/grafana/rollout-operator/issues/15 */}}
 rollout-group: ingester
 zone: {{ .rolloutZoneName }}
 {{- end }}


### PR DESCRIPTION
`name` label is required on pods that should be managed by the rollout-operator this pr ensure that it is added.
https://github.com/grafana/rollout-operator/issues/15
