### PR TITLE
[loki-distributed] Fix missing apiVersion and kind in volumeClaimTemplates

### DIFF
--- a/charts/loki-distributed/templates/compactor/statefulset-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/statefulset-compactor.yaml
@@ -169,7 +169,9 @@ spec:
   {{- if .Values.compactor.persistence.enabled }}
   volumeClaimTemplates:
   {{- range .Values.compactor.persistence.claims }}
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: {{ .name }}
         {{- with .annotations }}
         annotations:

--- a/charts/loki-distributed/templates/index-gateway/statefulset-index-gateway.yaml
+++ b/charts/loki-distributed/templates/index-gateway/statefulset-index-gateway.yaml
@@ -162,7 +162,9 @@ spec:
         {{- end }}
   {{- else }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- with .Values.indexGateway.persistence.annotations }}
         annotations:

--- a/charts/loki-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/statefulset-ingester.yaml
@@ -181,7 +181,9 @@ spec:
   {{- else }}
   volumeClaimTemplates:
   {{- range .Values.ingester.persistence.claims }}
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: {{ .name }}
         {{- with .annotations }}
         annotations:

--- a/charts/loki-distributed/templates/memcached-chunks/statefulset-memcached-chunks.yaml
+++ b/charts/loki-distributed/templates/memcached-chunks/statefulset-memcached-chunks.yaml
@@ -141,7 +141,9 @@ spec:
   {{- if or .Values.memcachedChunks.persistence.enabled .Values.memcachedChunks.volumeClaimTemplates }}
   volumeClaimTemplates:
   {{- if .Values.memcachedChunks.persistence.enabled }}
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
       spec:
         accessModes:

--- a/charts/loki-distributed/templates/memcached-frontend/statefulset-memcached-frontend.yaml
+++ b/charts/loki-distributed/templates/memcached-frontend/statefulset-memcached-frontend.yaml
@@ -135,7 +135,9 @@ spec:
       {{- end }}
   {{- if .Values.memcachedFrontend.persistence.enabled }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
       spec:
         accessModes:

--- a/charts/loki-distributed/templates/memcached-index-queries/statefulset-memcached-index-queries.yaml
+++ b/charts/loki-distributed/templates/memcached-index-queries/statefulset-memcached-index-queries.yaml
@@ -135,7 +135,9 @@ spec:
       {{- end }}
   {{- if .Values.memcachedIndexQueries.persistence.enabled }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
       spec:
         accessModes:

--- a/charts/loki-distributed/templates/memcached-index-writes/statefulset-memcached-index-writes.yaml
+++ b/charts/loki-distributed/templates/memcached-index-writes/statefulset-memcached-index-writes.yaml
@@ -135,7 +135,9 @@ spec:
       {{- end }}
   {{- if .Values.memcachedIndexWrites.persistence.enabled }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
       spec:
         accessModes:

--- a/charts/loki-distributed/templates/querier/statefulset-querier.yaml
+++ b/charts/loki-distributed/templates/querier/statefulset-querier.yaml
@@ -157,7 +157,9 @@ spec:
           emptyDir: {}
   {{- else }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- with .Values.querier.persistence.annotations }}
         annotations:

--- a/charts/loki-distributed/templates/ruler/statefulset-ruler.yaml
+++ b/charts/loki-distributed/templates/ruler/statefulset-ruler.yaml
@@ -155,7 +155,9 @@ spec:
           emptyDir: {}
   {{- else }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- with .Values.ruler.persistence.annotations }}
         annotations:


### PR DESCRIPTION
This PR fixes an issue where the volumeClaimTemplates sections in various StatefulSet manifests were missing the required `apiVersion: v1` and `kind: PersistentVolumeClaim` fields.

Replaces #2959 with additional templates.