### PR TITLE
Support templated content for annotations image-renderer-service.yaml

### DIFF
--- a/charts/grafana/templates/image-renderer-service.yaml
+++ b/charts/grafana/templates/image-renderer-service.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end }}
   {{- with .Values.imageRenderer.service.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml . | nindent 4) $root }}
   {{- end }}
 spec:
   type: ClusterIP


### PR DESCRIPTION
Wrap values with `tpl` to support templated content