### PR TITLE
Add OCI registry support for all Helm charts

### DIFF
--- a/.github/workflows/update-helm-repo.yaml
+++ b/.github/workflows/update-helm-repo.yaml
@@ -91,8 +91,10 @@ jobs:
           fi
 
   release:
-    needs: [ setup ]
+    needs: [setup]
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     env:
       github_app_id: ${{ secrets.github_app_id }}
     if: needs.setup.outputs.changed == 'true'
@@ -225,3 +227,14 @@ jobs:
         run: |
           cd helm-charts
           "${CR_TOOL_PATH}/cr" index --config "${CR_CONFIGFILE}" --token "${{ env.AUTHTOKEN }}" --index-path "${CR_INDEX_PATH}" --package-path "${CR_PACKAGE_PATH}" --push
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ env.AUTHTOKEN }}
+
+      - name: Push charts to GHCR
+        run: |
+          helm push "${{ env.CR_PACKAGE_PATH }}/${{ steps.parse-chart.outputs.packagename }}.tgz" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/helm-charts"


### PR DESCRIPTION
Some Helm charts, such as Loki, are not being pushed to an OCI registry because OCI support is missing in the `update-helm-repo.yaml` workflow, which is used for external releases.

Solution: This PR introduces a step that ensures Helm charts are also pushed to the GitHub Container Registry (GHCR) as part of the release process, providing OCI support for charts that were previously excluded.

