### PR TITLE
[cloudcost-exporter] use service portName for liveness and readiness probes

### DIFF
--- a/charts/cloudcost-exporter/Chart.yaml
+++ b/charts/cloudcost-exporter/Chart.yaml
@@ -5,10 +5,10 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.0
+version: 1.0.1
 
 # This is the version of cloudcost-exporter to be deployed, which should be incremented
 # with each release.
-appVersion: "0.7.12"
+appVersion: "0.7.13"
 
 home: https://github.com/grafana/cloudcost-exporter

--- a/charts/cloudcost-exporter/README.md
+++ b/charts/cloudcost-exporter/README.md
@@ -2,7 +2,7 @@
 
 Cloud Cost Exporter exports cloud provider agnostic cost metrics to Prometheus.
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.12](https://img.shields.io/badge/AppVersion-0.7.12-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.13](https://img.shields.io/badge/AppVersion-0.7.13-informational?style=flat-square)
 
 ## Installing the Chart
 

--- a/charts/cloudcost-exporter/templates/deployment.yaml
+++ b/charts/cloudcost-exporter/templates/deployment.yaml
@@ -40,11 +40,11 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: http
+              port: {{ .Values.service.portName }}
           readinessProbe:
             httpGet:
               path: /
-              port: http
+              port: {{ .Values.service.portName }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
Part of https://github.com/grafana/cloudcost-exporter/pull/464

Use the port name configured for the Service for the liveness and readiness probes.