### PR TITLE
[grafana] Image Pull Secrets for the Image Renderer deployment not set in values.yaml

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 8.12.0
+version: 8.12.1
 appVersion: 11.6.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -275,6 +275,7 @@ need to instead set `global.imageRegistry`.
 | `imageRenderer.image.repository`           | image-renderer Image repository                                                    | `grafana/grafana-image-renderer` |
 | `imageRenderer.image.tag`                  | image-renderer Image tag                                                           | `latest`                         |
 | `imageRenderer.image.sha`                  | image-renderer Image sha (optional)                                                | `""`                             |
+| `imageRenderer.image.pullSecrets`                  |  image-renderer Image pull secrets (optional)                              | `[]`                             |
 | `imageRenderer.image.pullPolicy`           | image-renderer ImagePullPolicy                                                     | `Always`                         |
 | `imageRenderer.env`                        | extra env-vars for image-renderer                                                  | `{}`                             |
 | `imageRenderer.envValueFrom`               | Environment variables for image-renderer from alternate sources. See the API docs on [EnvVarSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvarsource-v1-core) for format details. Can be templated | `{}` |

--- a/charts/grafana/templates/image-renderer-deployment.yaml
+++ b/charts/grafana/templates/image-renderer-deployment.yaml
@@ -58,11 +58,9 @@ spec:
       {{- with .Values.imageRenderer.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
-      {{- with (or .Values.global.imagePullSecrets .Values.imageRenderer.image.pullSecrets) }}
+      {{- if or .Values.imageRenderer.image.pullSecrets .Values.global.imagePullSecrets }}
       imagePullSecrets:
-        {{- range . }}
-        - name: {{ tpl . $root }}
-        {{- end}}
+        {{- include "grafana.imagePullSecrets" (dict "root" $root "imagePullSecrets" .Values.imageRenderer.image.pullSecrets) | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}-image-renderer

--- a/charts/grafana/templates/image-renderer-deployment.yaml
+++ b/charts/grafana/templates/image-renderer-deployment.yaml
@@ -58,7 +58,7 @@ spec:
       {{- with .Values.imageRenderer.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
-      {{- with .Values.imageRenderer.image.pullSecrets }}
+      {{- with (or .Values.global.imagePullSecrets .Values.imageRenderer.image.pullSecrets) }}
       imagePullSecrets:
         {{- range . }}
         - name: {{ tpl . $root }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1378,6 +1378,10 @@ imageRenderer:
     tag: latest
     # image-renderer Image sha (optional)
     sha: ""
+    # image-renderer Image pull secrets (optional)
+    # If "global.imagePullSecrets" is specified, the image pull secrets
+    # defined here get overwritten.
+    pullSecrets: []
     # image-renderer ImagePullPolicy
     pullPolicy: Always
   # extra environment variables

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1379,8 +1379,6 @@ imageRenderer:
     # image-renderer Image sha (optional)
     sha: ""
     # image-renderer Image pull secrets (optional)
-    # If "global.imagePullSecrets" is specified, the image pull secrets
-    # defined here get overwritten.
     pullSecrets: []
     # image-renderer ImagePullPolicy
     pullPolicy: Always


### PR DESCRIPTION
Addresses both remediations in the linked issue.

Closes #3652 

Included:
1. If 'global.imagePullSecrets' is set, then this will be also propagated to the Image Renderer component and will overwrite '.Values.imageRenderer.image.pullSecrets' if specified.
2. The sequence 'imageRenderer.image.pullSecrets' is specified with an empty default value in the values.yaml