### PR TITLE
[synthetic-monitoring-agent] Add deployment strategy

### DIFF
--- a/charts/synthetic-monitoring-agent/Chart.yaml
+++ b/charts/synthetic-monitoring-agent/Chart.yaml
@@ -15,4 +15,4 @@ name: synthetic-monitoring-agent
 sources:
   - https://github.com/grafana/synthetic-monitoring-agent
 type: application
-version: 0.4.0
+version: 0.5.0

--- a/charts/synthetic-monitoring-agent/README.md
+++ b/charts/synthetic-monitoring-agent/README.md
@@ -1,6 +1,6 @@
 # synthetic-monitoring-agent
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.9.3-0-gcd7aadd](https://img.shields.io/badge/AppVersion-v0.9.3--0--gcd7aadd-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.9.3-0-gcd7aadd](https://img.shields.io/badge/AppVersion-v0.9.3--0--gcd7aadd-informational?style=flat-square)
 
 Grafana's Synthetic Monitoring application. The agent provides probe functionality and executes network checks for monitoring remote targets.
 
@@ -37,6 +37,7 @@ Kubernetes: `^1.16.0-0`
 | autoscaling.minReplicas | int | `1` | Minimum autoscaling replicas |
 | autoscaling.targetCPUUtilizationPercentage | int | `60` | Target CPU utilisation percentage |
 | autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory utilisation percentage |
+| deploymentStrategy | object | `{}` | See `kubectl explain deployment.spec.strategy` for more ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |
 | extraObjects | list | `[]` | Add dynamic manifests via values: |
 | fullnameOverride | string | `""` | Override the fullname of the chart. |
 | hostAliases | list | `[]` | hostAliases to add |

--- a/charts/synthetic-monitoring-agent/templates/deployment.yaml
+++ b/charts/synthetic-monitoring-agent/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     {{- include "synthetic-monitoring-agent.labels" . | nindent 4 }}
 spec:
+  {{- with .Values.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
   minReadySeconds: 10
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/synthetic-monitoring-agent/templates/deployment.yaml
+++ b/charts/synthetic-monitoring-agent/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   {{- with .Values.deploymentStrategy }}
   strategy:
-    {{- toYaml . | trim | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   minReadySeconds: 10
   {{- if not .Values.autoscaling.enabled }}

--- a/charts/synthetic-monitoring-agent/values.yaml
+++ b/charts/synthetic-monitoring-agent/values.yaml
@@ -152,3 +152,8 @@ extraObjects: []
 secret:
 # -- Reference an existing secret for API token
   existingSecret: ""
+
+# -- See `kubectl explain deployment.spec.strategy` for more
+# ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+deploymentStrategy: {}
+  # type: RollingUpdate


### PR DESCRIPTION
Added a deploymentStrategy for the synthetic-monitoring-agent helm.

This allows more controle on how the pods will be deployed.
Used the same syntax as other helm charts already do.