### PR TITLE
[tempo-distributed] Remove replicas when autoscaling is enabled for compactor

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.39.4
+version: 1.39.5
 appVersion: 2.7.2
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.39.4](https://img.shields.io/badge/Version-1.39.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.2](https://img.shields.io/badge/AppVersion-2.7.2-informational?style=flat-square)
+![Version: 1.39.5](https://img.shields.io/badge/Version-1.39.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.2](https://img.shields.io/badge/AppVersion-2.7.2-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/compactor/deployment-compactor.yaml
+++ b/charts/tempo-distributed/templates/compactor/deployment-compactor.yaml
@@ -12,7 +12,9 @@ metadata:
   {{- end }}
 spec:
   minReadySeconds: {{ .Values.compactor.minReadySeconds }}
+{{- if not .Values.compactor.autoscaling.enabled }}
   replicas: {{ .Values.compactor.replicas }}
+{{- end }}
   revisionHistoryLimit: {{ .Values.tempo.revisionHistoryLimit }}
   selector:
     matchLabels:


### PR DESCRIPTION
This MR removes the `replicas` field from the compactor deployment when autoscaling is enabled. This prevents the deployment from being scaled back to the fixed replica count during rollouts, before the HPA/KEDA takes over again.