### PR TITLE
[grafana] Document limitation of alert's rule_version_record_limit to avoid DB saturation

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 8.11.1
+version: 8.11.2
 appVersion: 11.6.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -778,6 +778,7 @@ grafana.ini:
     ha_peers: {{ Name }}-headless:9094
     ha_listen_address: ${POD_IP}:9094
     ha_advertise_address: ${POD_IP}:9094
+    rule_version_record_limit: "5"
 
   alerting:
     enabled: false

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -890,6 +890,10 @@ grafana.ini:
   #   enabled: true
   #   allow_sign_up: true
   #   config_file: /etc/grafana/ldap.toml
+## Grafana's alerting configuration
+  # unified_alerting:
+  #   enabled: true
+  #   rule_version_record_limit: "5"
 
 ## Grafana's LDAP configuration
 ## Templated by the template in _helpers.tpl


### PR DESCRIPTION
I think we should at least document or enable by default the `rule_version_record_limit` setting. We had 10 millions of versions on our side because of alert changes via API. 

Related:
- https://github.com/grafana/grafana-operator/pull/1763
- https://github.com/grafana/grafana/blob/4f19995bef97a6a6b9816b6f5ab7363b0339b5f8/conf/defaults.ini#L1413-L1416
- https://community.grafana.com/t/alert-rule-version-table-in-database-too-large/137270/2