### PR TITLE
Update values.yaml - enable alertmanager v2 api by default

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.9.10
-version: 0.80.0
+version: 0.81.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -226,6 +226,7 @@ loki:
       rule_path: /tmp/loki/scratch
       alertmanager_url: https://alertmanager.xx
       external_url: https://alertmanager.xx
+      enable_alertmanager_v2: true
 
   # -- Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas
   schemaConfig:


### PR DESCRIPTION
This enables alertmanger's V2 api by default for the loki-distributed chart for loki ruler. Helps with making this more clear https://github.com/grafana/loki/issues/12859 (it should be fixed upstream, but for some reason, I still had to set it manually when I installed this chart)