### PR TITLE
[rollout-operator] make relabelings optional for rollout operator

### DIFF
--- a/charts/rollout-operator/Chart.yaml
+++ b/charts/rollout-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-operator
 description: "Grafana rollout-operator"
 type: application
-version: 0.18.0
+version: 0.18.1
 appVersion: v0.19.1
 home: https://github.com/grafana/rollout-operator
 kubeVersion: ^1.10.0-0

--- a/charts/rollout-operator/README.md
+++ b/charts/rollout-operator/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana rollout-operator](https://github.com/grafana/r
 
 # rollout-operator
 
-![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.19.1](https://img.shields.io/badge/AppVersion-v0.19.1-informational?style=flat-square)
+![Version: 0.18.1](https://img.shields.io/badge/Version-0.18.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.19.1](https://img.shields.io/badge/AppVersion-v0.19.1-informational?style=flat-square)
 
 Grafana rollout-operator
 

--- a/charts/rollout-operator/templates/servicemonitor.yaml
+++ b/charts/rollout-operator/templates/servicemonitor.yaml
@@ -28,9 +28,9 @@ spec:
       {{- with .Values.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
       relabelings:
-        {{- with .Values.serviceMonitor.relabelings }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       scheme: http
 {{- end -}}


### PR DESCRIPTION
Rollout operator always creates `relabelings` when serviceMonitor is enabled, which produces invalid yaml 
```
# Source: rollout-operator/templates/servicemonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: release-name-rollout-operator
  labels:
    helm.sh/chart: rollout-operator-0.18.1
    app.kubernetes.io/name: rollout-operator
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.19.1"
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: rollout-operator
      app.kubernetes.io/instance: release-name
  endpoints:
    - port: http-metrics
      relabelings:  < --- here
      scheme: http
```