### PR TITLE
[grafana] Fix HPA scaleTargetRef condition logic

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 8.10.1
+version: 8.10.2
 appVersion: 11.5.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/hpa.yaml
+++ b/charts/grafana/templates/hpa.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
-    {{- if has .Values.persistence.type $sts }}
+    {{- if (or (.Values.useStatefulSet) (and .Values.persistence.enabled (not .Values.persistence.existingClaim) (has .Values.persistence.type $sts)))}}
     kind: StatefulSet
     {{- else }}
     kind: Deployment


### PR DESCRIPTION
This PR modifies the HorizontalPodAutoscaler (HPA) `scaleTargetRef` condition logic to use the same `if` statement as used by the [charts/grafana/templates/statefulset.yaml](https://github.com/grafana/helm-charts/blob/2049e69629b1f9d8bfda37852de393ee6f403005/charts/grafana/templates/statefulset.yaml#L2) template, allowing for the correct target kind to be generated.

Fixes: [\[grafana\] Incorrect HPA scaleTargetRef creation for StatefulSets #3586](https://github.com/grafana/helm-charts/issues/3586)