### PR TITLE
[tempo-distributed] adds conditional ability to store tokengen output into k8s secret.

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.32.3
+version: 1.32.4
 appVersion: 2.7.1
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -883,6 +883,7 @@ The memcached default args are removed and should be provided manually. The sett
 | tempo.service.ipFamilies | list | `["IPv4"]` | Configure the IP families for all tempo services See the Service spec for details: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#servicespec-v1-core |
 | tempo.service.ipFamilyPolicy | string | `"SingleStack"` | Configure the IP family policy for all tempo services.  SingleStack, PreferDualStack or RequireDualStack |
 | tempo.structuredConfig | object | `{}` | Structured tempo configuration |
+| tokengenJob.adminTokenSecret | string | `""` | Name of the secret to store the admin token. If not specified, defaults to "<release-name>-admin-token" |
 | tokengenJob.annotations | object | `{}` |  |
 | tokengenJob.containerSecurityContext | object | `{"readOnlyRootFilesystem":true}` | The SecurityContext for tokenjobgen containers |
 | tokengenJob.enable | bool | `true` |  |
@@ -895,6 +896,7 @@ The memcached default args are removed and should be provided manually. The sett
 | tokengenJob.image.repository | string | `nil` | Docker image repository for the tokengenJob image. Overrides `tempo.image.repository` |
 | tokengenJob.image.tag | string | `nil` | Docker image tag for the tokengenJob image. Overrides `tempo.image.tag` |
 | tokengenJob.initContainers | list | `[]` |  |
+| tokengenJob.storeTokenInSecret | bool | `true` |  |
 | traces.jaeger.grpc.enabled | bool | `false` | Enable Tempo to ingest Jaeger GRPC traces |
 | traces.jaeger.grpc.receiverConfig | object | `{}` | Jaeger GRPC receiver config |
 | traces.jaeger.thriftBinary.enabled | bool | `false` | Enable Tempo to ingest Jaeger Thrift Binary traces |

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.32.3](https://img.shields.io/badge/Version-1.32.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.1](https://img.shields.io/badge/AppVersion-2.7.1-informational?style=flat-square)
+![Version: 1.32.4](https://img.shields.io/badge/Version-1.32.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.1](https://img.shields.io/badge/AppVersion-2.7.1-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -600,6 +600,9 @@ The memcached default args are removed and should be provided manually. The sett
 | ingester.zoneAwareReplication.zones[2].extraAffinity | object | `{}` | extraAffinity adds user defined custom affinity rules (merged with generated rules) |
 | ingester.zoneAwareReplication.zones[2].nodeSelector | string | `nil` | nodeselector to restrict where pods of this zone can be placed. E.g.: nodeSelector:   topology.kubernetes.io/zone: zone-c |
 | ingester.zoneAwareReplication.zones[2].storageClass | string | `nil` | Ingester data Persistent Volume Storage Class If defined, storageClassName: <storageClass> If set to "-", then use `storageClassName: ""`, which disables dynamic provisioning If undefined or set to null (the default), then fall back to the value of `ingester.persistentVolume.storageClass`. |
+| kubectlImage.pullPolicy | string | `"IfNotPresent"` |  |
+| kubectlImage.repository | string | `"bitnami/kubectl"` |  |
+| kubectlImage.tag | string | `"latest"` |  |
 | license.contents | string | `"NOTAVALIDLICENSE"` |  |
 | license.external | bool | `false` |  |
 | license.secretName | string | `"{{ include \"tempo.resourceName\" (dict \"ctx\" . \"component\" \"license\") }}"` |  |
@@ -883,7 +886,7 @@ The memcached default args are removed and should be provided manually. The sett
 | tempo.service.ipFamilies | list | `["IPv4"]` | Configure the IP families for all tempo services See the Service spec for details: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#servicespec-v1-core |
 | tempo.service.ipFamilyPolicy | string | `"SingleStack"` | Configure the IP family policy for all tempo services.  SingleStack, PreferDualStack or RequireDualStack |
 | tempo.structuredConfig | object | `{}` | Structured tempo configuration |
-| tokengenJob.adminTokenSecret | string | `""` | Name of the secret to store the admin token. If not specified, defaults to "<release-name>-admin-token" |
+| tokengenJob.adminTokenSecret | string | `"admin-token"` | Name of the secret to store the admin token. If not specified, defaults to "<release-name>-admin-token" |
 | tokengenJob.annotations | object | `{}` |  |
 | tokengenJob.containerSecurityContext | object | `{"readOnlyRootFilesystem":true}` | The SecurityContext for tokenjobgen containers |
 | tokengenJob.enable | bool | `true` |  |
@@ -896,7 +899,7 @@ The memcached default args are removed and should be provided manually. The sett
 | tokengenJob.image.repository | string | `nil` | Docker image repository for the tokengenJob image. Overrides `tempo.image.repository` |
 | tokengenJob.image.tag | string | `nil` | Docker image tag for the tokengenJob image. Overrides `tempo.image.tag` |
 | tokengenJob.initContainers | list | `[]` |  |
-| tokengenJob.storeTokenInSecret | bool | `true` |  |
+| tokengenJob.storeTokenInSecret | bool | `false` |  |
 | traces.jaeger.grpc.enabled | bool | `false` | Enable Tempo to ingest Jaeger GRPC traces |
 | traces.jaeger.grpc.receiverConfig | object | `{}` | Jaeger GRPC receiver config |
 | traces.jaeger.thriftBinary.enabled | bool | `false` | Enable Tempo to ingest Jaeger Thrift Binary traces |

--- a/charts/tempo-distributed/templates/tokengen/tokengen-job.yaml
+++ b/charts/tempo-distributed/templates/tokengen/tokengen-job.yaml
@@ -41,10 +41,14 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      initContainers:
-        {{- if .Values.tokengenJob.initContainers }}
+      {{- if .Values.tokengenJob.storeTokenInSecret }}
+      initContainers: 
+      {{- if .Values.tokengenJob.initContainers }}
         {{- toYaml .Values.tokengenJob.initContainers | nindent 8 }}
         {{- end }}
+      {{ else }}
+      containers:
+      {{- end }}
         - name: tokengen
           image: "{{ include "tempo.imageReference" $dict }}"
           imagePullPolicy: {{ .Values.tempo.image.pullPolicy }}
@@ -82,6 +86,7 @@ spec:
             {{- with .Values.tokengenJob.extraEnvFrom }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+      {{- if .Values.tokengenJob.storeTokenInSecret }}
       containers:
         - name: kubectl
           image: {{ .Values.kubectlImage.repository }}:{{ .Values.kubectlImage.tag }}
@@ -92,15 +97,11 @@ spec:
             - |
               if cat /shared/admin-token; then
                 echo "Admin token generated successfully and is readable"
-                {{- if .Values.tokengenJob.storeTokenInSecret | default true }}
                 # Create or update the secret with the admin token
-                kubectl create secret generic {{ .Values.tokengenJob.adminTokenSecret | default (printf "%s-admin-token" .Release.Name) }} \
+                kubectl create secret generic {{ .Values.tokengenJob.adminTokenSecret }} \
                   --from-file=token=/shared/admin-token \
                   --dry-run=client -o yaml | kubectl apply -f -
                 echo "Admin token secret created/updated successfully"
-                {{- else }}
-                echo "Skipping secret creation as storeTokenInSecret is disabled"
-                {{- end }}
               else
                 echo "Error: Admin token file not found or not readable at /shared/admin-token"
                 exit 1
@@ -108,6 +109,7 @@ spec:
           volumeMounts:
             - name: shared
               mountPath: /shared
+      {{- end }}
       restartPolicy: OnFailure
       volumes:
         - name: config

--- a/charts/tempo-distributed/templates/tokengen/tokengen-job.yaml
+++ b/charts/tempo-distributed/templates/tokengen/tokengen-job.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.enterprise.enabled -}}
-{{ if .Values.tokengenJob.enable }}
+{{- if and .Values.enterprise.enabled .Values.tokengenJob.enable -}}
 {{ $dict := dict "ctx" . "component" "tokengen-job" }}
 apiVersion: batch/v1
 kind: Job
@@ -26,20 +25,26 @@ spec:
         {{- end }}
       namespace: {{ .Release.Namespace | quote }}
     spec:
-      serviceAccountName: {{ template "tempo.serviceAccountName" . }}
+      serviceAccountName: {{ include "tempo.resourceName" (dict "ctx" . "component" "tokengen") }}
       {{- if .Values.tokengenJob.priorityClassName }}
       priorityClassName: {{ .Values.tokengenJob.priorityClassName }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.tokengenJob.securityContext | nindent 8 }}
-      {{- include "tempo.tokengenJobImagePullSecrets" . | nindent 6 -}}
+      {{- if .Values.tempo.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.tempo.image.pullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
       {{- with .Values.tokengenJob.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       initContainers:
+        {{- if .Values.tokengenJob.initContainers }}
         {{- toYaml .Values.tokengenJob.initContainers | nindent 8 }}
-      containers:
+        {{- end }}
         - name: tokengen
           image: "{{ include "tempo.imageReference" $dict }}"
           imagePullPolicy: {{ .Values.tempo.image.pullPolicy }}
@@ -47,6 +52,7 @@ spec:
             - "-target=tokengen"
             - "-config.expand-env=true"
             - "-config.file=/conf/tempo.yaml"
+            - "-tokengen.token-file=/shared/admin-token"
             {{- range $key, $value := .Values.tokengenJob.extraArgs }}
             - "-{{ $key }}={{ $value }}"
             {{- end }}
@@ -57,6 +63,8 @@ spec:
               name: runtime-config
             - name: license
               mountPath: /license
+            - name: shared
+              mountPath: /shared
             {{- if .Values.tokengenJob.extraVolumeMounts }}
               {{ toYaml .Values.tokengenJob.extraVolumeMounts | nindent 12 }}
             {{- end }}
@@ -74,8 +82,32 @@ spec:
             {{- with .Values.tokengenJob.extraEnvFrom }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-          securityContext:
-            {{- toYaml .Values.tokengenJob.containerSecurityContext | nindent 12 }}
+      containers:
+        - name: kubectl
+          image: {{ .Values.kubectlImage.repository }}:{{ .Values.kubectlImage.tag }}
+          imagePullPolicy: {{ .Values.kubectlImage.pullPolicy }}
+          command:
+            - "/bin/sh"
+            - "-c"
+            - |
+              if cat /shared/admin-token; then
+                echo "Admin token generated successfully and is readable"
+                {{- if .Values.tokengenJob.storeTokenInSecret | default true }}
+                # Create or update the secret with the admin token
+                kubectl create secret generic {{ .Values.tokengenJob.adminTokenSecret | default (printf "%s-admin-token" .Release.Name) }} \
+                  --from-file=token=/shared/admin-token \
+                  --dry-run=client -o yaml | kubectl apply -f -
+                echo "Admin token secret created/updated successfully"
+                {{- else }}
+                echo "Skipping secret creation as storeTokenInSecret is disabled"
+                {{- end }}
+              else
+                echo "Error: Admin token file not found or not readable at /shared/admin-token"
+                exit 1
+              fi
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
       restartPolicy: OnFailure
       volumes:
         - name: config
@@ -90,5 +122,6 @@ spec:
             secretName: {{ tpl .Values.license.secretName . }}
         - name: storage
           emptyDir: {}
-{{- end -}}
+        - name: shared
+          emptyDir: {}
 {{- end -}}

--- a/charts/tempo-distributed/templates/tokengen/tokengen-rbac.yaml
+++ b/charts/tempo-distributed/templates/tokengen/tokengen-rbac.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.enterprise.enabled .Values.tokengenJob.enable -}}
+{{ $dict := dict "ctx" . "component" "tokengen" }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "tempo.resourceName" $dict }}
+  labels:
+    {{- include "tempo.labels" $dict | nindent 4 }}
+  namespace: {{ .Release.Namespace | quote }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "tempo.resourceName" $dict }}
+  labels:
+    {{- include "tempo.labels" $dict | nindent 4 }}
+  namespace: {{ .Release.Namespace | quote }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "tempo.resourceName" $dict }}
+  namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "tempo.resourceName" $dict }}
+{{- end -}}

--- a/charts/tempo-distributed/templates/tokengen/tokengen-serviceaccount.yaml
+++ b/charts/tempo-distributed/templates/tokengen/tokengen-serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.enterprise.enabled .Values.tokengenJob.enable -}}
+{{ $dict := dict "ctx" . "component" "tokengen" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tempo.resourceName" $dict }}
+  labels:
+    {{- include "tempo.labels" $dict | nindent 4 }}
+  namespace: {{ .Release.Namespace | quote }}
+{{- end -}}

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -2119,10 +2119,9 @@ tokengenJob:
   env: []
   extraEnvFrom: []
   annotations: {}
-  storeTokenInSecret: true
+  storeTokenInSecret: false
   # -- Name of the secret to store the admin token. If not specified, defaults to "<release-name>-admin-token"
-  adminTokenSecret: ""
-
+  adminTokenSecret: "admin-token"
   image:
     # -- The Docker registry for the tokengenJob image. Overrides `tempo.image.registry`
     registry: null
@@ -2136,6 +2135,11 @@ tokengenJob:
   # -- The SecurityContext for tokenjobgen containers
   containerSecurityContext:
     readOnlyRootFilesystem: true
+
+kubectlImage:
+  repository: bitnami/kubectl
+  tag: latest
+  pullPolicy: IfNotPresent
 
 # Settings for the admin_api service providing authentication and authorization service.
 # Can only be enabled if enterprise.enabled is true - requires license.

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -2119,6 +2119,10 @@ tokengenJob:
   env: []
   extraEnvFrom: []
   annotations: {}
+  storeTokenInSecret: true
+  # -- Name of the secret to store the admin token. If not specified, defaults to "<release-name>-admin-token"
+  adminTokenSecret: ""
+
   image:
     # -- The Docker registry for the tokengenJob image. Overrides `tempo.image.registry`
     registry: null


### PR DESCRIPTION
This PR adds conditional capability to enterprise-traces to store tokengen output in a kubernetes secret to provide parity with Loki and Mimir.  This allows other helm jobs to access the admin token for additional operations such as tenant provisioning.

Fixes: #deployment_tools/217968