### PR TITLE
CI: only install gateway CRDs if k8s version >= 1.23

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -83,6 +83,7 @@ jobs:
           # Compare version with 1.23. The gateway CRDs use x-kubernetes-validations, which is only supported from 1.23 onwards.
           if [ "$major_version" -eq 1 ] && [ "$minor_version" -ge 23 ] || [ "$major_version" -gt 1 ]; then
             echo "Kubernetes version $version >= 1.23, applying Gateway API CRDs"
+            kubectl apply -k https://github.com/kubernetes-sigs/gateway-api/config/crd
           else
             echo "Kubernetes version $version < 1.23, skipping Gateway API CRDs installation"
             echo "Please use an older version of Gateway API CRDs or upgrade your Kubernetes version"

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -72,9 +72,21 @@ jobs:
           kubectl_version: ${{ inputs.kind_kubectl_version }}
           node_image: ${{ inputs.kind_node_image }}
 
-      - name: Apply Gateway API CRDs
+      - name: Check Kubernetes version and apply Gateway API CRDs
         if: steps.list-changed.outputs.changed == 'true'
-        run: kubectl apply -k https://github.com/kubernetes-sigs/gateway-api/config/crd
+        run: |
+          # Get Kubernetes version and extract the major.minor version
+          version=$(kubectl version -o json | jq -r '.serverVersion.major + "." + .serverVersion.minor' | tr -d '+')
+          major_version=$(echo $version | cut -d. -f1)
+          minor_version=$(echo $version | cut -d. -f2)
+          
+          # Compare version with 1.23. The gateway CRDs use x-kubernetes-validations, which is only supported from 1.23 onwards.
+          if [ "$major_version" -eq 1 ] && [ "$minor_version" -ge 23 ] || [ "$major_version" -gt 1 ]; then
+            echo "Kubernetes version $version >= 1.23, applying Gateway API CRDs"
+          else
+            echo "Kubernetes version $version < 1.23, skipping Gateway API CRDs installation"
+            echo "Please use an older version of Gateway API CRDs or upgrade your Kubernetes version"
+          fi
 
       - name: Run chart-testing (install)
         run: |


### PR DESCRIPTION
Follow-up of #3400

The gateway CRDs installed use `x-kubernetes-validations` which is only [available as of 1.23](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#jsonschemaprops-v1-apiextensions-k8s-io).

This breaks CI when the kubectl version is lower than 1.23. We use these CI actions for grafana/mimir-distributed [with 1.20 for example](https://github.com/grafana/mimir/blob/a7f1e3f79fe0a72f64d2f60c6ce65afa03e2dd8c/.github/workflows/helm-ci.yml#L11-L18)