### PR TITLE
[grafana] set unified_alerting.screenshots.capture to true when imageRenderer is enabled

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 8.8.5
+version: 8.8.6
 appVersion: 11.4.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -867,6 +867,8 @@ grafana.ini:
     url: https://grafana.net
   server:
     domain: "{{ if (and .Values.ingress.enabled .Values.ingress.hosts) }}{{ tpl (.Values.ingress.hosts | first) . }}{{ else }}''{{ end }}"
+  unified_alerting.screenshots:
+    capture: "{{ .Values.imageRenderer.enabled }}"
 ## grafana Authentication can be enabled with the following values on grafana.ini
  # server:
       # The full public facing url you use in browser, used for redirects and emails


### PR DESCRIPTION
~~Set environment variable `GF_UNIFIED_ALERTING_SCREENSHOTS_CAPTURE` to true when `imageRenderer.enabled` is true.~~
I changed values.yaml so that unified_alerting.screenshots.capture is true in grafana.ini when imageRenderer is enabled.
This will cause screenshots to be attached to alerts when `imageRenderer.enabled` is set to true.

As mentioned in #1556, currently screenshot is not attached to alerts even though `imageRenderer.enabled` is set to true.
It would be natural for alerts to have a screenshot attached when the imageRenderer is enabled.