### PR TITLE
defining an annotation for the secret gateway loki-distributed-gateway

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.9.10
-version: 0.79.4
+version: 0.79.5
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.79.4](https://img.shields.io/badge/Version-0.79.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.10](https://img.shields.io/badge/AppVersion-2.9.10-informational?style=flat-square)
+![Version: 0.79.5](https://img.shields.io/badge/Version-0.79.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.10](https://img.shields.io/badge/AppVersion-2.9.10-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 

--- a/charts/loki-distributed/templates/gateway/secret-gateway.yaml
+++ b/charts/loki-distributed/templates/gateway/secret-gateway.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ include "loki.gatewayFullname" $ }}
   labels:
     {{- include "loki.gatewayLabels" $ | nindent 4 }}
+  {{- with .Values.loki.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 stringData:
   .htpasswd: |
     {{- tpl .basicAuth.htpasswd $ | nindent 4 }}


### PR DESCRIPTION
This pull request suggests making changes to the Loki Distributed Gateway secret.
The goal of these changes is to add annotations that will allow you to override and use them, for example, in integration with Vault Secrets Webhook. This will enable more flexible configuration and management of secrets in the system.