### PR TITLE
[rollout-operator] Enable setting containers.extraArgs

### DIFF
--- a/charts/rollout-operator/Chart.yaml
+++ b/charts/rollout-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-operator
 description: "Grafana rollout-operator"
 type: application
-version: 0.27.1
+version: 0.28.0
 appVersion: v0.26.0
 home: https://github.com/grafana/rollout-operator
 kubeVersion: ^1.10.0-0

--- a/charts/rollout-operator/README.md
+++ b/charts/rollout-operator/README.md
@@ -40,7 +40,7 @@ It is not a highly available application and runs as a single pod.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| extraArgs | list | `[]` | List of additional cli arguments to configure rollout-operator (example: `--log.level=info`) |
+| extraArgs | list | `[]` | List of additional CLI arguments to configure rollout-operator (example: `--log.level=info`) |
 | fullnameOverride | string | `""` |  |
 | global.commonLabels | object | `{}` | Common labels for all object directly managed by this chart. |
 | hostAliases | list | `[]` | hostAliases to add |

--- a/charts/rollout-operator/README.md
+++ b/charts/rollout-operator/README.md
@@ -40,7 +40,7 @@ It is not a highly available application and runs as a single pod.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| extraArgs | list | `[]` | List of additional cli arguments to configure agent-operator (example: `--log.level`) |
+| extraArgs | list | `[]` | List of additional cli arguments to configure rollout-operator (example: `--log.level=info`) |
 | fullnameOverride | string | `""` |  |
 | global.commonLabels | object | `{}` | Common labels for all object directly managed by this chart. |
 | hostAliases | list | `[]` | hostAliases to add |

--- a/charts/rollout-operator/README.md
+++ b/charts/rollout-operator/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana rollout-operator](https://github.com/grafana/r
 
 # rollout-operator
 
-![Version: 0.27.1](https://img.shields.io/badge/Version-0.27.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.26.0](https://img.shields.io/badge/AppVersion-v0.26.0-informational?style=flat-square)
+![Version: 0.28.0](https://img.shields.io/badge/Version-0.28.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.26.0](https://img.shields.io/badge/AppVersion-v0.26.0-informational?style=flat-square)
 
 Grafana rollout-operator
 
@@ -40,6 +40,7 @@ It is not a highly available application and runs as a single pod.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| extraArgs | list | `[]` | List of additional cli arguments to configure agent-operator (example: `--log.level`) |
 | fullnameOverride | string | `""` |  |
 | global.commonLabels | object | `{}` | Common labels for all object directly managed by this chart. |
 | hostAliases | list | `[]` | hostAliases to add |

--- a/charts/rollout-operator/templates/deployment.yaml
+++ b/charts/rollout-operator/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - -kubernetes.namespace={{ .Release.Namespace }}
+          {{- range .Values.extraArgs  }}
+          - {{ . }}
+          {{- end }}
           ports:
             - name: http-metrics
               containerPort: 8001

--- a/charts/rollout-operator/values.yaml
+++ b/charts/rollout-operator/values.yaml
@@ -51,7 +51,7 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# -- List of additional cli arguments to configure agent-operator (example: `--log.level`)
+# -- List of additional cli arguments to configure rollout-operator (example: `--log.level=info`)
 extraArgs: []
 
 resources:

--- a/charts/rollout-operator/values.yaml
+++ b/charts/rollout-operator/values.yaml
@@ -51,6 +51,9 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+# -- List of additional cli arguments to configure agent-operator (example: `--log.level`)
+extraArgs: []
+
 resources:
   limits:
     # cpu: "1"

--- a/charts/rollout-operator/values.yaml
+++ b/charts/rollout-operator/values.yaml
@@ -51,7 +51,7 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# -- List of additional cli arguments to configure rollout-operator (example: `--log.level=info`)
+# -- List of additional CLI arguments to configure rollout-operator (example: `--log.level=info`)
 extraArgs: []
 
 resources:


### PR DESCRIPTION
This PR is an update of https://github.com/grafana/helm-charts/pull/3473

I came across this while attempting to deploy the [Loki Helm chart](https://github.com/grafana/loki/tree/main/production/helm/loki) and found that I needed to set `args` for deploying with Mimir.

This will enable users to specify additional arguments while preserving the existing default.