### PR TITLE
[tempo-distributed] Add optional provisioner job to provision tenants from configuration

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.32.5
+version: 1.32.6
 appVersion: 2.7.1
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.32.5](https://img.shields.io/badge/Version-1.32.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.1](https://img.shields.io/badge/AppVersion-2.7.1-informational?style=flat-square)
+![Version: 1.32.6](https://img.shields.io/badge/Version-1.32.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.1](https://img.shields.io/badge/AppVersion-2.7.1-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -736,6 +736,27 @@ The memcached default args are removed and should be provided manually. The sett
 | prometheusRule.groups | list | `[]` | Contents of Prometheus rules file |
 | prometheusRule.labels | object | `{}` | Additional PrometheusRule labels |
 | prometheusRule.namespace | string | `nil` | Alternative namespace for the PrometheusRule resource |
+| provisioner.additionalTenants | list | `[]` | Additional tenants to be created. Each tenant will get a read and write policy and associated token. Tenant must have a name and a namespace for the secret containting the token to be created in. For example additionalTenants:   - name: tempo     secretNamespace: grafana |
+| provisioner.affinity | object | `{}` | Affinity for tokengen Pods |
+| provisioner.annotations | object | `{}` | Additional annotations for the `provisioner` Job |
+| provisioner.apiUrl | string | `""` | URL for the admin API service. Must be set to a valid URL. Example: "http://tempo-admin-api.namespace.svc:3100" |
+| provisioner.enabled | bool | `false` | Whether the job should be part of the deployment |
+| provisioner.env | list | `[]` | Additional Kubernetes environment |
+| provisioner.extraArgs | object | `{}` | Additional arguments for the provisioner command |
+| provisioner.extraVolumeMounts | list | `[]` | Volume mounts to add to the provisioner pods |
+| provisioner.hookType | string | `"post-install"` | Hook type(s) to customize when the job runs.  defaults to post-install |
+| provisioner.image | object | `{"digest":null,"pullPolicy":"IfNotPresent","registry":"us-docker.pkg.dev","repository":"grafanalabs-global/docker-enterprise-provisioner-prod/enterprise-provisioner","tag":null}` | Provisioner image to Utilize |
+| provisioner.image.digest | string | `nil` | Overrides the image tag with an image digest |
+| provisioner.image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
+| provisioner.image.registry | string | `"us-docker.pkg.dev"` | The Docker registry |
+| provisioner.image.repository | string | `"grafanalabs-global/docker-enterprise-provisioner-prod/enterprise-provisioner"` | Docker image repository |
+| provisioner.image.tag | string | `nil` | Overrides the image tag whose default is the chart's appVersion |
+| provisioner.labels | object | `{}` | Additional labels for the `provisioner` Job |
+| provisioner.nodeSelector | object | `{}` | Node selector for tokengen Pods |
+| provisioner.priorityClassName | string | `nil` | The name of the PriorityClass for provisioner Job |
+| provisioner.provisionedSecretPrefix | string | `nil` | Name of the secret to store provisioned tokens in |
+| provisioner.securityContext | object | `{"runAsGroup":10001,"runAsNonRoot":true,"runAsUser":10001}` | Run containers as nonroot user (uid=10001)` |
+| provisioner.tolerations | list | `[]` | Tolerations for tokengen Pods |
 | querier.affinity | string | Hard node and soft zone anti-affinity | Affinity for querier pods. Passed through `tpl` and, thus, to be configured as string |
 | querier.appProtocol | object | `{"grpc":null}` | Adds the appProtocol field to the querier service. This allows querier to work with istio protocol selection. |
 | querier.appProtocol.grpc | string | `nil` | Set the optional grpc service protocol. Ex: "grpc", "http2" or "https" |

--- a/charts/tempo-distributed/templates/provisioner/provisioner-job.yaml
+++ b/charts/tempo-distributed/templates/provisioner/provisioner-job.yaml
@@ -1,0 +1,123 @@
+{{- if and .Values.provisioner.enabled .Values.enterprise.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "tempo.resourceName" (dict "ctx" . "component" "provisioner") }}
+  labels:
+    {{- include "tempo.labels" (dict "ctx" . "component" "provisioner") | nindent 4 }}
+    {{- with .Values.provisioner.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.provisioner.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    "helm.sh/hook": "{{ .Values.provisioner.hookType }}"
+    "helm.sh/hook-weight": "20"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  backoffLimit: 6
+  completions: 1
+  parallelism: 1
+  selector:
+  template:
+    metadata:
+      labels:
+        {{- include "tempo.podLabels" (dict "ctx" . "component" "provisioner") | nindent 8 }}
+      annotations:
+        {{- include "tempo.podAnnotations" (dict "ctx" . "component" "provisioner") | nindent 8 }}
+      namespace: {{ .Release.Namespace | quote }}
+    spec:
+      serviceAccountName: {{ include "tempo.resourceName" (dict "ctx" . "component" "provisioner") }}
+      {{- if .Values.provisioner.priorityClassName }}
+      priorityClassName: {{ .Values.provisioner.priorityClassName }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.provisioner.securityContext | nindent 8 }}
+      {{- if .Values.tempo.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.tempo.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      initContainers:
+        {{- range $index, $tenant := .Values.provisioner.additionalTenants }}
+        - name: provisioner-{{ $tenant.name }}
+          image: "{{ $.Values.provisioner.image.registry }}/{{ $.Values.provisioner.image.repository }}:{{ $.Values.provisioner.image.tag }}"
+          imagePullPolicy: {{ $.Values.provisioner.image.pullPolicy }}
+          command:
+            - /usr/bin/provisioner
+          args:
+            - -bootstrap-path=/bootstrap
+            - -cluster-name={{ include "tempo.clusterName" $ }}
+            - -api-url={{ $.Values.provisioner.apiUrl }}
+            - -tenant={{ $tenant.name }}
+            - -access-policy=write-{{ $tenant.name }}:{{ $tenant.name }}:traces:write
+            - -access-policy=read-{{ $tenant.name }}:{{ $tenant.name }}:traces:read
+            - -token=write-{{ $tenant.name }}
+            - -token=read-{{ $tenant.name }}
+            {{- range $flag, $value := $.Values.provisioner.extraArgs }}
+            - -{{ $flag }}={{ $value }}
+            {{- end }}
+          volumeMounts:
+            {{- if $.Values.provisioner.extraVolumeMounts }}
+              {{ toYaml $.Values.provisioner.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+            {{- if $.Values.global.extraVolumeMounts }}
+              {{ toYaml $.Values.global.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+            - name: bootstrap
+              mountPath: /bootstrap
+            - name: admin-token
+              mountPath: /bootstrap/token
+              subPath: token
+          {{- with $.Values.provisioner.env }}
+          env:
+            {{ toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
+      containers:
+        - name: create-secret
+          image: {{ .Values.kubectlImage.repository }}:{{ .Values.kubectlImage.tag }}
+          imagePullPolicy: {{ .Values.kubectlImage.pullPolicy | default "IfNotPresent" }}
+          command:
+            - /bin/bash
+            - -exuc
+            - |
+              # In this case, the admin resources have already been created, the provisioner job
+              # does not write the token files to the bootstrap mount.
+              # Therefore, secrets are only created if the respective token files exist.
+              # Note: the following bash commands should always return a success status code. 
+              # Therefore, in case the token file does not exist, the first clause of the 
+              # or-operation is successful.
+              {{- $secretPrefix := .Values.provisioner.provisionedSecretPrefix | default (include "tempo.resourceName" (dict "ctx" . "component" "token")) }}
+              {{- range .Values.provisioner.additionalTenants }}
+              ! test -s /bootstrap/token-write-{{ .name }} || \
+                kubectl --namespace "{{ .secretNamespace }}" create secret generic "{{ $secretPrefix }}-{{ .name }}" \
+                  --from-literal=token-write="$(cat /bootstrap/token-write-{{ .name }})" \
+                  --from-literal=token-read="$(cat /bootstrap/token-read-{{ .name }})"
+              {{- end }}
+          volumeMounts:
+            - name: bootstrap
+              mountPath: /bootstrap
+      {{- with .Values.provisioner.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.provisioner.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.provisioner.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: OnFailure
+      volumes:
+        - name: admin-token
+          secret:
+            secretName: {{ .Values.tokengenJob.adminTokenSecret }}
+        - name: bootstrap
+          emptyDir: {}
+{{- end -}}

--- a/charts/tempo-distributed/templates/provisioner/provisioner-rbac.yaml
+++ b/charts/tempo-distributed/templates/provisioner/provisioner-rbac.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.provisioner.enabled .Values.enterprise.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "tempo.resourceName" (dict "ctx" . "component" "provisioner") }}
+  labels:
+    {{- include "tempo.labels" (dict "ctx" . "component" "provisioner") | nindent 4 }}
+  namespace: {{ .Release.Namespace | quote }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "tempo.resourceName" (dict "ctx" . "component" "provisioner") }}
+  labels:
+    {{- include "tempo.labels" (dict "ctx" . "component" "provisioner") | nindent 4 }}
+  namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "tempo.resourceName" (dict "ctx" . "component" "provisioner") }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "tempo.resourceName" (dict "ctx" . "component" "provisioner") }}
+  namespace: {{ .Release.Namespace | quote }}
+{{- end -}}

--- a/charts/tempo-distributed/templates/provisioner/provisioner-serviceaccount.yaml
+++ b/charts/tempo-distributed/templates/provisioner/provisioner-serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.provisioner.enabled .Values.enterprise.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tempo.resourceName" (dict "ctx" . "component" "provisioner") }}
+  labels:
+    {{- include "tempo.labels" (dict "ctx" . "component" "provisioner") | nindent 4 }}
+  namespace: {{ .Release.Namespace | quote }}
+{{- end -}}

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -2138,6 +2138,60 @@ tokengenJob:
   containerSecurityContext:
     readOnlyRootFilesystem: true
 
+provisioner:
+  # -- Whether the job should be part of the deployment
+  enabled: false
+  # -- Name of the secret to store provisioned tokens in
+  provisionedSecretPrefix: null
+  # -- Hook type(s) to customize when the job runs.  defaults to post-install
+  hookType: "post-install"
+  # -- URL for the admin API service. Must be set to a valid URL.
+  # Example: "http://tempo-admin-api.namespace.svc:3100"
+  apiUrl: ""
+  # -- Additional tenants to be created. Each tenant will get a read and write policy
+  # and associated token. Tenant must have a name and a namespace for the secret containting
+  # the token to be created in. For example
+  # additionalTenants:
+  #   - name: tempo
+  #     secretNamespace: grafana
+  additionalTenants: []
+  # -- Additional arguments for the provisioner command
+  extraArgs: {}
+  # -- Additional Kubernetes environment
+  env: []
+  # -- Additional labels for the `provisioner` Job
+  labels: {}
+  # -- Additional annotations for the `provisioner` Job
+  annotations: {}
+  # -- Affinity for tokengen Pods
+  affinity: {}
+  # -- Node selector for tokengen Pods
+  nodeSelector: {}
+  # -- Tolerations for tokengen Pods
+  tolerations: []
+  # -- The name of the PriorityClass for provisioner Job
+  priorityClassName: null
+  # -- Run containers as nonroot user (uid=10001)`
+  securityContext:
+    runAsNonRoot: true
+    runAsGroup: 10001
+    runAsUser: 10001
+  # -- Provisioner image to Utilize
+  image:
+    # -- The Docker registry
+    registry: us-docker.pkg.dev
+    # -- Docker image repository
+    repository: grafanalabs-global/docker-enterprise-provisioner-prod/enterprise-provisioner
+    # -- Overrides the image tag whose default is the chart's appVersion
+    tag: null
+    # -- Overrides the image tag with an image digest
+    digest: null
+    # -- Docker image pull policy
+    pullPolicy: IfNotPresent
+  # -- Volume mounts to add to the provisioner pods
+  extraVolumeMounts: []
+
+
 kubectlImage:
   repository: bitnami/kubectl
   tag: latest


### PR DESCRIPTION
What this PR does
Grafana's Federal Cloud offering needs to utilize [enterprise provisioner](https://github.com/grafana/enterprise-provisioner) via configuration to ensure tenants are created properly in a security constrained environment. This change provides consistent tenant management across Grafana products (aligning with Loki and Mimir).

This PR adds an optional job that runs via helm post-install hook that calls the Grafana Enterprise Provisioner app to create tenants, access policies and tokens via the admin api based on configuration in the helm values.

Which issue(s) this PR fixes or relates to
Fixes #3596
Fixes #deployment_tools/2110675