### PR TITLE
[tempo] Add traces_storage option for spans metrics

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 1.20.0
+version: 1.21.0
 appVersion: 2.7.1
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 1.20.0](https://img.shields.io/badge/Version-1.20.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.1](https://img.shields.io/badge/AppVersion-2.7.1-informational?style=flat-square)
+![Version: 1.21.0](https://img.shields.io/badge/Version-1.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.1](https://img.shields.io/badge/AppVersion-2.7.1-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -198,6 +198,8 @@ config: |
             path: "/tmp/tempo"
             remote_write:
               - url: {{ .Values.tempo.metricsGenerator.remoteWriteUrl }}
+          traces_storage:
+            path: "/tmp/traces"
       {{- end }}
 
 tempoQuery:


### PR DESCRIPTION
Trace WAL files are required for enabling `local-blocks` processor. This setting's default is `""` rather than a default path, which should be set to a sensible default when enabling the metrics-generator.

Here is the relevant documentation concerning the `metrics_generator` config:

https://grafana.com/docs/tempo/latest/configuration/#metrics-generator