### PR TITLE
[grafana-sampling] Add support for live debugging

### DIFF
--- a/charts/grafana-sampling/Chart.lock
+++ b/charts/grafana-sampling/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: alloy
   repository: https://grafana.github.io/helm-charts
-  version: 0.10.1
+  version: 0.12.5
 - name: alloy
   repository: https://grafana.github.io/helm-charts
-  version: 0.10.1
-digest: sha256:dc461e633c1504ba6c60e11c21afc3346444e175d4e3b7e0b538240c392c81d0
-generated: "2024-12-11T10:44:32.61011-08:00"
+  version: 0.12.5
+digest: sha256:e3981ad0a096fac88106d866d61a1cae09a0feec8f50e8f97bdaa0dee556e0a2
+generated: "2025-03-31T15:26:38.379304672+02:00"

--- a/charts/grafana-sampling/Chart.yaml
+++ b/charts/grafana-sampling/Chart.yaml
@@ -2,17 +2,17 @@ apiVersion: v2
 name: grafana-sampling
 description: A Helm chart for a layered OTLP tail sampling and metrics generation pipeline.
 type: application
-version: 1.1.4
-appVersion: "v1.5.1"
+version: 1.1.5
+appVersion: "v1.7.5"
 sources:
   - https://github.com/grafana/alloy
   - https://grafana.com/docs/grafana-cloud/monitor-applications/application-observability/setup/sampling/tail/
 dependencies:
   - name: alloy
-    version: 0.10.1
+    version: 0.12.5
     repository: https://grafana.github.io/helm-charts
     alias: alloy-deployment
   - name: alloy
-    version: 0.10.1
+    version: 0.12.5
     repository: https://grafana.github.io/helm-charts
     alias: alloy-statefulset

--- a/charts/grafana-sampling/README.md
+++ b/charts/grafana-sampling/README.md
@@ -145,6 +145,7 @@ A major chart version change indicates that there is an incompatible breaking ch
 | batch.statefulset.timeout | string | `"200ms"` |  |
 | deployment.otlp.receiver | object | `{"grpc":{"max_recv_msg_size":"4MB"}}` | otlp receiver settings for deployment (loadbalancer) |
 | deployment.otlp.receiver.grpc.max_recv_msg_size | string | `"4MB"` | gRPC max message receive size. Default to 4MB |
+| liveDebugging.enabled | bool | `false` | Enable live debugging in the Alloy UI. |
 | metricsGeneration.dimensions | list | `["service.namespace","service.version","deployment.environment","k8s.cluster.name","k8s.pod.name"]` | Additional dimensions to add to generated metrics. |
 | metricsGeneration.enabled | bool | `true` | Toggle generation of spanmetrics and servicegraph metrics. |
 | metricsGeneration.legacy | bool | `true` | Use legacy metric names that match those used by the Tempo metrics generator. |

--- a/charts/grafana-sampling/README.md
+++ b/charts/grafana-sampling/README.md
@@ -1,6 +1,6 @@
 # grafana-sampling
 
-![Version: 1.1.4](https://img.shields.io/badge/Version-1.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.5.1](https://img.shields.io/badge/AppVersion-v1.5.1-informational?style=flat-square)
+![Version: 1.1.5](https://img.shields.io/badge/Version-1.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.7.5](https://img.shields.io/badge/AppVersion-v1.7.5-informational?style=flat-square)
 
 A Helm chart for a layered OTLP tail sampling and metrics generation pipeline.
 

--- a/charts/grafana-sampling/templates/_alloy_config_deployment.alloy.txt
+++ b/charts/grafana-sampling/templates/_alloy_config_deployment.alloy.txt
@@ -2,4 +2,7 @@
   {{- include "deployment.receiver.otlp" . }}
   {{- include "deployment.processor.batch" . }}
   {{- include "deployment.exporter.loadbalancing" . }}
+  {{- if .Values.liveDebugging.enabled -}}
+    {{- include "liveDebugging" . }}
+  {{- end -}}
 {{- end -}}

--- a/charts/grafana-sampling/templates/_alloy_config_statefulset.alloy.txt
+++ b/charts/grafana-sampling/templates/_alloy_config_statefulset.alloy.txt
@@ -17,4 +17,7 @@
   {{- include "statefulset.processor.batch" . }}
   {{- include "exporter.otlp" . }}
   {{- include "auth.basic" . }}
+  {{- if .Values.liveDebugging.enabled -}}
+    {{- include "liveDebugging" . }}
+  {{- end -}}
 {{- end -}}

--- a/charts/grafana-sampling/templates/_live_debugging.alloy.txt
+++ b/charts/grafana-sampling/templates/_live_debugging.alloy.txt
@@ -1,0 +1,5 @@
+{{- define "liveDebugging" -}}
+  livedebugging {
+    enabled = true
+  }
+{{ end }}

--- a/charts/grafana-sampling/values.yaml
+++ b/charts/grafana-sampling/values.yaml
@@ -175,6 +175,6 @@ alloy-statefulset:
     create: false
   rbac:
     create: false
-
 liveDebugging:
+  # -- Enable live debugging in the Alloy UI.
   enabled: false

--- a/charts/grafana-sampling/values.yaml
+++ b/charts/grafana-sampling/values.yaml
@@ -175,3 +175,6 @@ alloy-statefulset:
     create: false
   rbac:
     create: false
+
+liveDebugging:
+  enabled: false


### PR DESCRIPTION
  - This feature has been recently graduated to GA and is very useful during troubleshooting.
  - Upgrades alloy to v1.7.5
  - See [official doc](https://grafana.com/docs/alloy/latest/troubleshoot/debug/#live-debugging-page)