### PR TITLE
[rollout-operator] Add commonLabels (#3319)

### DIFF
--- a/charts/rollout-operator/Chart.yaml
+++ b/charts/rollout-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-operator
 description: "Grafana rollout-operator"
 type: application
-version: 0.18.0
+version: 0.19.0
 appVersion: v0.19.1
 home: https://github.com/grafana/rollout-operator
 kubeVersion: ^1.10.0-0

--- a/charts/rollout-operator/README.md
+++ b/charts/rollout-operator/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana rollout-operator](https://github.com/grafana/r
 
 # rollout-operator
 
-![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.19.1](https://img.shields.io/badge/AppVersion-v0.19.1-informational?style=flat-square)
+![Version: 0.19.0](https://img.shields.io/badge/Version-0.19.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.19.1](https://img.shields.io/badge/AppVersion-v0.19.1-informational?style=flat-square)
 
 Grafana rollout-operator
 
@@ -41,6 +41,7 @@ It is not a highly available application and runs as a single pod.
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
+| global.commonLabels | object | `{}` | Common labels for all object directly managed by this chart. |
 | hostAliases | list | `[]` | hostAliases to add |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"grafana/rollout-operator"` |  |

--- a/charts/rollout-operator/templates/_helpers.tpl
+++ b/charts/rollout-operator/templates/_helpers.tpl
@@ -48,6 +48,9 @@ helm.sh/chart: {{ include "rollout-operator.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.global.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/rollout-operator/templates/role.yaml
+++ b/charts/rollout-operator/templates/role.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "rollout-operator.fullname" . }}
+  labels:
+    {{- include "rollout-operator.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/charts/rollout-operator/templates/rolebinding.yaml
+++ b/charts/rollout-operator/templates/rolebinding.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "rollout-operator.fullname" . }}
+  labels:
+    {{- include "rollout-operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/rollout-operator/values.yaml
+++ b/charts/rollout-operator/values.yaml
@@ -2,6 +2,12 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+
+global:
+  # -- Common labels for all object directly managed by this chart.
+  commonLabels: {}
+
+
 image:
   repository: grafana/rollout-operator
   pullPolicy: IfNotPresent


### PR DESCRIPTION
Every object created by the chart can have custom labels.

Fixes https://github.com/grafana/helm-charts/issues/3319

I edited  Rollour operator Charts using the same logic used for https://github.com/grafana/mimir/issues/9067
