### PR TITLE
[tempo-distributed] remove mention of deprecated `global_overrides` helm value

### DIFF
--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1040,7 +1040,7 @@ metricsGenerator:
     #   headers:
     #     x-scope-orgid: operations
 # Global overrides
-global_overrides:
+overrides:
   defaults:
     metrics_generator:
       processors:


### PR DESCRIPTION
Per `README.md`:

> From Chart versions < 1.33.0
Breaking Change * In order to reduce confusion, the overrides configurations have been renamed as below.
global_overrides => overrides (this is where the defaults for every tenant is set) overrides => per_tenant_overrides (this is where configurations for specific tenants can be set)

The `global_overrides` key is also no longer mentioned in any [values.yaml](https://github.com/grafana/helm-charts/blob/main/charts/tempo-distributed/values.yaml) defaults.