### PR TITLE
[grafana] Allow users to override curl short options

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 8.14.0
+version: 8.15.0
 appVersion: 11.6.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -150,6 +150,7 @@ need to instead set `global.imageRegistry`.
 | `alerting`                                | Configure grafana alerting (passed through tpl) | `{}`                                                  |
 | `notifiers`                               | Configure grafana notifiers                   | `{}`                                                    |
 | `dashboardProviders`                      | Configure grafana dashboard providers         | `{}`                                                    |
+| `defaultCurlOptions`                      | Configure default curl short options for all dashboards, the beginning dash is required  | `-skf`       |
 | `dashboards`                              | Dashboards to import                          | `{}`                                                    |
 | `dashboardsConfigMaps`                    | ConfigMaps reference that contains dashboards | `{}`                                                    |
 | `grafana.ini`                             | Grafana's primary configuration               | `{}`                                                    |

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -396,6 +396,12 @@ dashboards:
         value: Loki
     local-dashboard:
       url: https://raw.githubusercontent.com/user/repository/master/dashboards/dashboard.json
+      # default: -skf
+      # -s  - silent mode
+      # -k  - allow insecure (eg: non-TLS) connections
+      # -f  - fail fast
+      # -L  - follow HTTP redirects
+      curlOptions: -Lf
 ```
 
 ## BASE64 dashboards

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -396,7 +396,10 @@ dashboards:
       - name: DS_LOKI
         value: Loki
     local-dashboard:
-      url: https://raw.githubusercontent.com/user/repository/master/dashboards/dashboard.json
+      url: https://github.com/cloudnative-pg/grafana-dashboards/blob/main/charts/cluster/grafana-dashboard.json
+      # redirects to:
+      # https://raw.githubusercontent.com/cloudnative-pg/grafana-dashboards/refs/heads/main/charts/cluster/grafana-dashboard.json
+
       # default: -skf
       # -s  - silent mode
       # -k  - allow insecure (eg: non-TLS) connections

--- a/charts/grafana/templates/_config.tpl
+++ b/charts/grafana/templates/_config.tpl
@@ -85,7 +85,7 @@ download_dashboards.sh: |
 {{- range $provider, $dashboards := .Values.dashboards }}
   {{- range $key, $value := $dashboards }}
     {{- if (or (hasKey $value "gnetId") (hasKey $value "url")) }}
-  curl {{ get $value "curlOptions" | default "-skf" }} \
+  curl {{ get $value "curlOptions" | default .Values.defaultCurlOptions }} \
   --connect-timeout 60 \
   --max-time 60 \
     {{- if not $value.b64content }}

--- a/charts/grafana/templates/_config.tpl
+++ b/charts/grafana/templates/_config.tpl
@@ -85,7 +85,7 @@ download_dashboards.sh: |
 {{- range $provider, $dashboards := .Values.dashboards }}
   {{- range $key, $value := $dashboards }}
     {{- if (or (hasKey $value "gnetId") (hasKey $value "url")) }}
-  curl -skf \
+  curl {{ get $value "curlOptions" | default "-skf" }} \
   --connect-timeout 60 \
   --max-time 60 \
     {{- if not $value.b64content }}

--- a/charts/grafana/templates/_config.tpl
+++ b/charts/grafana/templates/_config.tpl
@@ -85,7 +85,7 @@ download_dashboards.sh: |
 {{- range $provider, $dashboards := .Values.dashboards }}
   {{- range $key, $value := $dashboards }}
     {{- if (or (hasKey $value "gnetId") (hasKey $value "url")) }}
-  curl {{ get $value "curlOptions" | default .Values.defaultCurlOptions }} \
+  curl {{ get $value "curlOptions" | default $.Values.defaultCurlOptions }} \
   --connect-timeout 60 \
   --max-time 60 \
     {{- if not $value.b64content }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -825,6 +825,7 @@ dashboards: {}
   #     datasource: Prometheus
   #   local-dashboard:
   #     url: https://example.com/repository/test.json
+  #     curlOptions: "-sLf"
   #     token: ''
   #   local-dashboard-base64:
   #     url: https://example.com/repository/test-b64.json

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -806,6 +806,13 @@ dashboardProviders: {}
 #      options:
 #        path: /var/lib/grafana/dashboards/default
 
+## Configure how curl fetches remote dashboards. The beginning dash is required.
+## NOTE: This sets the default short flags for all dashboards, but these
+##       defaults can be overridden individually for each dashboard. See the
+##       example dashboards section below.
+##
+defaultCurlOptions: "-skf"
+
 ## Configure grafana dashboard to import
 ## NOTE: To use dashboards you must also enable/configure dashboardProviders
 ## ref: https://grafana.com/dashboards

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -811,6 +811,11 @@ dashboardProviders: {}
 ##       defaults can be overridden individually for each dashboard. See the
 ##       example dashboards section below.
 ##
+## -s  - silent mode
+## -k  - allow insecure (eg: non-TLS) connections
+## -f  - fail fast
+## See the curl documentation for additional options
+##
 defaultCurlOptions: "-skf"
 
 ## Configure grafana dashboard to import

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -808,8 +808,8 @@ dashboardProviders: {}
 
 ## Configure how curl fetches remote dashboards. The beginning dash is required.
 ## NOTE: This sets the default short flags for all dashboards, but these
-##       defaults can be overridden individually for each dashboard. See the
-##       example dashboards section below.
+##       defaults can be overridden individually for each dashboard by setting
+##       curlOptions. See the example dashboards section below.
 ##
 ## -s  - silent mode
 ## -k  - allow insecure (eg: non-TLS) connections


### PR DESCRIPTION
With the following `values.yaml` snippet:

```yaml
dashboardProviders:
  dashboardproviders.yaml:
    apiVersion: 1
    providers:
      - name: default
        orgId: 1
        folder: ''
        type: file
        disableDeletion: true
        editable: false
        options:
          path: "/var/lib/grafana/dashboards/default"
dashboards:
  default:
    "cert-manager":
      url: "https://github.com/monitoring-mixins/website/raw/refs/heads/master/assets/cert-manager/dashboards/overview.json"
    "cloudnative-pg":
      url: "https://github.com/cloudnative-pg/grafana-dashboards/raw/refs/heads/main/charts/cluster/grafana-dashboard.json"
    "nginx":
      url: "https://github.com/kubernetes/ingress-nginx/raw/refs/heads/main/deploy/grafana/dashboards/nginx.json"
    "request-handling-performance":
      url: "https://github.com/kubernetes/ingress-nginx/raw/refs/heads/main/deploy/grafana/dashboards/request-handling-performance.json"
```

The `download-dashboards` container does not correctly download the specified dashboards, because those URLs redirect to their equivalent `raw.githubusercontent.com` URLs:

```yaml
dashboardProviders:
  dashboardproviders.yaml:
    apiVersion: 1
    providers:
      - name: default
        orgId: 1
        folder: ''
        type: file
        disableDeletion: true
        editable: false
        options:
          path: "/var/lib/grafana/dashboards/default"
dashboards:
  default:
    "cert-manager":
      url: "https://raw.githubusercontent.com/monitoring-mixins/website/refs/heads/master/assets/cert-manager/dashboards/overview.json"
    "cloudnative-pg":
      url: "https://raw.githubusercontent.com/cloudnative-pg/grafana-dashboards/refs/heads/main/charts/cluster/grafana-dashboard.json"
    "nginx":
      url: "https://raw.githubusercontent.com/kubernetes/ingress-nginx/refs/heads/main/deploy/grafana/dashboards/nginx.json"
    "request-handling-performance":
      url: "https://raw.githubusercontent.com/kubernetes/ingress-nginx/refs/heads/main/deploy/grafana/dashboards/request-handling-performance.json"
```

This PR allows users to override the options passed to `curl` in the `download_dashboards.sh` script for each dashboard. I intend to use this new feature to turn off silent mode (remove `-s`) and allow curl to follow HTTP redirects (`-L`).

I tried to ensure the preexisting behavior is preserved.

WARNING: Untested!

Partially handles #200.