### PR TITLE
[tempo-distributed] Add extraVolumes to support mTLS for provisioner job

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.39.2
+version: 1.39.3
 appVersion: 2.7.1
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.39.2](https://img.shields.io/badge/Version-1.39.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.1](https://img.shields.io/badge/AppVersion-2.7.1-informational?style=flat-square)
+![Version: 1.39.3](https://img.shields.io/badge/Version-1.39.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.1](https://img.shields.io/badge/AppVersion-2.7.1-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -766,6 +766,7 @@ The memcached default args are removed and should be provided manually. The sett
 | provisioner.env | list | `[]` | Additional Kubernetes environment |
 | provisioner.extraArgs | object | `{}` | Additional arguments for the provisioner command |
 | provisioner.extraVolumeMounts | list | `[]` | Volume mounts to add to the provisioner pods |
+| provisioner.extraVolumes | list | `[]` | Volumes to add to the provisioner pods |
 | provisioner.hookType | string | `"post-install"` | Hook type(s) to customize when the job runs.  defaults to post-install |
 | provisioner.image | object | `{"digest":null,"pullPolicy":"IfNotPresent","registry":"us-docker.pkg.dev","repository":"grafanalabs-global/docker-enterprise-provisioner-prod/enterprise-provisioner","tag":null}` | Provisioner image to Utilize |
 | provisioner.image.digest | string | `nil` | Overrides the image tag with an image digest |

--- a/charts/tempo-distributed/templates/provisioner/provisioner-job.yaml
+++ b/charts/tempo-distributed/templates/provisioner/provisioner-job.yaml
@@ -42,24 +42,27 @@ spec:
       {{- end }}
       {{- end }}
       initContainers:
-        {{- range $index, $tenant := .Values.provisioner.additionalTenants }}
-        - name: provisioner-{{ $tenant.name }}
+        - name: provisioner
           image: "{{ $.Values.provisioner.image.registry }}/{{ $.Values.provisioner.image.repository }}:{{ $.Values.provisioner.image.tag }}"
           imagePullPolicy: {{ $.Values.provisioner.image.pullPolicy }}
           command:
-            - /usr/bin/provisioner
-          args:
-            - -bootstrap-path=/bootstrap
-            - -cluster-name={{ include "tempo.clusterName" $ }}
-            - -api-url={{ $.Values.provisioner.apiUrl }}
-            - -tenant={{ $tenant.name }}
-            - -access-policy=write-{{ $tenant.name }}:{{ $tenant.name }}:traces:write
-            - -access-policy=read-{{ $tenant.name }}:{{ $tenant.name }}:traces:read
-            - -token=write-{{ $tenant.name }}
-            - -token=read-{{ $tenant.name }}
-            {{- range $flag, $value := $.Values.provisioner.extraArgs }}
-            - -{{ $flag }}={{ $value }}
-            {{- end }}
+            - /bin/bash
+            - -euc
+            - |
+              {{- range $tenant := .Values.provisioner.additionalTenants }}
+              /usr/bin/provisioner \
+                -bootstrap-path=/bootstrap \
+                -cluster-name={{ include "tempo.clusterName" $ }} \
+                -api-url={{ $.Values.provisioner.apiUrl }} \
+                -tenant={{ $tenant.name }} \
+                -access-policy=write-{{ $tenant.name }}:{{ $tenant.name }}:traces:write \
+                -access-policy=read-{{ $tenant.name }}:{{ $tenant.name }}:traces:read \
+                -token=write-{{ $tenant.name }} \
+                -token=read-{{ $tenant.name }}
+                {{- range $flag, $value := $.Values.provisioner.extraArgs }}
+                - -{{ $flag }}={{ $value }}
+                {{- end }}
+              {{- end }}
           volumeMounts:
             {{- if $.Values.provisioner.extraVolumeMounts }}
               {{ toYaml $.Values.provisioner.extraVolumeMounts | nindent 12 }}
@@ -76,7 +79,6 @@ spec:
           env:
             {{ toYaml . | nindent 12 }}
           {{- end }}
-        {{- end }}
       containers:
         - name: create-secret
           image: {{ .Values.kubectlImage.repository }}:{{ .Values.kubectlImage.tag }}
@@ -120,4 +122,10 @@ spec:
             secretName: {{ .Values.tokengenJob.adminTokenSecret }}
         - name: bootstrap
           emptyDir: {}
+        {{- if .Values.provisioner.extraVolumes }}
+        {{- toYaml .Values.provisioner.extraVolumes | nindent 8 }}
+        {{- end }}
+        {{- if .Values.global.extraVolumes }}
+        {{- toYaml .Values.global.extraVolumes | nindent 8 }}
+        {{- end }}
 {{- end -}}

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -2275,6 +2275,8 @@ provisioner:
     pullPolicy: IfNotPresent
   # -- Volume mounts to add to the provisioner pods
   extraVolumeMounts: []
+  # -- Volumes to add to the provisioner pods
+  extraVolumes: []
 
 
 kubectlImage:


### PR DESCRIPTION
This PR adds extraVolumes to the provisioner definition to ensure it can properly mount TLS certificates. This PR also corrects the initContainer to use a single container with a call to /usr/bin/provisioner for each tenant, instead of an initContainer per tenant.

Fixes: #3701 