### PR TITLE
[tempo-distributed] Remove duplicated ingester podLabels

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.23.0
+version: 1.23.1
 appVersion: 2.6.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.23.0](https://img.shields.io/badge/Version-1.23.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.0](https://img.shields.io/badge/AppVersion-2.6.0-informational?style=flat-square)
+![Version: 1.23.1](https://img.shields.io/badge/Version-1.23.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.0](https://img.shields.io/badge/AppVersion-2.6.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
@@ -42,9 +42,6 @@ spec:
         {{- with .Values.tempo.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- with .Values.ingester.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap-tempo.yaml") . | sha256sum }}
         {{- with .Values.tempo.podAnnotations }}


### PR DESCRIPTION
Closes https://github.com/grafana/helm-charts/issues/3237

Ran into an issue when trying to add `podLabels` into our deploy of tempo. 
```
RUNTIME ERROR: Parsing Helm output: yaml: unmarshal errors:
  line 1752: mapping key "name" already defined at line 1751
```

Tracking back to the rendering here, it seems like the `.Values.ingester.podLabels` are duplicated between the statefulset definition and the `_helpers.tpl` function : https://github.com/grafana/helm-charts/blob/main/charts/tempo-distributed/templates/ingester/_helpers-ingester.tpl#L172-L174