### PR TITLE
[rollout-operator] fix: add missing patch permission to apps/statefulsets

### DIFF
--- a/charts/rollout-operator/Chart.yaml
+++ b/charts/rollout-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-operator
 description: "Grafana rollout-operator"
 type: application
-version: 0.27.0
+version: 0.27.1
 appVersion: v0.26.0
 home: https://github.com/grafana/rollout-operator
 kubeVersion: ^1.10.0-0

--- a/charts/rollout-operator/README.md
+++ b/charts/rollout-operator/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana rollout-operator](https://github.com/grafana/r
 
 # rollout-operator
 
-![Version: 0.27.0](https://img.shields.io/badge/Version-0.27.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.26.0](https://img.shields.io/badge/AppVersion-v0.26.0-informational?style=flat-square)
+![Version: 0.27.1](https://img.shields.io/badge/Version-0.27.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.26.0](https://img.shields.io/badge/AppVersion-v0.26.0-informational?style=flat-square)
 
 Grafana rollout-operator
 

--- a/charts/rollout-operator/README.md
+++ b/charts/rollout-operator/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana rollout-operator](https://github.com/grafana/r
 
 # rollout-operator
 
-![Version: 0.27.1](https://img.shields.io/badge/Version-0.27.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.26.0](https://img.shields.io/badge/AppVersion-v0.26.0-informational?style=flat-square)
+![Version: 0.27.1](https://img.shields.io/badge/Version-0.27.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.26.0](https://img.shields.io/badge/AppVersion-v0.26.0-informational?style=flat-square)
 
 Grafana rollout-operator
 

--- a/charts/rollout-operator/templates/role.yaml
+++ b/charts/rollout-operator/templates/role.yaml
@@ -23,6 +23,7 @@ rules:
   - list
   - get
   - watch
+  - patch
 - apiGroups:
   - apps
   resources:


### PR DESCRIPTION
Based on tests, I think the `patch` permission to `apps/statefulsets` is missing.

```
level=warn ts=2025-04-17T09:02:31.196597988Z msg="unable to adjust desired replicas of StatefulSet" group=ingester err="statefulsets.apps \"loki-general-ingester-zone-b\" is forbidden: User \"system:serviceaccount:loki:loki-general-rollout-operator\" cannot patch resource \"statefulsets\" in API group \"apps\" in the namespace \"loki\""
level=debug ts=2025-04-17T09:02:31.196748498Z msg="reconciling StatefulSet" statefulset=loki-general-ingester-zone-a
level=debug ts=2025-04-17T09:02:31.196812368Z msg="reconciling StatefulSet" statefulset=loki-general-ingester-zone-b
level=debug ts=2025-04-17T09:02:31.196850638Z msg="reconciling StatefulSet" statefulset=loki-general-ingester-zone-c
level=info ts=2025-04-17T09:02:31.196885908Z msg="reconcile done"
```

Also, you can see this is being added on the [development](https://github.com/grafana/rollout-operator/blob/main/development/rollout-operator-role.yaml) manifests.