### PR TITLE
[Tempo Distributed] Added max_duration under 'search' to enable querying beyond 7 days in Grafana.

### DIFF
--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -873,6 +873,8 @@ queryFrontend:
       concurrent_jobs: 1000
       # -- The target number of bytes for each job to handle when performing a backend search
       target_bytes_per_job: 104857600
+      # -- Allows to query beyond 7 days (default value) in Grafana.
+      max_duration: 720h
     # -- Trace by ID lookup configuration
     trace_by_id:
       # -- The number of shards to split a trace by id query into.
@@ -1410,6 +1412,7 @@ config: |
     search:
       target_bytes_per_job: {{ .Values.queryFrontend.config.search.target_bytes_per_job }}
       concurrent_jobs: {{ .Values.queryFrontend.config.search.concurrent_jobs }}
+      max_duration: {{ .Values.queryFrontend.config.search.max_duration }}
     trace_by_id:
       query_shards: {{ .Values.queryFrontend.config.trace_by_id.query_shards }}
     metrics:


### PR DESCRIPTION
Allows the addition of the max_duration setting under queryFrontend.config.search. If omitted, the default value of '7 days' takes precedence, preventing the user from running queries beyond this limit.

Reference: https://github.com/grafana/helm-charts/issues/3623