### PR TITLE
[fluent-bit] fix(fluent-bit): servicemonitor label fix

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: fluent-bit
-version: 2.6.0
+version: 2.6.1
 appVersion: v2.1.0
 kubeVersion: "^1.10.0-0"
 description: "Uses fluent-bit Loki go plugin for gathering logs and sending them to Loki"

--- a/charts/fluent-bit/templates/servicemonitor.yaml
+++ b/charts/fluent-bit/templates/servicemonitor.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: {{ template "fluent-bit-loki.name" . }}
     chart: {{ template "fluent-bit-loki.chart" . }}
-    release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     {{- if .Values.serviceMonitor.additionalLabels }}
 {{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}


### PR DESCRIPTION
# Remove `release` label from `ServiceMonitor`

## Rationale

Prometheus operator is configured to scrape `ServiceMonitor` objects based on labels, and the common way to do this is by the `release` label of the Prometheus operator itself. Having a chart include its own `release` label in the object breaks this functionality without much added benefit.

This is already the way e.g. [Grafana Alloy](https://github.com/grafana/alloy/blob/main/operations/helm/charts/alloy/templates/servicemonitor.yaml#L5-L13) chart is set up.

## Current behaviour

```bash
# Produces two release labels, which k8s won't accept, and helm install fails
$ helm template . --set serviceMonitor.enabled=true --set serviceMonitor.additionalLabels.release=prometheus-stack | grep -A10 "kind: ServiceMonitor"
kind: ServiceMonitor
metadata:
  name: release-name-fluent-bit-loki
  labels:
    app: fluent-bit-loki
    chart: fluent-bit-2.6.0
    release: release-name
    heritage: Helm
    release: prometheus-stack
spec:
  selector:
```

## Behaviour after this PR

```bash
# only one `release` label - works fine
$ helm template . --set serviceMonitor.enabled=true --set serviceMonitor.additionalLabels.release=prometheus-stack | grep -A10 "kind: ServiceMonitor"
kind: ServiceMonitor
metadata:
  name: release-name-fluent-bit-loki
  labels:
    app: fluent-bit-loki
    chart: fluent-bit-2.6.0
    heritage: Helm
    release: prometheus-stack
```