### PR TITLE
[grafana] Make the Helm hook type for the testFramework configurable

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 8.5.10
+version: 8.5.11
 appVersion: 11.3.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/tests/test-configmap.yaml
+++ b/charts/grafana/templates/tests/test-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "grafana.fullname" . }}-test
   namespace: {{ include "grafana.namespace" . }}
   annotations:
-    "helm.sh/hook": test
+    "helm.sh/hook": {{ .Values.testFramework.hookType | default "test" }}
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     {{- include "grafana.labels" . | nindent 4 }}

--- a/charts/grafana/templates/tests/test-podsecuritypolicy.yaml
+++ b/charts/grafana/templates/tests/test-podsecuritypolicy.yaml
@@ -4,7 +4,7 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ include "grafana.fullname" . }}-test
   annotations:
-    "helm.sh/hook": test
+    "helm.sh/hook": {{ .Values.testFramework.hookType | default "test" }}
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     {{- include "grafana.labels" . | nindent 4 }}

--- a/charts/grafana/templates/tests/test-role.yaml
+++ b/charts/grafana/templates/tests/test-role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "grafana.fullname" . }}-test
   namespace: {{ include "grafana.namespace" . }}
   annotations:
-    "helm.sh/hook": test
+    "helm.sh/hook": {{ .Values.testFramework.hookType | default "test" }}
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     {{- include "grafana.labels" . | nindent 4 }}

--- a/charts/grafana/templates/tests/test-rolebinding.yaml
+++ b/charts/grafana/templates/tests/test-rolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "grafana.fullname" . }}-test
   namespace: {{ include "grafana.namespace" . }}
   annotations:
-    "helm.sh/hook": test
+    "helm.sh/hook": {{ .Values.testFramework.hookType | default "test" }}
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     {{- include "grafana.labels" . | nindent 4 }}

--- a/charts/grafana/templates/tests/test-serviceaccount.yaml
+++ b/charts/grafana/templates/tests/test-serviceaccount.yaml
@@ -7,6 +7,6 @@ metadata:
   name: {{ include "grafana.serviceAccountNameTest" . }}
   namespace: {{ include "grafana.namespace" . }}
   annotations:
-    "helm.sh/hook": test
+    "helm.sh/hook": {{ .Values.testFramework.hookType | default "test" }}
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 {{- end }}

--- a/charts/grafana/templates/tests/test.yaml
+++ b/charts/grafana/templates/tests/test.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": test
+    "helm.sh/hook": {{ .Values.testFramework.hookType | default "test" }}
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   namespace: {{ include "grafana.namespace" . }}
 spec:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -114,6 +114,10 @@ image:
 
 testFramework:
   enabled: true
+  ## The type of Helm hook used to run this test. Defaults to test.
+  ## ref: https://helm.sh/docs/topics/charts_hooks/#the-available-hooks
+  ##
+  # hookType: test
   image:
     # -- The Docker registry
     registry: docker.io


### PR DESCRIPTION
## Story
As a user of the testFramework, I'd like to be able to run it automatically `post-install` and `post-upgrade` to check the health endpoint of my Grafana instance any time it is altered. Additionally, upon failure of this test, I'd like it to rollback which happens automatically when using the previously mentioned hook types.
