### PR TITLE
[rollout-operator] add missing namespace

### DIFF
--- a/charts/rollout-operator/Chart.yaml
+++ b/charts/rollout-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-operator
 description: "Grafana rollout-operator"
 type: application
-version: 0.26.0
+version: 0.26.1
 appVersion: v0.25.0
 home: https://github.com/grafana/rollout-operator
 kubeVersion: ^1.10.0-0

--- a/charts/rollout-operator/README.md
+++ b/charts/rollout-operator/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana rollout-operator](https://github.com/grafana/r
 
 # rollout-operator
 
-![Version: 0.26.0](https://img.shields.io/badge/Version-0.26.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.25.0](https://img.shields.io/badge/AppVersion-v0.25.0-informational?style=flat-square)
+![Version: 0.26.1](https://img.shields.io/badge/Version-0.26.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.25.0](https://img.shields.io/badge/AppVersion-v0.25.0-informational?style=flat-square)
 
 Grafana rollout-operator
 

--- a/charts/rollout-operator/templates/deployment.yaml
+++ b/charts/rollout-operator/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      namespace: {{ .Release.Namespace | quote }}
       labels:
         {{- include "rollout-operator.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}


### PR DESCRIPTION
After seeing that https://github.com/grafana/helm-charts/pull/3638 merged (to address https://github.com/grafana/helm-charts/issues/3632) I realized I missed the inner template metadata section within the Deployment. Apologies!