### PR TITLE
[tempo-distributed] Fixes minor regression in tempo-distributed compactor extraEnv

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.18.4
+version: 1.18.5
 appVersion: 2.6.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.18.4](https://img.shields.io/badge/Version-1.18.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.0](https://img.shields.io/badge/AppVersion-2.6.0-informational?style=flat-square)
+![Version: 1.18.5](https://img.shields.io/badge/Version-1.18.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.0](https://img.shields.io/badge/AppVersion-2.6.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/compactor/deployment-compactor.yaml
+++ b/charts/tempo-distributed/templates/compactor/deployment-compactor.yaml
@@ -70,7 +70,7 @@ spec:
               name: http-metrics
             - containerPort: {{ include "tempo.memberlistBindPort" . }}
               name: http-memberlist
-          {{- if or .Values.global.extraEnv .Values.compactor.env }}
+          {{- if or .Values.global.extraEnv .Values.compactor.extraEnv }}
           env:
             {{- with .Values.global.extraEnv }}
               {{ toYaml . | nindent 12 }}


### PR DESCRIPTION
A recent change to add a global extraEnv (https://github.com/grafana/helm-charts/commit/2126cb60a0974de3369ad210ebce8be786d4ccaa) made a small typo for the compactor component, so that it was looking at `compactor.env` instead of `compactor.extraEnv` (in the case `global.extraEnv` is not set). 

This PR just fixes that.