### PR TITLE
[tempo-distributed] Added LegacyOverrides for processors

### DIFF
--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -403,7 +403,7 @@ metricsGenerator:
       external_labels: {}
       stale_duration: 15m
     processor:
-      # -- For processors to be enabled and generate metrics, pass the names of the processors to overrides.metrics_generator_processors value like [service-graphs, span-metrics]
+      # -- For processors to be enabled and generate metrics, pass the names of the processors to overrides.LegacyOverrides.metrics_generator_processors value like [service-graphs, span-metrics]
       service_graphs:
         # -- Additional dimensions to add to the metrics. Dimensions are searched for in the
         # -- resource and span attributes and are added to the metrics if present.


### PR DESCRIPTION
To enable metrics generator, the chart says to pass the names of the processors to overrides.metrics_generator_processors value like [service-graphs, span-metrics
but this does not work.

the following block must be added:
```bash
global_overrides:
  per_tenant_override_config: /runtime-config/overrides.yaml

overrides:
  legacyOverrides:
    metrics_generator_processors:
      - service-graphs
      - span-metrics
```


this does not work (which is presented in the chart):

```bash
overrides:
    metrics_generator_processors:
      - service-graphs
      - span-metrics
```
the following works in the single binary version:
```bash
overrides:
  defaults:
    metrics_generator:
      processors: [service-graphs, span-metrics, local-blocks]
```