### PR TITLE
[grafana] correct array formatting for grafana.ini

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 8.5.2
+version: 8.5.3
 appVersion: 11.2.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_config.tpl
+++ b/charts/grafana/templates/_config.tpl
@@ -13,6 +13,8 @@ grafana.ini: |
   {{- if not (kindIs "map" $elemVal) }}
   {{- if kindIs "invalid" $elemVal }}
   {{ $elem }} =
+  {{- else if kindIs "slice" $elemVal }}
+  {{ $elem }} = {{ toJson $elemVal }}
   {{- else if kindIs "string" $elemVal }}
   {{ $elem }} = {{ tpl $elemVal $ }}
   {{- else }}
@@ -26,6 +28,8 @@ grafana.ini: |
   {{- range $elem, $elemVal := $value }}
   {{- if kindIs "invalid" $elemVal }}
   {{ $elem }} =
+  {{- else if kindIs "slice" $elemVal }}
+  {{ $elem }} = {{ toJson $elemVal }}
   {{- else if kindIs "string" $elemVal }}
   {{ $elem }} = {{ tpl $elemVal $ }}
   {{- else }}


### PR DESCRIPTION
fixes array format in configmap grafana.ini.

previously produced: `org_mapping = ["a" "b" "c"]`, which grafana did not apply correctly
now produces: `org_mapping = ["a", "b", "c"]`, which grafana applies correctly

of note:
for some reason this only seems to work when applied as TOML style array lists `["a", "b", "c"]`, even though the file type is nominally ini, which would suggest the following would actually be appropriate:
```
org_mapping[] = "a"
org_mapping[] = "b"
org_mapping[] = "c"
```

🤷 
