### PR TITLE
[synthetic-monitoring-agent] bump version to v0.29.3

### DIFF
--- a/charts/synthetic-monitoring-agent/Chart.yaml
+++ b/charts/synthetic-monitoring-agent/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v0.9.3-0-gcd7aadd
+appVersion: v0.29.3
 description: Grafana's Synthetic Monitoring application. The agent provides probe functionality and executes network checks for monitoring remote targets.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png
@@ -15,4 +15,4 @@ name: synthetic-monitoring-agent
 sources:
   - https://github.com/grafana/synthetic-monitoring-agent
 type: application
-version: 0.5.0
+version: 0.6.0

--- a/charts/synthetic-monitoring-agent/README.md
+++ b/charts/synthetic-monitoring-agent/README.md
@@ -1,6 +1,6 @@
 # synthetic-monitoring-agent
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.9.3-0-gcd7aadd](https://img.shields.io/badge/AppVersion-v0.9.3--0--gcd7aadd-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.3](https://img.shields.io/badge/AppVersion-v0.29.3-informational?style=flat-square)
 
 Grafana's Synthetic Monitoring application. The agent provides probe functionality and executes network checks for monitoring remote targets.
 


### PR DESCRIPTION
A user brought the existence of this helm chart to my knowledge, and figured I could bump the version. Perhaps we could set up some automation for this, e.g. renovate?