### PR TITLE
update-helm-repo: fix oci image push

### DIFF
--- a/.github/workflows/update-helm-repo.yaml
+++ b/.github/workflows/update-helm-repo.yaml
@@ -94,8 +94,7 @@ jobs:
     needs: [setup]
     runs-on: ubuntu-latest
     permissions:
-      contents: write # to push chart release, create release, and push tags to github
-      packages: write # to push package to ghcr
+      packages: write # allows GITHUB_TOKEN to push package to ghcr
     env:
       github_app_id: ${{ secrets.github_app_id }}
     if: needs.setup.outputs.changed == 'true'
@@ -234,7 +233,9 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ env.AUTHTOKEN }}
+          # GitHub App installation token cannot push package to the org's package registry;
+          # using GITHUB_TOKEN here instead to avoid using PAT.
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push charts to GHCR
         run: |


### PR DESCRIPTION
This is the fixup for https://github.com/grafana/helm-charts/pull/3366

Relates to #3068

It turned out GitHub doesn't support publishing a package using GitHub App installation tokens (or fine-grained personal tokens). That is, as of today, the users are left with using either "classic" PAT with org-scopes or the magical `GITHUB_TOKEN` ([docs](https://docs.github.com/en/packages/learn-github-packages/publishing-a-package#publishing-a-package)).

This PR fixes the `update-helm-repo` workflow, updating the last step to use the `GITHUB_TOKEN` token. 

Note that, the package is pushed to the `GITHUB_REPOSITORY_OWNER` repository, under the name `helm-charts/<chart-name>`. The package the is automatically associated with the source repository, that run the push. 