### PR TITLE
[tempo-distributed] Support specific nodePort assignments 

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.21.1
+version: 1.21.2
 appVersion: 2.6.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.21.1](https://img.shields.io/badge/Version-1.21.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.0](https://img.shields.io/badge/AppVersion-2.6.0-informational?style=flat-square)
+![Version: 1.21.2](https://img.shields.io/badge/Version-1.21.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.0](https://img.shields.io/badge/AppVersion-2.6.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -351,6 +351,7 @@ The memcached default args are removed and should be provided manually. The sett
 | distributor.service.labels | object | `{}` | Labels for distributor service |
 | distributor.service.loadBalancerIP | string | `""` | If type is LoadBalancer you can assign the IP to the LoadBalancer |
 | distributor.service.loadBalancerSourceRanges | list | `[]` | If type is LoadBalancer limit incoming traffic from IPs. |
+| distributor.service.nodePorts | object | `{"grpc":null,"grpcJaeger":null,"grpcOtlp":null,"grpcOtlpLegacy":null,"jaegerBinary":null,"jaegerCompact":null,"jaegerHttp":null,"opencensus":null,"otlpHttp":null,"zipkin":null}` | If type is NodePort you can set specific `nodePort` values for each service. null will assign a random port |
 | distributor.service.type | string | `"ClusterIP"` | Type of service for the distributor |
 | distributor.serviceDiscovery.annotations | object | `{}` | Annotations for distributorDiscovery service |
 | distributor.serviceDiscovery.labels | object | `{}` | Labels for distributorDiscovery service |
@@ -388,6 +389,7 @@ The memcached default args are removed and should be provided manually. The sett
 | enterpriseFederationFrontend.service.annotations | object | `{}` | Annotations for enterpriseFederationFrontend service |
 | enterpriseFederationFrontend.service.loadBalancerIP | string | `""` | If type is LoadBalancer you can assign the IP to the LoadBalancer |
 | enterpriseFederationFrontend.service.loadBalancerSourceRanges | list | `[]` | If type is LoadBalancer limit incoming traffic from IPs. |
+| enterpriseFederationFrontend.service.nodePort | string | `nil` | If type is NodePort set the nodePort.  Null will assign a random port |
 | enterpriseFederationFrontend.service.port | int | `3100` | Port of the federation-frontend service |
 | enterpriseFederationFrontend.service.type | string | `"ClusterIP"` | Type of service for the enterpriseFederationFrontend |
 | enterpriseFederationFrontend.terminationGracePeriodSeconds | int | `30` | Grace period to allow the federation-frontend to shutdown before it is killed |
@@ -429,6 +431,7 @@ The memcached default args are removed and should be provided manually. The sett
 | enterpriseGateway.service.clusterIP | string | `nil` | ClusterIP of the enterprise gateway service |
 | enterpriseGateway.service.labels | object | `{}` | Labels for enterprise gateway service |
 | enterpriseGateway.service.loadBalancerIP | string | `nil` | Load balancer IPO address if service type is LoadBalancer for enterprise gateway service |
+| enterpriseGateway.service.nodePort | string | `nil` | If type is NodePort, set a nodePort value.  Null will assign a random port |
 | enterpriseGateway.service.port | string | `nil` | Port of the enterprise gateway service; if left undefined, the service will listen on the same port as the pod |
 | enterpriseGateway.service.type | string | `"ClusterIP"` | Type of the enterprise gateway service |
 | enterpriseGateway.strategy.rollingUpdate.maxSurge | int | `0` |  |
@@ -788,6 +791,7 @@ The memcached default args are removed and should be provided manually. The sett
 | queryFrontend.service.labels | object | `{}` | Labels for queryFrontend service |
 | queryFrontend.service.loadBalancerIP | string | `""` | If type is LoadBalancer you can assign the IP to the LoadBalancer |
 | queryFrontend.service.loadBalancerSourceRanges | list | `[]` | If type is LoadBalancer limit incoming traffic from IPs. |
+| queryFrontend.service.nodePorts | object | `{"grpc":null,"jaegerMetrics":null,"jaegerUi":null,"metrics":null}` | If type is NodePort, set the 'nodePort'.  Null will assign a random nodeport |
 | queryFrontend.service.port | int | `16686` | Port of the query-frontend service |
 | queryFrontend.service.type | string | `"ClusterIP"` | Type of service for the queryFrontend |
 | queryFrontend.serviceDiscovery.annotations | object | `{}` | Annotations for queryFrontendDiscovery service |

--- a/charts/tempo-distributed/templates/distributor/service-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/service-distributor.yaml
@@ -23,6 +23,9 @@ spec:
       port: 9095
       protocol: TCP
       targetPort: 9095
+      {{- if (and (eq .Values.distributor.service.type "NodePort") (.Values.distributor.service.nodePorts.grpc)) }}
+      nodePort: {{ .Values.distributor.service.nodePorts.grpc }}
+      {{- end }}
       {{- if .Values.distributor.appProtocol.grpc }}
       appProtocol: {{ .Values.distributor.appProtocol.grpc }}
       {{- end }}
@@ -31,18 +34,27 @@ spec:
       port: 6831
       protocol: UDP
       targetPort: jaeger-compact
+      {{- if (and (eq .Values.distributor.service.type "NodePort") (.Values.distributor.service.nodePorts.jaegerCompact)) }}
+      nodePort: {{ .Values.distributor.service.nodePorts.jaegerCompact }}
+      {{- end }}
     {{- end }}
     {{- if .Values.traces.jaeger.thriftBinary.enabled }}
     - name: distributor-jaeger-thrift-binary
       port: 6832
       protocol: UDP
       targetPort: jaeger-binary
+      {{- if (and (eq .Values.distributor.service.type "NodePort") (.Values.distributor.service.nodePorts.jaegerBinary)) }}
+      nodePort: {{ .Values.distributor.service.nodePorts.jaegerBinary }}
+      {{- end }}
     {{- end }}
     {{- if .Values.traces.jaeger.thriftHttp.enabled }}
     - name: distributor-jaeger-thrift-http
       port: 14268
       protocol: TCP
       targetPort: jaeger-http
+      {{- if (and (eq .Values.distributor.service.type "NodePort") (.Values.distributor.service.nodePorts.jaegerHttp)) }}
+      nodePort: {{ .Values.distributor.service.nodePorts.jaegerHttp }}
+      {{- end }}
     {{- end }}
     {{- if .Values.traces.jaeger.grpc.enabled }}
     - name: grpc-distributor-jaeger
@@ -52,18 +64,27 @@ spec:
       {{- if .Values.distributor.appProtocol.grpc }}
       appProtocol: {{ .Values.distributor.appProtocol.grpc }}
       {{- end }}
+      {{- if (and (eq .Values.distributor.service.type "NodePort") (.Values.distributor.service.nodePorts.grpcJaeger)) }}
+      nodePort: {{ .Values.distributor.service.nodePorts.grpcJaeger }}
+      {{- end }}
     {{- end }}
     {{- if .Values.traces.zipkin.enabled }}
     - name: distributor-zipkin
       port: 9411
       protocol: TCP
       targetPort: zipkin
+      {{- if (and (eq .Values.distributor.service.type "NodePort") (.Values.distributor.service.nodePorts.zipkin)) }}
+      nodePort: {{ .Values.distributor.service.nodePorts.zipkin }}
+      {{- end }}
     {{- end }}
     {{- if .Values.traces.otlp.http.enabled }}
     - name: distributor-otlp-http
       port: 4318
       protocol: TCP
       targetPort: otlp-http
+      {{- if (and (eq .Values.distributor.service.type "NodePort") (.Values.distributor.service.nodePorts.otlpHttp)) }}
+      nodePort: {{ .Values.distributor.service.nodePorts.otlpHttp }}
+      {{- end }}
     {{- end }}
     {{- if .Values.traces.otlp.grpc.enabled }}
     - name: grpc-distributor-otlp
@@ -73,6 +94,9 @@ spec:
       {{- if .Values.distributor.appProtocol.grpc }}
       appProtocol: {{ .Values.distributor.appProtocol.grpc }}
       {{- end }}
+      {{- if (and (eq .Values.distributor.service.type "NodePort") (.Values.distributor.service.nodePorts.grpcOtlp)) }}
+      nodePort: {{ .Values.distributor.service.nodePorts.grpcOtlp }}
+      {{- end }}
     - name: distributor-otlp-legacy
       port: 55680
       protocol: TCP
@@ -80,12 +104,18 @@ spec:
       {{- if .Values.distributor.appProtocol.grpc }}
       appProtocol: {{ .Values.distributor.appProtocol.grpc }}
       {{- end }}
+      {{- if (and (eq .Values.distributor.service.type "NodePort") (.Values.distributor.service.nodePorts.grpcOtlpLegacy)) }}
+      nodePort: {{ .Values.distributor.service.nodePorts.grpcOtlpLegacy }}
+      {{- end }}
     {{- end }}
     {{- if .Values.traces.opencensus.enabled }}
     - name: distributor-opencensus
       port: 55678
       protocol: TCP
       targetPort: opencensus
+      {{- if (and (eq .Values.distributor.service.type "NodePort") (.Values.distributor.service.nodePorts.opencensus)) }}
+      nodePort: {{ .Values.distributor.service.nodePorts.opencensus }}
+      {{- end }}
     {{- end }}
   {{- if .Values.distributor.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.distributor.service.loadBalancerIP  }}

--- a/charts/tempo-distributed/templates/enterprise-federation-frontend/service-federation-frontend.yaml
+++ b/charts/tempo-distributed/templates/enterprise-federation-frontend/service-federation-frontend.yaml
@@ -16,6 +16,9 @@ spec:
     - name: http-metrics
       port: 3100
       targetPort: 3100
+      {{- if (and (eq .Values.enterpriseFederationFrontend.service.type "NodePort") (.Values.enterpriseFederationFrontend.service.nodePort)) }}
+      nodePort: {{ .Values.enterpriseFederationFrontend.service.nodePort }}
+      {{- end }}
   {{- if .Values.enterpriseFederationFrontend.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.enterpriseFederationFrontend.service.loadBalancerIP  }}
   {{- end }}

--- a/charts/tempo-distributed/templates/enterprise-gateway/gateway-svc.yaml
+++ b/charts/tempo-distributed/templates/enterprise-gateway/gateway-svc.yaml
@@ -25,6 +25,9 @@ spec:
       protocol: TCP
       name: http-metrics
       targetPort: http-metrics
+      {{- if (and (eq .Values.enterpriseGateway.service.type "NodePort") (.Values.enterpriseGateway.service.nodePort)) }}
+      nodePort: {{ .Values.enterpriseGateway.service.nodePort }}
+      {{- end }}
   selector:
     {{- include "tempo.selectorLabels" $dict | nindent 4 }}
 {{- end -}}

--- a/charts/tempo-distributed/templates/query-frontend/service-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/service-query-frontend.yaml
@@ -18,6 +18,9 @@ spec:
     - name: http-metrics
       port: 3100
       targetPort: 3100
+      {{- if and (eq "NodePort" .Values.queryFrontend.service.type) .Values.queryFrontend.service.nodePorts.metrics }}
+      nodePort: {{ .Values.queryFrontend.service.nodePorts.metrics }}
+      {{- end }}
     - name: grpc
       port: 9095
       protocol: TCP
@@ -25,13 +28,22 @@ spec:
       {{- if .Values.queryFrontend.appProtocol.grpc }}
       appProtocol: {{ .Values.queryFrontend.appProtocol.grpc }}
       {{- end }}
+      {{- if and (eq "NodePort" .Values.queryFrontend.service.type) .Values.queryFrontend.service.nodePorts.grpc }}
+      nodePort: {{ .Values.queryFrontend.service.nodePorts.grpc }}
+      {{- end }}
     {{- if .Values.queryFrontend.query.enabled }}
     - name: tempo-query-jaeger-ui
       port: {{ .Values.queryFrontend.service.port }}
       targetPort: {{ .Values.queryFrontend.service.port }}
+      {{- if and (eq "NodePort" .Values.queryFrontend.service.type) .Values.queryFrontend.service.nodePorts.jaegerUi }}
+      nodePort: {{ .Values.queryFrontend.service.nodePorts.jaegerUi }}
+      {{- end }}
     - name: tempo-query-metrics
       port: 16687
       targetPort: jaeger-metrics
+      {{- if and (eq "NodePort" .Values.queryFrontend.service.type) .Values.queryFrontend.service.nodePorts.jaegerMetrics }}
+      nodePort: {{ .Values.queryFrontend.service.nodePorts.jaegerMetrics }}
+      {{- end }}
     {{- end }}
   {{- if .Values.queryFrontend.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.queryFrontend.service.loadBalancerIP  }}

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -478,6 +478,19 @@ distributor:
     loadBalancerSourceRanges: []
     # -- If type is LoadBalancer you can set it to 'Local' [preserve the client source IP](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip)
     externalTrafficPolicy: null
+    # -- If type is NodePort you can set specific `nodePort` values for each service. null will assign a random port
+    nodePorts:
+      grpc: null
+      jaegerCompact: null
+      jaegerBinary: null
+      jaegerHttp: null
+      grpcJaeger: null
+      zipkin: null
+      otlpHttp: null
+      grpcOtlp: null
+      grpcOtlpLegacy: null
+      opencensus: null
+
   serviceDiscovery:
     # -- Annotations for distributorDiscovery service
     annotations: {}
@@ -869,6 +882,12 @@ queryFrontend:
     loadBalancerIP: ""
     # -- If type is LoadBalancer limit incoming traffic from IPs.
     loadBalancerSourceRanges: []
+    # -- If type is NodePort, set the 'nodePort'.  Null will assign a random nodeport
+    nodePorts:
+      metrics: null
+      grpc: null
+      jaegerUi: null
+      jaegerMetrics: null
   serviceDiscovery:
     # -- Annotations for queryFrontendDiscovery service
     annotations: {}
@@ -1001,6 +1020,8 @@ enterpriseFederationFrontend:
     loadBalancerIP: ""
     # -- If type is LoadBalancer limit incoming traffic from IPs.
     loadBalancerSourceRanges: []
+    # -- If type is NodePort set the nodePort.  Null will assign a random port
+    nodePort: null
   # -- The name of the PriorityClass for federation-frontend pods
   priorityClassName: null
   # -- Labels for enterpriseFederationFrontend pods
@@ -2207,6 +2228,8 @@ enterpriseGateway:
     annotations: {}
     # -- Labels for enterprise gateway service
     labels: {}
+    # -- If type is NodePort, set a nodePort value.  Null will assign a random port
+    nodePort: null
 
   strategy:
     type: RollingUpdate


### PR DESCRIPTION
For services in `tempo-distributed` where the service type can be set to `NodePort`, the chart should support setting specific NodePort values for those services.