### PR TITLE
[tempo] fix port 3200 alignment

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 1.23.0
+version: 1.23.1
 appVersion: 2.8.0
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 1.23.0](https://img.shields.io/badge/Version-1.23.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.0](https://img.shields.io/badge/AppVersion-2.8.0-informational?style=flat-square)
+![Version: 1.23.1](https://img.shields.io/badge/Version-1.23.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.0](https://img.shields.io/badge/AppVersion-2.8.0-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 
@@ -64,7 +64,7 @@ Grafana Tempo Single Binary Mode
 | tempo.ingester | object | `{}` | Configuration options for the ingester. Refers to: https://grafana.com/docs/tempo/latest/configuration/#ingester |
 | tempo.livenessProbe.failureThreshold | int | `3` |  |
 | tempo.livenessProbe.httpGet.path | string | `"/ready"` |  |
-| tempo.livenessProbe.httpGet.port | int | `3100` |  |
+| tempo.livenessProbe.httpGet.port | int | `3200` |  |
 | tempo.livenessProbe.initialDelaySeconds | int | `30` |  |
 | tempo.livenessProbe.periodSeconds | int | `10` |  |
 | tempo.livenessProbe.successThreshold | int | `1` |  |
@@ -82,7 +82,7 @@ Grafana Tempo Single Binary Mode
 | tempo.queryFrontend | object | `{}` | Configuration options for the query-fronted. Refers to: https://grafana.com/docs/tempo/latest/configuration/#query-frontend |
 | tempo.readinessProbe.failureThreshold | int | `3` |  |
 | tempo.readinessProbe.httpGet.path | string | `"/ready"` |  |
-| tempo.readinessProbe.httpGet.port | int | `3100` |  |
+| tempo.readinessProbe.httpGet.port | int | `3200` |  |
 | tempo.readinessProbe.initialDelaySeconds | int | `20` |  |
 | tempo.readinessProbe.periodSeconds | int | `10` |  |
 | tempo.readinessProbe.successThreshold | int | `1` |  |
@@ -99,7 +99,7 @@ Grafana Tempo Single Binary Mode
 | tempo.resources | object | `{}` |  |
 | tempo.retention | string | `"24h"` |  |
 | tempo.securityContext | object | `{}` |  |
-| tempo.server.http_listen_port | int | `3100` | HTTP server listen port |
+| tempo.server.http_listen_port | int | `3200` | HTTP server listen port |
 | tempo.storage.trace.backend | string | `"local"` |  |
 | tempo.storage.trace.local.path | string | `"/var/tempo/traces"` |  |
 | tempo.storage.trace.wal.path | string | `"/var/tempo/wal"` |  |

--- a/charts/tempo/templates/_ports.tpl
+++ b/charts/tempo/templates/_ports.tpl
@@ -24,9 +24,9 @@
 {{/* TCP sockets */}}
 {{- define "tempo.tcp"}}
 - name: tempo-prom-metrics
-  port: 3100
+  port: 3200
   protocol: TCP
-  targetPort: 3100
+  targetPort: 3200
 {{- if .Values.tempoQuery.enabled }}
 - name: jaeger-metrics
   port: 16687

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -88,12 +88,12 @@ tempo:
   # Refers to: https://grafana.com/docs/tempo/latest/configuration/#server
   server:
     # -- HTTP server listen port
-    http_listen_port: 3100
+    http_listen_port: 3200
   # Readiness and Liveness Probe Configuration Options
   livenessProbe:
     httpGet:
       path: /ready
-      port: 3100
+      port: 3200
     initialDelaySeconds: 30
     periodSeconds: 10
     timeoutSeconds: 5
@@ -102,7 +102,7 @@ tempo:
   readinessProbe:
     httpGet:
       path: /ready
-      port: 3100
+      port: 3200
     initialDelaySeconds: 20
     periodSeconds: 10
     timeoutSeconds: 5


### PR DESCRIPTION
in https://github.com/grafana/helm-charts/pull/3745 i forgot that port 3100 is set also in the k8s service and the tempo config itself, this PR fixes it 