### PR TITLE
chore(github): Update codeowners check to run on latest ubuntu

### DIFF
--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -4,7 +4,7 @@ on: workflow_call
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: install yq


### PR DESCRIPTION
It previously explicitly used ubuntu-20.04 which is EOL.

Related #3656