### PR TITLE
[grafana] feat(grafana): Introduce profiling container port

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 8.7.1
+version: 8.8.0
 appVersion: 11.4.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 8.6.4
+version: 8.6.5
 appVersion: 11.3.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -1088,6 +1088,9 @@ containers:
       - name: {{ .Values.gossipPortName }}-udp
         containerPort: 9094
         protocol: UDP
+      - name: profiling
+        containerPort: 6060
+        protocol: TCP
     env:
       - name: POD_IP
         valueFrom:


### PR DESCRIPTION
In order to enable profiling using Grafana Alloy and Grafana Pyroscope
currently you would need to abuse another container port or insert a
dummy container to facitilitate profile collection.

This is because a containerPort is matched with the annotations to
enable profiling. As a workaround I am "abusing" the port :9094, as for
the example I am working on it is unused. This change will make it
possible to coexist with gossip-tcp and you would be able to enable
profiling like this:

```
helm upgrade -n pyroscope-test --install grafana grafana/grafana \
  --set env.GF_DIAGNOSTICS_PROFILING_ENABLED=true \
  --set env.GF_DIAGNOSTICS_PROFILING_ADDR=0.0.0.0 \
  --set env.GF_DIAGNOSTICS_PROFILING_PORT=6060 \
  --set-string 'podAnnotations.profiles\.grafana\.com/cpu\.scrape=true' \
  --set-string 'podAnnotations.profiles\.grafana\.com/cpu\.port=6060' \
  --set-string 'podAnnotations.profiles\.grafana\.com/memory\.scrape=true' \
  --set-string 'podAnnotations.profiles\.grafana\.com/memory\.port=6060' \
  --set-string 'podAnnotations.profiles\.grafana\.com/goroutine\.scrape=true' \
  --set-string 'podAnnotations.profiles\.grafana\.com/goroutine\.port=6060'
```

This is related to https://github.com/grafana/pyroscope/pull/3753
