### PR TITLE
[tempo-distributed]: add support for templated extraObjects

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.39.4
+version: 1.40.0
 appVersion: 2.7.2
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.39.4](https://img.shields.io/badge/Version-1.39.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.2](https://img.shields.io/badge/AppVersion-2.7.2-informational?style=flat-square)
+![Version: 1.40.0](https://img.shields.io/badge/Version-1.40.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.2](https://img.shields.io/badge/AppVersion-2.7.2-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/extra-manifests.yaml
+++ b/charts/tempo-distributed/templates/extra-manifests.yaml
@@ -1,4 +1,8 @@
 {{ range .Values.extraObjects }}
 ---
-{{ tpl (toYaml .) $ }}
+{{- if typeIs "string" . }}
+  {{ tpl . $ }}
+{{ else }}
+  {{ tpl (. | toYaml) $ }}
+{{- end }}
 {{ end }}

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -2527,3 +2527,18 @@ extraObjects: []
   #     data:
   #       - key: secret-access-key
   #         name: awssm-secret
+  #
+  # alternatively, you can use strings, which will be templated:
+  #
+  # - |
+  #   apiVersion: "kubernetes-client.io/v1"
+  #   kind: ExternalSecret
+  #   metadata:
+  #     name: {{ .Release.Name }}-secrets
+  #     labels:
+  #       {{- include "tempo.labels" . | nindent 4 }}
+  #   spec:
+  #     backendType: aws
+  #     data:
+  #       - key: secret-access-key
+  #         name: awssm-secret


### PR DESCRIPTION
A follow-up to https://github.com/grafana/helm-charts/pull/2722, allowing to add `extraObjects` as strings and templating them. This is already supported by some LGTM charts.