### PR TITLE
[tempo-distributed] Add support for extraLabels

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.20.0
+version: 1.20.1
 appVersion: 2.6.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.20.0](https://img.shields.io/badge/Version-1.20.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.0](https://img.shields.io/badge/AppVersion-2.6.0-informational?style=flat-square)
+![Version: 1.20.1](https://img.shields.io/badge/Version-1.20.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.0](https://img.shields.io/badge/AppVersion-2.6.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -437,6 +437,7 @@ The memcached default args are removed and should be provided manually. The sett
 | externalConfigVersion | string | `"0"` | When 'useExternalConfig' is true, then changing 'externalConfigVersion' triggers restart of services - otherwise changes to the configuration cause a restart. |
 | externalRuntimeConfigName | string | `"{{ include \"tempo.resourceName\" (dict \"ctx\" . \"component\" \"runtime\") }}"` | Name of the Secret or ConfigMap that contains the runtime configuration (used for naming even if config is internal). |
 | extraObjects | list | `[]` | Create extra manifests via values. |
+| extraLabels  | object | `{}` | Custom labels for all manifests. |
 | fullnameOverride | string | `""` |  |
 | gateway.affinity | string | Hard node and soft zone anti-affinity | Affinity for gateway pods. Passed through `tpl` and, thus, to be configured as string |
 | gateway.autoscaling.behavior | object | `{}` | Autoscaling behavior configuration for the gateway |

--- a/charts/tempo-distributed/templates/_helpers.tpl
+++ b/charts/tempo-distributed/templates/_helpers.tpl
@@ -90,7 +90,7 @@ app.kubernetes.io/part-of: memberlist
 app.kubernetes.io/version: {{ .ctx.Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .ctx.Release.Service }}
-{{- with .Values.extraLabels }}
+{{- with $.Values.extraLabels }}
 {{ toYaml . }}
 {{- end }}
 {{- end -}}

--- a/charts/tempo-distributed/templates/_helpers.tpl
+++ b/charts/tempo-distributed/templates/_helpers.tpl
@@ -90,6 +90,9 @@ app.kubernetes.io/part-of: memberlist
 app.kubernetes.io/version: {{ .ctx.Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .ctx.Release.Service }}
+{{- with .Values.extraLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -2309,3 +2309,6 @@ extraObjects: []
   #     data:
   #       - key: secret-access-key
   #         name: awssm-secret
+
+# Apply extra labels to common labels.
+extraLabels: {}


### PR DESCRIPTION
This PR adds extra labels to all manifests, ensuring that the common labels are applied consistently across all resources. It does not introduce any breaking changes or modify existing functionality, but simply extends the labeling structure for better resource identification and management.