### PR TITLE
[agent-operator] Add commonLabels (#3319)

### DIFF
--- a/charts/agent-operator/Chart.yaml
+++ b/charts/agent-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: grafana-agent-operator
 description: A Helm chart for Grafana Agent Operator
 type: application
-version: 0.4.4
+version: 0.5.0
 appVersion: "0.43.3"
 home: https://grafana.com/docs/agent/v0.43/
 icon: https://raw.githubusercontent.com/grafana/agent/v0.43.3/docs/sources/assets/logo_and_name.png

--- a/charts/agent-operator/README.md
+++ b/charts/agent-operator/README.md
@@ -1,6 +1,6 @@
 # grafana-agent-operator
 
-![Version: 0.4.4](https://img.shields.io/badge/Version-0.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.43.3](https://img.shields.io/badge/AppVersion-0.43.3-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.43.3](https://img.shields.io/badge/AppVersion-0.43.3-informational?style=flat-square)
 
 A Helm chart for Grafana Agent Operator
 
@@ -58,6 +58,7 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 | containerSecurityContext | object | `{}` | Container security context (allowPrivilegeEscalation, etc.) |
 | extraArgs | list | `[]` | List of additional cli arguments to configure agent-operator (example: `--log.level`) |
 | fullnameOverride | string | `""` | Overrides the chart's computed fullname |
+| global.commonLabels | object | `{}` | Common labels for all object directly managed by this chart. |
 | hostAliases | list | `[]` | hostAliases to add |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.pullSecrets | list | `[]` | Image pull secrets |

--- a/charts/agent-operator/templates/_helpers.tpl
+++ b/charts/agent-operator/templates/_helpers.tpl
@@ -44,6 +44,9 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels }}
 {{- end }}
+{{- with .Values.global.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/agent-operator/values.yaml
+++ b/charts/agent-operator/values.yaml
@@ -1,3 +1,7 @@
+global:
+  # -- Common labels for all object directly managed by this chart.
+  commonLabels: {}
+
 # -- Overrides the chart's name
 nameOverride: ""
 


### PR DESCRIPTION
Every object created by the chart can have custom labels.

Fixes https://github.com/grafana/helm-charts/issues/3319

I edited Rollour operator Charts using the same logic used for https://github.com/grafana/mimir/issues/9067