### PR TITLE
[grafana] Update Grafana to 11.6.1

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 8.13.0
-appVersion: 11.6.0-security-01
+version: 8.13.1
+appVersion: 11.6.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.com


### PR DESCRIPTION
Update `appVersion` to the final release version of the container image `11.6.1`.