### PR TITLE
[grafana] Add volumeName field to statefulset template

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 8.13.1
+version: 8.13.2
 appVersion: 11.6.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 8.13.2
+version: 8.14.0
 appVersion: 11.6.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/statefulset.yaml
+++ b/charts/grafana/templates/statefulset.yaml
@@ -46,6 +46,7 @@ spec:
     spec:
       accessModes: {{ .Values.persistence.accessModes }}
       storageClassName: {{ .Values.persistence.storageClassName }}
+      volumeName: {{ .Values.persistence.volumeName | quote }}
       resources:
         requests:
           storage: {{ .Values.persistence.size }}

--- a/charts/grafana/templates/statefulset.yaml
+++ b/charts/grafana/templates/statefulset.yaml
@@ -46,7 +46,9 @@ spec:
     spec:
       accessModes: {{ .Values.persistence.accessModes }}
       storageClassName: {{ .Values.persistence.storageClassName }}
-      volumeName: {{ .Values.persistence.volumeName | quote }}
+      {{- with .Values.persistence.volumeName }}
+      volumeName: {{ . | quote }}
+      {{- end }}
       resources:
         requests:
           storage: {{ .Values.persistence.size }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -416,6 +416,8 @@ persistence:
   type: pvc
   enabled: false
   # storageClassName: default
+  ## (Optional) Use this to bind the claim to an existing PersistentVolume (PV) by name.
+  volumeName: ""
   accessModes:
     - ReadWriteOnce
   size: 10Gi


### PR DESCRIPTION
### What this PR does / Why we need it:
#### PR
- Add `volumeName` field to statefulset template
- Update chart templates for better volume management
- Bump Chart version to 8.13.2

#### Needs
Why is this needed

Currently, when using Grafana as a StatefulSet, we may need to delete the existing Grafana and reinstall it. Even if the PV's Reclaim Policy is set to 'Retain' and we manually restore the PV, we cannot reuse the recovered PV because the volumeName field is missing in the statefulset.yaml

What would you like to be added

I worked around the issue and solved it as follows.
```yaml
volumeClaimTemplates:
  - apiVersion: v1
    kind: PersistentVolumeClaim
    metadata:
      name: storage
    spec:
      accessModes: {{ .Values.persistence.accessModes }}
      storageClassName: {{ .Values.persistence.storageClassName }}
      volumeName: {{ .Values.persistence.volumeName | quote }} # This is an added new line
      ...
```
Then, I specified the existing PV name in the user values and reinstalled the chart.
First, I revised the chart myself.
In charts/grafana/templates/statefulset.yaml, add the volumeName entry as follows.
```yaml
  # StatefulSet Setting
  persistence:
    enabled: true
    type: sts
    storageClassName: azuredisk-ssd-lrs
    accessModes:
      - ReadWriteOnce
    size: 8Gi
    finalizers:
      - kubernetes.io/pvc-protection
    volumeName: restore-grafana-pv # Restored PV Name
```
This allowed me to successfully reuse the existing PV.

Who is this feature for?

If this is added, I think it will make it easier for those who run Grafana with StatefulSet and have created custom dashboards but have to delete and reinstall Grafana due to unavoidable circumstances to preserve existing dashboards.

### Special notes for reviewer:

- No changes to appVersion
- Passed helm lint locally

---

Fixes #3538
