### PR TITLE
[grafana] fix extra spaces in extra objects to fix templating

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 8.11.2
+version: 8.11.3
 appVersion: 11.6.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/extra-manifests.yaml
+++ b/charts/grafana/templates/extra-manifests.yaml
@@ -1,8 +1,8 @@
 {{ range .Values.extraObjects }}
 ---
 {{- if typeIs "string" . }}
-  {{ tpl . $ }}
+{{ tpl . $ }}
 {{ else }}
-  {{ tpl (. | toYaml) $ }}
+{{ tpl (. | toYaml) $ }}
 {{- end }}
 {{ end }}


### PR DESCRIPTION
This pull request fixes some extra spaces on the grafana chart extra-manifests.yaml that breaks templating. Basically, those objects are in the helm templates but not déployed in clusters