### PR TITLE
workflows: bring back missing permissions to update-helm-repo

### DIFF
--- a/.github/workflows/update-helm-repo.yaml
+++ b/.github/workflows/update-helm-repo.yaml
@@ -94,6 +94,7 @@ jobs:
     needs: [setup]
     runs-on: ubuntu-latest
     permissions:
+      contents: write # allows GITHUB_TOKEN to push chart release, create release, and push tags to github
       packages: write # allows GITHUB_TOKEN to push package to ghcr
     env:
       github_app_id: ${{ secrets.github_app_id }}


### PR DESCRIPTION
This is a fixup to #3366 #3418

In #3383 I'd already added these permissions, but I removed them later in #3418 — removing them was wrong.

That is, the workflow uses `GITHUB_TOKEN` to push the tag to the **source** repository. This is indicated by the error (note `github-actions[bot]`):

```
Pushing tag mimir-distributed-5.6.0-weekly.314
remote: Permission to grafana/mimir.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/grafana/mimir/': The requested URL returned error: 403
```

This was the part I've missed. My thinking was that the tags are always created by the GitHub App install token (ref. to what I _wrongly_ mentioned in this comment https://github.com/grafana/helm-charts/pull/3418#discussion_r1836710790).

This PR should fix the workflow.