### PR TITLE
`managed-by` is set at install time by the managing installer, and should not be templated.

### DIFF
--- a/charts/agent-operator/templates/_helpers.tpl
+++ b/charts/agent-operator/templates/_helpers.tpl
@@ -35,7 +35,6 @@ Common labels
 */}}
 {{- define "ga-operator.labels" -}}
 {{ include "ga-operator.selectorLabels" . }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/component: operator
 helm.sh/chart: {{ include "ga-operator.chart" . }}
 {{- if .Chart.AppVersion }}

--- a/charts/enterprise-logs-simple/templates/_helpers.tpl
+++ b/charts/enterprise-logs-simple/templates/_helpers.tpl
@@ -39,7 +39,6 @@ helm.sh/chart: {{ include "enterprise-logs.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*

--- a/charts/enterprise-logs/templates/_helpers.tpl
+++ b/charts/enterprise-logs/templates/_helpers.tpl
@@ -39,7 +39,6 @@ helm.sh/chart: {{ include "enterprise-logs.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*

--- a/charts/grafana/templates/_helpers.tpl
+++ b/charts/grafana/templates/_helpers.tpl
@@ -70,7 +70,6 @@ helm.sh/chart: {{ include "grafana.chart" . }}
 {{- if or .Chart.AppVersion .Values.image.tag }}
 app.kubernetes.io/version: {{ mustRegexReplaceAllLiteral "@sha.*" .Values.image.tag "" | default .Chart.AppVersion | trunc 63 | trimSuffix "-" | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- with .Values.extraLabels }}
 {{ toYaml . }}
 {{- end }}
@@ -93,7 +92,6 @@ helm.sh/chart: {{ include "grafana.chart" . }}
 {{- if or .Chart.AppVersion .Values.image.tag }}
 app.kubernetes.io/version: {{ mustRegexReplaceAllLiteral "@sha.*" .Values.image.tag "" | default .Chart.AppVersion | trunc 63 | trimSuffix "-" | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*

--- a/charts/grafana/templates/hpa.yaml
+++ b/charts/grafana/templates/hpa.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "grafana.name" . }}
     helm.sh/chart: {{ include "grafana.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   scaleTargetRef:

--- a/charts/grafana/templates/image-renderer-hpa.yaml
+++ b/charts/grafana/templates/image-renderer-hpa.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "grafana.name" . }}-image-renderer
     helm.sh/chart: {{ include "grafana.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   scaleTargetRef:

--- a/charts/loki-canary/templates/_helpers.tpl
+++ b/charts/loki-canary/templates/_helpers.tpl
@@ -39,7 +39,6 @@ helm.sh/chart: {{ include "loki-canary.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*

--- a/charts/loki-distributed/templates/_helpers.tpl
+++ b/charts/loki-distributed/templates/_helpers.tpl
@@ -39,7 +39,6 @@ helm.sh/chart: {{ include "loki.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*

--- a/charts/promtail/templates/_helpers.tpl
+++ b/charts/promtail/templates/_helpers.tpl
@@ -39,7 +39,6 @@ helm.sh/chart: {{ include "promtail.chart" . }}
 {{- if or .Chart.AppVersion .Values.image.tag }}
 app.kubernetes.io/version: {{ mustRegexReplaceAllLiteral "@sha.*" .Values.image.tag "" | default .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*

--- a/charts/rollout-operator/templates/_helpers.tpl
+++ b/charts/rollout-operator/templates/_helpers.tpl
@@ -47,7 +47,6 @@ helm.sh/chart: {{ include "rollout-operator.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*

--- a/charts/snyk-exporter/templates/_helpers.tpl
+++ b/charts/snyk-exporter/templates/_helpers.tpl
@@ -39,7 +39,6 @@ helm.sh/chart: {{ include "this.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*

--- a/charts/synthetic-monitoring-agent/templates/_helpers.tpl
+++ b/charts/synthetic-monitoring-agent/templates/_helpers.tpl
@@ -39,7 +39,6 @@ helm.sh/chart: {{ include "synthetic-monitoring-agent.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*

--- a/charts/tempo-distributed/templates/_helpers.tpl
+++ b/charts/tempo-distributed/templates/_helpers.tpl
@@ -89,7 +89,6 @@ app.kubernetes.io/part-of: memberlist
 {{- if .ctx.Chart.AppVersion }}
 app.kubernetes.io/version: {{ .ctx.Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .ctx.Release.Service }}
 {{- end -}}
 
 {{/*
@@ -260,7 +259,6 @@ helm.sh/chart: {{ include "tempo.chart" .ctx }}
 app.kubernetes.io/name: {{ include "tempo.name" .ctx }}
 app.kubernetes.io/instance: {{ .ctx.Release.Name }}
 app.kubernetes.io/version: {{ .ctx.Chart.AppVersion | quote }}
-app.kubernetes.io/managed-by: {{ .ctx.Release.Service }}
 {{- if .component }}
 app.kubernetes.io/component: {{ .component }}
 {{- end }}

--- a/charts/tempo-distributed/templates/ingester/_helpers-ingester.tpl
+++ b/charts/tempo-distributed/templates/ingester/_helpers-ingester.tpl
@@ -88,7 +88,6 @@ app.kubernetes.io/part-of: memberlist
 {{- if .ctx.Chart.AppVersion }}
 app.kubernetes.io/version: {{ .ctx.Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .ctx.Release.Service }}
 {{- end -}}
 {{/*
 Resource name template
@@ -161,7 +160,6 @@ helm.sh/chart: {{ include "tempo.chart" .ctx }}
 app.kubernetes.io/name: {{ include "tempo.name" .ctx }}
 app.kubernetes.io/instance: {{ .ctx.Release.Name }}
 app.kubernetes.io/version: {{ .ctx.Chart.AppVersion | quote }}
-app.kubernetes.io/managed-by: {{ .ctx.Release.Service }}
 {{- if .component }}
 app.kubernetes.io/component: {{ .component }}
 {{- end }}

--- a/charts/tempo-vulture/templates/_helpers.tpl
+++ b/charts/tempo-vulture/templates/_helpers.tpl
@@ -39,7 +39,6 @@ helm.sh/chart: {{ include "tempo-vulture.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*

--- a/charts/tempo/templates/_helpers.tpl
+++ b/charts/tempo/templates/_helpers.tpl
@@ -51,7 +51,6 @@ helm.sh/chart: {{ include "tempo.chart" . }}
 {{- if or .Chart.AppVersion .Values.tempo.tag }}
 app.kubernetes.io/version: {{ mustRegexReplaceAllLiteral "@sha.*" .Values.tempo.tag "" | default .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- with .Values.extraLabels }}
 {{ toYaml . }}
 {{- end }}
@@ -74,7 +73,6 @@ helm.sh/chart: {{ include "tempo.chart" . }}
 {{- if or .Chart.AppVersion .Values.image.tag }}
 app.kubernetes.io/version: {{ mustRegexReplaceAllLiteral "@sha.*" .Values.image.tag "" | default .Chart.AppVersion | quote }}
 {{- end }}`
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
`app.kubernetes.io/managed-by: Helm` is automatically applied to resources _installed_ by Helm via `helm install`, and does not need to be (read: should not be) manually templated. The label is an install-time label that should be applied by the tool actually installing the resources into the cluster.

This matters because `helm template` should (and by default will) produce YAML without this label, as it is unknown at template-time what will "manage" the resource - e.g. `helm template | kubectl apply -f -` should not produce resources with the `app.kubernetes.io/managed-by: Helm` label, because the resources are not managed by helm.


xref: https://github.com/istio/istio/issues/53698