### PR TITLE
[grafana-sampling] add batch config options and k8s.pod.name to metrics dimensions

### DIFF
--- a/charts/grafana-sampling/Chart.yaml
+++ b/charts/grafana-sampling/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: grafana-sampling
 description: A Helm chart for a layered OTLP tail sampling and metrics generation pipeline.
 type: application
-version: 1.0.1
+version: 1.1.0
 appVersion: "v1.3.0"
 sources:
   - https://github.com/grafana/alloy

--- a/charts/grafana-sampling/README.md
+++ b/charts/grafana-sampling/README.md
@@ -139,7 +139,11 @@ A major chart version change indicates that there is an incompatible breaking ch
 | alloy-statefulset.rbac.create | bool | `false` |  |
 | alloy-statefulset.service.clusterIP | string | `"None"` |  |
 | alloy-statefulset.serviceAccount.create | bool | `false` |  |
-| metricsGeneration.dimensions | list | `["service.namespace","service.version","deployment.environment","k8s.cluster.name"]` | Additional dimensions to add to generated metrics. |
+| batch.deployment | object | `{"send_batch_max_size":0,"send_batch_size":8192,"timeout":"200ms"}` | Configure batch processing options. |
+| batch.statefulset.send_batch_max_size | int | `0` |  |
+| batch.statefulset.send_batch_size | int | `8192` |  |
+| batch.statefulset.timeout | string | `"200ms"` |  |
+| metricsGeneration.dimensions | list | `["service.namespace","service.version","deployment.environment","k8s.cluster.name","k8s.pod.name"]` | Additional dimensions to add to generated metrics. |
 | metricsGeneration.enabled | bool | `true` | Toggle generation of spanmetrics and servicegraph metrics. |
 | metricsGeneration.legacy | bool | `true` | Use legacy metric names that match those used by the Tempo metrics generator. |
 | sampling.decisionWait | string | `"15s"` | Wait time since the first span of a trace before making a sampling decision. |

--- a/charts/grafana-sampling/README.md
+++ b/charts/grafana-sampling/README.md
@@ -1,6 +1,6 @@
 # grafana-sampling
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
 
 A Helm chart for a layered OTLP tail sampling and metrics generation pipeline.
 

--- a/charts/grafana-sampling/templates/_otelcol_processor_batch.alloy.txt
+++ b/charts/grafana-sampling/templates/_otelcol_processor_batch.alloy.txt
@@ -1,6 +1,10 @@
 {{- define "deployment.processor.batch" -}}
 otelcol.processor.batch "default" {
   // https://grafana.com/docs/alloy/latest/reference/components/otelcol.processor.batch/
+  timeout = {{ .Values.batch.deployment.timeout | quote }}
+  send_batch_size = {{ .Values.batch.deployment.send_batch_size }}
+  send_batch_max_size = {{ .Values.batch.deployment.send_batch_max_size }}
+
   output {
     traces = [otelcol.exporter.loadbalancing.default.input]
   }
@@ -11,6 +15,10 @@ otelcol.processor.batch "default" {
 {{- define "statefulset.processor.batch" -}}
 otelcol.processor.batch "default" {
   // https://grafana.com/docs/alloy/latest/reference/components/otelcol.processor.batch/
+  timeout = {{ .Values.batch.statefulset.timeout | quote }}
+  send_batch_size = {{ .Values.batch.statefulset.send_batch_size }}
+  send_batch_max_size = {{ .Values.batch.statefulset.send_batch_max_size }}
+
   output {
     {{ if .Values.metricsGeneration.enabled }}
     metrics = [otelcol.exporter.prometheus.grafana_cloud_prometheus.input]

--- a/charts/grafana-sampling/values.yaml
+++ b/charts/grafana-sampling/values.yaml
@@ -9,6 +9,7 @@ metricsGeneration:
     - service.version
     - deployment.environment
     - k8s.cluster.name
+    - k8s.pod.name
 
 sampling:
   # -- Toggle tail sampling.
@@ -48,6 +49,17 @@ sampling:
         }
       }
     }
+
+batch:
+  # -- Configure batch processing options.
+  deployment:
+    timeout: 200ms
+    send_batch_size: 8192
+    send_batch_max_size: 0
+  statefulset:
+    timeout: 200ms
+    send_batch_size: 8192
+    send_batch_max_size: 0
 
 # @ignored Ignore alloy deployment
 alloy-deployment:


### PR DESCRIPTION
This PR makes batch processing options configurable for the deployment and statefulset batch processors. Additionally, k8s.pod.name is added to the set of default dimensions to avoid issue with faulty target_info metric generation.