### PR TITLE
[grafana-sampling] Update default servicegraph metrics_flush_interval

### DIFF
--- a/charts/grafana-sampling/Chart.yaml
+++ b/charts/grafana-sampling/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: grafana-sampling
 description: A Helm chart for a layered OTLP tail sampling and metrics generation pipeline.
 type: application
-version: 1.1.2
+version: 1.1.3
 appVersion: "v1.5.1"
 sources:
   - https://github.com/grafana/alloy

--- a/charts/grafana-sampling/README.md
+++ b/charts/grafana-sampling/README.md
@@ -1,6 +1,6 @@
 # grafana-sampling
 
-![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.5.1](https://img.shields.io/badge/AppVersion-v1.5.1-informational?style=flat-square)
+![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.5.1](https://img.shields.io/badge/AppVersion-v1.5.1-informational?style=flat-square)
 
 A Helm chart for a layered OTLP tail sampling and metrics generation pipeline.
 
@@ -148,6 +148,7 @@ A major chart version change indicates that there is an incompatible breaking ch
 | metricsGeneration.dimensions | list | `["service.namespace","service.version","deployment.environment","k8s.cluster.name","k8s.pod.name"]` | Additional dimensions to add to generated metrics. |
 | metricsGeneration.enabled | bool | `true` | Toggle generation of spanmetrics and servicegraph metrics. |
 | metricsGeneration.legacy | bool | `true` | Use legacy metric names that match those used by the Tempo metrics generator. |
+| metricsGeneration.serviceGraph.metricsFlushInterval | string | `"60s"` | The interval at which metrics are flushed to downstream components. |
 | sampling.decisionWait | string | `"15s"` | Wait time since the first span of a trace before making a sampling decision. |
 | sampling.enabled | bool | `true` | Toggle tail sampling. |
 | sampling.extraPolicies | string | A policy to sample long requests is added by default. | User-defined policies in alloy format. |

--- a/charts/grafana-sampling/templates/_otelcol_connector_servicegraph.alloy.txt
+++ b/charts/grafana-sampling/templates/_otelcol_connector_servicegraph.alloy.txt
@@ -7,6 +7,7 @@ otelcol.connector.servicegraph "default" {
     {{- end }}
   ]
   latency_histogram_buckets = ["0s", "0.005s", "0.01s", "0.025s", "0.05s", "0.075s", "0.1s", "0.25s", "0.5s", "0.75s", "1s", "2.5s", "5s", "7.5s", "10s"]
+  metrics_flush_interval = {{ $.Values.metricsGeneration.serviceGraph.metricsFlushInterval | quote }}
 
   store {
     ttl = "2s"

--- a/charts/grafana-sampling/values.yaml
+++ b/charts/grafana-sampling/values.yaml
@@ -10,6 +10,9 @@ metricsGeneration:
     - deployment.environment
     - k8s.cluster.name
     - k8s.pod.name
+  serviceGraph:
+    # -- The interval at which metrics are flushed to downstream components.
+    metricsFlushInterval: 60s
 
 sampling:
   # -- Toggle tail sampling.


### PR DESCRIPTION
Fixes https://github.com/grafana/helm-charts/issues/3588

The default flush interval is 0s which generates a lot of metrics. This change will set it to 60s by default, which will eventually be the default upstream. As part of this change it is also made available in the values so it can be customised.