### PR TITLE
update-helm-repo: Test a different format for expanding app ID

### DIFF
--- a/.github/workflows/update-helm-repo.yaml
+++ b/.github/workflows/update-helm-repo.yaml
@@ -107,7 +107,7 @@ jobs:
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
         id: app-token
         with:
-          app_id: ${github_app_id}
+          app_id: ${{ env.github_app_id }}
           private_key: ${{ secrets.github_app_pem }}
 
       - name: Set the correct token (Github App or PAT)


### PR DESCRIPTION
It's defined in the env, but it's possible this syntax for env expansion only works inside bash/run statements, and is not done by the normal processor. Let's just try setting it, to see if it fixes: https://raintank-corp.slack.com/archives/C08Q3NB2VL3/p1746043218511839 (I don't know of another way to test changes here)

I double checked and the same potential issue doesn't appear in any other steps.