### PR TITLE
fix(tempo): servicemonitor label

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 1.18.3
+version: 1.18.4
 appVersion: 2.7.1
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/templates/servicemonitor.yaml
+++ b/charts/tempo/templates/servicemonitor.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: {{ template "tempo.name" . }}
     chart: {{ template "tempo.chart" . }}
-    release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     {{- if .Values.serviceMonitor.additionalLabels }}
 {{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}


### PR DESCRIPTION
# Remove `release` label from `ServiceMonitor`

## Rationale

Prometheus operator is configured to scrape `ServiceMonitor` objects based on labels, and the common way to do this is by the `release` label of the Prometheus operator itself. Having a chart include its own `release` label in the object breaks this functionality without much added benefit.

This is already the way e.g. [Grafana Alloy](https://github.com/grafana/alloy/blob/main/operations/helm/charts/alloy/templates/servicemonitor.yaml#L5-L13) chart is set up.

## Current behaviour

```bash
# Produces two release labels, which k8s won't accept, and helm install fails
$ helm template . --set serviceMonitor.enabled=true --set serviceMonitor.additionalLabels.release=prometheus-stack | grep -A10 "kind: ServiceMonitor"
kind: ServiceMonitor
metadata:
  name: release-name-tempo
  namespace: default
  labels:
    app: tempo
    chart: tempo-1.18.3
    release: release-name
    heritage: Helm
    release: prometheus-stack
```


## Behaviour after this PR

```bash
# only one `release` label - works fine
$ helm template . --set serviceMonitor.enabled=true --set serviceMonitor.additionalLabels.release=prometheus-stack | grep -A10 "kind: ServiceMonitor"
kind: ServiceMonitor
metadata:
  name: release-name-tempo
  namespace: default
  labels:
    app: tempo
    chart: tempo-1.18.3
    heritage: Helm
    release: prometheus-stack
spec:
  selector:
```