### PR TITLE
[loki-distributed] Add resource requests and limits to tokengen job template

### DIFF
--- a/charts/enterprise-logs/Chart.yaml
+++ b/charts/enterprise-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v2"
 name: "enterprise-logs"
 type: application
-version: "2.5.0"
+version: "2.5.1"
 appVersion: "v1.5.2"
 kubeVersion: "^1.10.0-0"
 description: "Grafana Enterprise Logs"

--- a/charts/enterprise-logs/small.yaml
+++ b/charts/enterprise-logs/small.yaml
@@ -35,6 +35,17 @@ compactor:
       cpu: 2
       memory: 1Gi
 
+# -target=tokengen
+# defined in enterprise-logs chart
+tokengen:
+  resources:
+    limits:
+      cpu: 1
+      memory: 1Gi
+    requests:
+      cpu: 0.5
+      memory: 500Mi
+
 # -target=gateway
 # defined in enterprise-logs chart
 gateway:

--- a/charts/enterprise-logs/templates/tokengen/job-tokengen.yaml
+++ b/charts/enterprise-logs/templates/tokengen/job-tokengen.yaml
@@ -73,6 +73,8 @@ spec:
               mountPath: /etc/loki/config
             - name: license
               mountPath: /etc/enterprise-logs/license
+          resources:
+            {{- toYaml .Values.enterprise.tokengen.resources | nindent 8 }}
           env:
             {{- if .Values.tokengen.env }}
               {{ toYaml .Values.tokengen.env | nindent 12 }}
@@ -97,6 +99,8 @@ spec:
               mountPath: /etc/loki/config
             - name: license
               mountPath: /etc/enterprise-logs/license
+          resources:
+            {{- toYaml .Values.enterprise.tokengen.resources | nindent 8 }}
           securityContext:
             {{- toYaml .Values.tokengen.containerSecurityContext | nindent 12 }}
       restartPolicy: OnFailure

--- a/charts/enterprise-logs/values.yaml
+++ b/charts/enterprise-logs/values.yaml
@@ -189,6 +189,11 @@ tokengen:
   extraVolumes: []
   # -- Additional volume mounts for Pods
   extraVolumeMounts: []
+
+  # -- Request and limit Kubernetes resources
+  # -- Values are defined in small.yaml and large.yaml
+  resources: {}
+
   # -- Run containers as user `enterprise-logs(uid=10001)`
   podSecurityContext:
     runAsNonRoot: true


### PR DESCRIPTION
The` job-tokengen.yaml` template within the Helm chart currently does not include resource `limits `and `requests` for both `initContainers` and regular `containers`. 

By adding resource configuration to the chart, we ensure that users can specify `limits `and `requests` for `CPU` and `memory`, preventing such errors and allowing users to manage resource quotas more effectively.

**What has been changed:**
- Added resource limits and requests configuration to initContainers and containers.
- The resource values are read from the chart’s values.yaml.

**Why is this useful:**
- Resolves errors related to missing resource limits in Kubernetes resource quotas.
- Provides flexibility to users to define the resource needs of their jobs.
- Aligns with best practices for managing resources in Kubernetes.