### PR TITLE
Set init-chown-data readOnlyRootFilesystem

### DIFF
--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -130,6 +130,7 @@ need to instead set `global.imageRegistry`.
 | `initChownData.image.sha`                 | init-chown-data container image sha (optional)| `""`                                                    |
 | `initChownData.image.pullPolicy`          | init-chown-data container image pull policy   | `IfNotPresent`                                          |
 | `initChownData.resources`                 | init-chown-data pod resource requests & limits | `{}`                                                   |
+| `initChownData.securityContext`           | init-chown-data pod securityContext           | `{"readOnlyRootFilesystem": true, "runAsNonRoot": false}`, "runAsUser": 0, "seccompProfile": {"type": "RuntimeDefault"}, "capabilities": {"add": ["CHOWN"], "drop": ["ALL"]}}` |
 | `schedulerName`                           | Alternate scheduler name                      | `nil`                                                   |
 | `env`                                     | Extra environment variables passed to pods    | `{}`                                                    |
 | `envValueFrom`                            | Environment variables from alternate sources. See the API docs on [EnvVarSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvarsource-v1-core) for format details. Can be templated | `{}` |

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -475,6 +475,7 @@ initChownData:
   #    cpu: 100m
   #    memory: 128Mi
   securityContext:
+    readOnlyRootFilesystem: true
     runAsNonRoot: false
     runAsUser: 0
     seccompProfile:


### PR DESCRIPTION
Trivy recommends setting `readOnlyRootFilesystem` where possible.