### PR TITLE
Add missing permissions in update-helm-repo workflow

### DIFF
--- a/.github/workflows/update-helm-repo.yaml
+++ b/.github/workflows/update-helm-repo.yaml
@@ -94,7 +94,8 @@ jobs:
     needs: [setup]
     runs-on: ubuntu-latest
     permissions:
-      packages: write
+      contents: write # to push chart release, create release, and push tags to github
+      packages: write # to push package to ghcr
     env:
       github_app_id: ${{ secrets.github_app_id }}
     if: needs.setup.outputs.changed == 'true'


### PR DESCRIPTION
This is the fixup for #3366

The changes in #3366 added an explicit list of `permissions`, the workflow intents to use. It seems that this broke the release of Helm charts in Mimir. The "Push release tag on origin" now fails with the following:

```
Pushing tag mimir-distributed-5.6.0-weekly.314
remote: Permission to grafana/mimir.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/grafana/mimir/': The requested URL returned error: 403
Error: Process completed with exit code 128.
```

(refer to this [failed build][2])

If I understand it right, even though we add all necessary permissions in the repo's "Workflow permissions" settings, the `permissions` explicitly defined in workflow's YAML override those (refer to [github docs][1]). And since the workflow doesn't list the `contents: write`, the action, that executes the workflow cannot push the tag. This PR fixes that.

[1]: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
[2]: https://github.com/grafana/mimir/actions/runs/11553216656/job/32153944957