### PR TITLE
[grafana-sampling] add max message receive size config param 

### DIFF
--- a/charts/grafana-sampling/Chart.yaml
+++ b/charts/grafana-sampling/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: grafana-sampling
 description: A Helm chart for a layered OTLP tail sampling and metrics generation pipeline.
 type: application
-version: 1.1.1
+version: 1.1.2
 appVersion: "v1.5.1"
 sources:
   - https://github.com/grafana/alloy

--- a/charts/grafana-sampling/README.md
+++ b/charts/grafana-sampling/README.md
@@ -1,6 +1,6 @@
 # grafana-sampling
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.5.1](https://img.shields.io/badge/AppVersion-v1.5.1-informational?style=flat-square)
+![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.5.1](https://img.shields.io/badge/AppVersion-v1.5.1-informational?style=flat-square)
 
 A Helm chart for a layered OTLP tail sampling and metrics generation pipeline.
 
@@ -143,6 +143,8 @@ A major chart version change indicates that there is an incompatible breaking ch
 | batch.statefulset.send_batch_max_size | int | `0` |  |
 | batch.statefulset.send_batch_size | int | `8192` |  |
 | batch.statefulset.timeout | string | `"200ms"` |  |
+| deployment.otlp.receiver | object | `{"grpc":{"max_recv_msg_size":"4MB"}}` | otlp receiver settings for deployment (loadbalancer) |
+| deployment.otlp.receiver.grpc.max_recv_msg_size | string | `"4MB"` | gRPC max message receive size. Default to 4MB |
 | metricsGeneration.dimensions | list | `["service.namespace","service.version","deployment.environment","k8s.cluster.name","k8s.pod.name"]` | Additional dimensions to add to generated metrics. |
 | metricsGeneration.enabled | bool | `true` | Toggle generation of spanmetrics and servicegraph metrics. |
 | metricsGeneration.legacy | bool | `true` | Use legacy metric names that match those used by the Tempo metrics generator. |
@@ -153,4 +155,6 @@ A major chart version change indicates that there is an incompatible breaking ch
 | sampling.failedRequests.sample | bool | `false` | Toggle sampling failed requests. |
 | sampling.successfulRequests.percentage | int | `10` | Percentage of successful requests to sample. |
 | sampling.successfulRequests.sample | bool | `true` | Toggle sampling successful requests. |
+| statefulset.otlp.receiver | object | `{"grpc":{"max_recv_msg_size":"4MB"}}` | otlp receiver settings for statefulset (sampler) |
+| statefulset.otlp.receiver.grpc.max_recv_msg_size | string | `"4MB"` | gRPC max message receive size. Default to 4MB |
 

--- a/charts/grafana-sampling/templates/_otelcol_receiver_otlp.alloy.txt
+++ b/charts/grafana-sampling/templates/_otelcol_receiver_otlp.alloy.txt
@@ -3,7 +3,10 @@ otelcol.receiver.otlp "default" {
   // https://grafana.com/docs/alloy/latest/reference/components/otelcol.receiver.otlp/
 
   // configures the default grpc endpoint "0.0.0.0:4317"
-  grpc { }
+  grpc {
+    max_recv_msg_size = {{ .Values.deployment.otlp.receiver.grpc.max_recv_msg_size | quote }}
+  }
+
   // configures the default http/protobuf endpoint "0.0.0.0:4318"
   http { }
 
@@ -19,7 +22,9 @@ otelcol.receiver.otlp "default" {
   // https://grafana.com/docs/alloy/latest/reference/components/otelcol.receiver.otlp/
 
   // configures the default grpc endpoint "0.0.0.0:4317"
-  grpc { }
+  grpc {
+    max_recv_msg_size = {{ .Values.statefulset.otlp.receiver.grpc.max_recv_msg_size | quote }}
+  }
 
   output {
     traces = [

--- a/charts/grafana-sampling/values.yaml
+++ b/charts/grafana-sampling/values.yaml
@@ -61,6 +61,23 @@ batch:
     send_batch_size: 8192
     send_batch_max_size: 0
 
+
+deployment:
+  otlp:
+    # -- otlp receiver settings for deployment (loadbalancer)
+    receiver:
+      grpc:
+        # -- gRPC max message receive size. Default to 4MB
+        max_recv_msg_size: 4MB
+
+statefulset:
+  otlp:
+    # -- otlp receiver settings for statefulset (sampler)
+    receiver:
+      grpc:
+        # -- gRPC max message receive size. Default to 4MB
+        max_recv_msg_size: 4MB
+
 # @ignored Ignore alloy deployment
 alloy-deployment:
   # -- Do not change this.


### PR DESCRIPTION
Add max message receive size config param for otlp receivers used in sampling chart. Defaults to 4MB. 

Resolves #3483 

Example configuration:
```yaml
deployment:
  otlp:
    receiver:
      grpc:
        max_recv_msg_size: 4MB

statefulset:
  otlp:
    receiver:
      grpc:
        max_recv_msg_size: 16MB
```