### PR TITLE
[grafana]: chore: bump k8s-sidecar to 1.30.0

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 8.9.0
+version: 8.9.1
 appVersion: 11.5.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -166,7 +166,7 @@ need to instead set `global.imageRegistry`.
 | `lifecycleHooks`                          | Lifecycle hooks for podStart and preStop [Example](https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/#define-poststart-and-prestop-handlers)     | `{}`                                                    |
 | `sidecar.image.registry`                  | Sidecar image registry                        | `quay.io`                          |
 | `sidecar.image.repository`                | Sidecar image repository                      | `kiwigrid/k8s-sidecar`                          |
-| `sidecar.image.tag`                       | Sidecar image tag                             | `1.28.0`                                                |
+| `sidecar.image.tag`                       | Sidecar image tag                             | `1.30.0`                                                |
 | `sidecar.image.sha`                       | Sidecar image sha (optional)                  | `""`                                                    |
 | `sidecar.imagePullPolicy`                 | Sidecar image pull policy                     | `IfNotPresent`                                          |
 | `sidecar.resources`                       | Sidecar resources                             | `{}`                                                    |

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -930,7 +930,7 @@ sidecar:
     # -- The Docker registry
     registry: quay.io
     repository: kiwigrid/k8s-sidecar
-    tag: 1.28.0
+    tag: 1.30.0
     sha: ""
   imagePullPolicy: IfNotPresent
   resources: {}


### PR DESCRIPTION
* bump k8s-sidecar to 1.30.0
* fixes
  * CVE-2024-9143
  * CVE-2024-50602

```
quay.io/kiwigrid/k8s-sidecar:1.28.0 (alpine 3.20.3)

Total: 5 (UNKNOWN: 0, LOW: 2, MEDIUM: 3, HIGH: 0, CRITICAL: 0)

┌────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                            Title                            │
├────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2024-13176 │ MEDIUM   │ fixed  │ 3.3.2-r0          │ 3.3.2-r2      │ openssl: Timing side-channel in ECDSA signature computation │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-13176                  │
│            ├────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│            │ CVE-2024-9143  │ LOW      │        │                   │ 3.3.2-r3      │ openssl: Low-level invalid GF(2^m) parameters lead to OOB   │
│            │                │          │        │                   │               │ memory access                                               │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-9143                   │
├────────────┼────────────────┼──────────┤        ├───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libexpat   │ CVE-2024-50602 │ MEDIUM   │        │ 2.6.3-r0          │ 2.6.4-r0      │ libexpat: expat: DoS via XML_ResumeParser                   │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-50602                  │
├────────────┼────────────────┤          │        ├───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libssl3    │ CVE-2024-13176 │          │        │ 3.3.2-r0          │ 3.3.2-r2      │ openssl: Timing side-channel in ECDSA signature computation │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-13176                  │
│            ├────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│            │ CVE-2024-9143  │ LOW      │        │                   │ 3.3.2-r3      │ openssl: Low-level invalid GF(2^m) parameters lead to OOB   │
│            │                │          │        │                   │               │ memory access                                               │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-9143                   │
└────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘

```

---

```
quay.io/kiwigrid/k8s-sidecar:1.30.0 (alpine 3.21.2)

Total: 2 (UNKNOWN: 0, LOW: 0, MEDIUM: 2, HIGH: 0, CRITICAL: 0)

┌────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                            Title                            │
├────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2024-13176 │ MEDIUM   │ fixed  │ 3.3.2-r4          │ 3.3.2-r5      │ openssl: Timing side-channel in ECDSA signature computation │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-13176                  │
├────────────┤                │          │        │                   │               │                                                             │
│ libssl3    │                │          │        │                   │               │                                                             │
│            │                │          │        │                   │               │                                                             │
└────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘

```