### PR TITLE
[grafana] Add support for custom script and extra mounts in Grafana sidecar

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 8.13.1
+version: 8.13.2
 appVersion: 11.6.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -230,6 +230,10 @@ initContainers:
       - name: SKIP_TLS_VERIFY
         value: "{{ . }}"
       {{- end }}
+      {{- if .Values.sidecar.datasources.script }}
+      - name: SCRIPT
+        value: "{{ .Values.sidecar.datasources.script }}"
+      {{- end }}
     {{- with .Values.sidecar.resources }}
     resources:
       {{- toYaml . | nindent 6 }}
@@ -241,6 +245,9 @@ initContainers:
     volumeMounts:
       - name: sc-datasources-volume
         mountPath: "/etc/grafana/provisioning/datasources"
+      {{- with .Values.sidecar.datasources.extraMounts }}
+      {{- toYaml . | trim | nindent 6 }}
+      {{- end }}
 {{- end }}
 {{- if and .Values.sidecar.notifiers.enabled .Values.sidecar.notifiers.initNotifiers }}
   - name: {{ include "grafana.name" . }}-init-sc-notifiers

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -230,9 +230,9 @@ initContainers:
       - name: SKIP_TLS_VERIFY
         value: "{{ . }}"
       {{- end }}
-      {{- if .Values.sidecar.datasources.script }}
+      {{- with .Values.sidecar.datasources.script }}
       - name: SCRIPT
-        value: "{{ .Values.sidecar.datasources.script }}"
+        value: {{ quote . }}
       {{- end }}
     {{- with .Values.sidecar.resources }}
     resources:
@@ -295,6 +295,10 @@ initContainers:
       - name: SKIP_TLS_VERIFY
         value: "{{ . }}"
       {{- end }}
+      {{- with .Values.sidecar.notifiers.script }}
+      - name: SCRIPT
+        value: {{ quote . }}
+      {{- end }}
     {{- with .Values.sidecar.livenessProbe }}
     livenessProbe:
       {{- toYaml . | nindent 6 }}
@@ -314,6 +318,9 @@ initContainers:
     volumeMounts:
       - name: sc-notifiers-volume
         mountPath: "/etc/grafana/provisioning/notifiers"
+      {{- with .Values.sidecar.notifiers.extraMounts }}
+      {{- toYaml . | trim | nindent 6 }}
+      {{- end }}
 {{- end}}
 {{- with .Values.extraInitContainers }}
   {{- tpl (toYaml .) $root | nindent 2 }}
@@ -510,7 +517,7 @@ containers:
       {{- end }}
       {{- with .Values.sidecar.dashboards.script }}
       - name: SCRIPT
-        value: "{{ . }}"
+        value: {{ quote . }}
       {{- end }}
       {{- if not .Values.sidecar.dashboards.skipReload }}
       {{- if and (not .Values.env.GF_SECURITY_ADMIN_USER) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
@@ -636,9 +643,9 @@ containers:
       - name: SKIP_TLS_VERIFY
         value: "{{ .Values.sidecar.skipTlsVerify }}"
       {{- end }}
-      {{- if .Values.sidecar.datasources.script }}
+      {{- with .Values.sidecar.datasources.script }}
       - name: SCRIPT
-        value: "{{ .Values.sidecar.datasources.script }}"
+        value: {{ quote . }}
       {{- end }}
       {{- if and (not .Values.env.GF_SECURITY_ADMIN_USER) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: REQ_USERNAME
@@ -759,9 +766,9 @@ containers:
       - name: SKIP_TLS_VERIFY
         value: "{{ . }}"
       {{- end }}
-      {{- if .Values.sidecar.notifiers.script }}
+      {{- with .Values.sidecar.notifiers.script }}
       - name: SCRIPT
-        value: "{{ .Values.sidecar.notifiers.script }}"
+        value: {{ quote . }}
       {{- end }}
       {{- if and (not .Values.env.GF_SECURITY_ADMIN_USER) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: REQ_USERNAME
@@ -880,7 +887,7 @@ containers:
       {{- end }}
       {{- with .Values.sidecar.plugins.script }}
       - name: SCRIPT
-        value: "{{ . }}"
+        value: {{ quote . }}
       {{- end }}
       {{- with .Values.sidecar.skipTlsVerify }}
       - name: SKIP_TLS_VERIFY

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1020,7 +1020,9 @@ sidecar:
     #
     # Endpoint to send request to reload alerts
     reloadURL: "http://localhost:3000/api/admin/provisioning/alerting/reload"
-    # Absolute path to shell script to execute after a alert got reloaded
+    # Absolute path to a script to execute after a configmap got reloaded.
+    # It runs before calls to REQ_URI. If the file is not executable it will be passed to sh.
+    # Otherwise, it's executed as is. Shebangs known to work are #!/bin/sh and #!/usr/bin/env python
     script: null
     skipReload: false
     # This is needed if skipReload is true, to load any alerts defined at startup time.
@@ -1097,7 +1099,9 @@ sidecar:
     #
     # Endpoint to send request to reload alerts
     reloadURL: "http://localhost:3000/api/admin/provisioning/dashboards/reload"
-    # Absolute path to shell script to execute after a configmap got reloaded
+    # Absolute path to a script to execute after a configmap got reloaded.
+    # It runs before calls to REQ_URI. If the file is not executable it will be passed to sh.
+    # Otherwise, it's executed as is. Shebangs known to work are #!/bin/sh and #!/usr/bin/env python
     script: null
     skipReload: false
     # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
@@ -1201,7 +1205,9 @@ sidecar:
     #
     # Endpoint to send request to reload datasources
     reloadURL: "http://localhost:3000/api/admin/provisioning/datasources/reload"
-    # Absolute path to shell script to execute after a datasource got reloaded
+    # Absolute path to a script to execute after a configmap got reloaded.
+    # It runs before calls to REQ_URI. If the file is not executable it will be passed to sh.
+    # Otherwise, it's executed as is. Shebangs known to work are #!/bin/sh and #!/usr/bin/env python
     script: null
     skipReload: false
     # This is needed if skipReload is true, to load any datasources defined at startup time.
@@ -1267,7 +1273,9 @@ sidecar:
     #
     # Endpoint to send request to reload plugins
     reloadURL: "http://localhost:3000/api/admin/provisioning/plugins/reload"
-    # Absolute path to shell script to execute after a plugin got reloaded
+    # Absolute path to a script to execute after a configmap got reloaded.
+    # It runs before calls to REQ_URI. If the file is not executable it will be passed to sh.
+    # Otherwise, it's executed as is. Shebangs known to work are #!/bin/sh and #!/usr/bin/env python
     script: null
     skipReload: false
     # Deploy the datasource sidecar as an initContainer in addition to a container.
@@ -1333,7 +1341,9 @@ sidecar:
     #
     # Endpoint to send request to reload notifiers
     reloadURL: "http://localhost:3000/api/admin/provisioning/notifications/reload"
-    # Absolute path to shell script to execute after a notifier got reloaded
+    # Absolute path to a script to execute after a configmap got reloaded.
+    # It runs before calls to REQ_URI. If the file is not executable it will be passed to sh.
+    # Otherwise, it's executed as is. Shebangs known to work are #!/bin/sh and #!/usr/bin/env python
     script: null
     skipReload: false
     # Deploy the notifier sidecar as an initContainer in addition to a container.


### PR DESCRIPTION
## Background

- Grafana's chart uses [kiwigrid/k8s-sidecar](https://github.com/kiwigrid/k8s-sidecar) as default container image for sidecar and init containers.
- The lifecycle execution of the "script" is after the file has been written and before executing the HTTP call.
- There are some cases where the script is used for variable or string substitution for dynamic content.
- Using the approach with an init container, the script should only run once at initialization, otherwise the watch will always detect a difference in the file and rewrite perpetually

## Goals

- Allow using the script functionality from the Grafana init container (before only conf in the side container section)
- Allow using the "extraMounts" also in the init container configuration