### PR TITLE
[tempo-distributed] Ports/service related configuration not configureable

### DIFF
--- a/charts/tempo-distributed/templates/gateway/deployment-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/deployment-gateway.yaml
@@ -55,7 +55,7 @@ spec:
           image: "{{ include "tempo.imageReference" $dict }}"
           imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
           ports:
-            - name: http-metrics
+            - name: {{  .Values.gateway.service.name }}
               containerPort: 8080
               protocol: TCP
           {{- if or .Values.global.extraEnv .Values.gateway.extraEnv }}
@@ -72,7 +72,15 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           readinessProbe:
-            {{- toYaml .Values.gateway.readinessProbe | nindent 12 }}
+            httpGet:
+              path: {{ .Values.gateway.path }}
+              port: {{ .Values.gateway.service.name }}
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.gateway.service.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.gateway.service.timeoutSeconds }}
+            periodSeconds: {{ .Values.gateway.service.periodSeconds }}
+            successThreshold: {{ .Values.gateway.service.successThreshold }}
+            failureThreshold: {{ .Values.gateway.service.failureThreshold }}
           volumeMounts:
             - name: config
               mountPath: /etc/nginx

--- a/charts/tempo-distributed/templates/gateway/service-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/service-gateway.yaml
@@ -22,9 +22,9 @@ spec:
   loadBalancerIP: {{ .Values.gateway.service.loadBalancerIP }}
   {{- end }}
   ports:
-    - name: http-metrics
+    - name: {{ .Values.gateway.service.name }}
       port: {{ .Values.gateway.service.port }}
-      targetPort: http-metrics
+      targetPort: 8080
       {{- if and (eq "NodePort" .Values.gateway.service.type) .Values.gateway.service.nodePort }}
       nodePort: {{ .Values.gateway.service.nodePort }}
       {{- end }}

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -1903,6 +1903,8 @@ gateway:
   tolerations: []
   # Gateway service configuration
   service:
+    # -- Port Name of the gateway service
+    name: http-gateway
     # -- Port of the gateway service
     port: 80
     # -- Type of the gateway service
@@ -1960,9 +1962,11 @@ gateway:
   readinessProbe:
     httpGet:
       path: /
-      port: http-metrics
     initialDelaySeconds: 15
     timeoutSeconds: 1
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 3
   nginxConfig:
     # -- NGINX log format
     logFormat: |-


### PR DESCRIPTION
Hi,

None of the service/port related configurations for gateway were actually dynamic.
Also changed the probe so the parameters could be configured 

Cheers
