### PR TITLE
[tempo-distributed] Fix Memcached StatefulSet volumeMounts formatting issue

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.32.1
+version: 1.32.2
 appVersion: 2.7.1
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.32.1](https://img.shields.io/badge/Version-1.32.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.1](https://img.shields.io/badge/AppVersion-2.7.1-informational?style=flat-square)
+![Version: 1.32.2](https://img.shields.io/badge/Version-1.32.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.1](https://img.shields.io/badge/AppVersion-2.7.1-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/memcached/statefulset-memcached.yaml
+++ b/charts/tempo-distributed/templates/memcached/statefulset-memcached.yaml
@@ -104,11 +104,11 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-        {{- end }}
           {{- with .Values.memcached.extraVolumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- end }}
       {{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.Version }}
       {{- with .Values.memcached.topologySpreadConstraints }}
       topologySpreadConstraints:


### PR DESCRIPTION
## Description
In using this chart, I came across a formatting error. The conditional for disabling memcached-exporter does not wrap all of its possible settings. If you use volumeMounts and disable memcached-exporter, it still adds the volumeMounts and results in adding a second duplicate section to the memcached container config.

This change fixes that. 

I also wonder if we should set the memcached-exporter extraVolumeMounts to be configured via:
`.Values.memcachedExporter.extraVolumeMounts` rather than the current `.Values.memcached.extraVolumeMounts` so that it is possible to mount different things into each container in the case you may need to rather than them both getting the same thing.