### PR TITLE
[grafana] fix: allow nameOverride for PVC

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 9.0.0
+version: 8.6.0
 appVersion: 11.2.2-security-01
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 8.5.8
+version: 9.0.0
 appVersion: 11.2.2-security-01
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/pvc.yaml
+++ b/charts/grafana/templates/pvc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "grafana.fullname" . }}
+  name: {{ if .Values.persistence.nameOverride }}{{ .Values.persistence.nameOverride }}{{ else }}{{ include "grafana.fullname" . }}{{ end }}
   namespace: {{ include "grafana.namespace" . }}
   labels:
     {{- include "grafana.labels" . | nindent 4 }}

--- a/charts/grafana/templates/statefulset.yaml
+++ b/charts/grafana/templates/statefulset.yaml
@@ -42,7 +42,7 @@ spec:
   - apiVersion: v1
     kind: PersistentVolumeClaim
     metadata:
-      name: {{ include "grafana.fullname" . }}
+      name: {{ if .Values.persistence.nameOverride }}{{ .Values.persistence.nameOverride }}{{ else }}{{ include "grafana.fullname" . }}{{ end }}
     spec:
       accessModes: {{ .Values.persistence.accessModes }}
       storageClassName: {{ .Values.persistence.storageClassName }}

--- a/charts/grafana/templates/statefulset.yaml
+++ b/charts/grafana/templates/statefulset.yaml
@@ -42,7 +42,7 @@ spec:
   - apiVersion: v1
     kind: PersistentVolumeClaim
     metadata:
-      name: storage
+      name: {{ include "grafana.fullname" . }}
     spec:
       accessModes: {{ .Values.persistence.accessModes }}
       storageClassName: {{ .Values.persistence.storageClassName }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -373,6 +373,8 @@ persistence:
   type: pvc
   enabled: false
   # storageClassName: default
+  ## Set the name of the PVC
+  # nameOverride: ""
   accessModes:
     - ReadWriteOnce
   size: 10Gi


### PR DESCRIPTION
I have a usecase where using the volumeClaimTemplate `.metadata.name` as the `{{ include "grafana.fullname" . }}` would aid in flexibility. 

Users currently using a statefulSet would need to set `.Values.persistence.nameOverride` to `storage` to avoid a breaking change.