### PR TITLE
[grafana] Yaml numbers in grafana.ini break templating

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 9.2.2
+version: 9.2.3
 appVersion: 12.0.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_config.tpl
+++ b/charts/grafana/templates/_config.tpl
@@ -16,7 +16,7 @@ grafana.ini: |
   {{- else if kindIs "slice" $elemVal }}
   {{ $elem }} = {{ toJson $elemVal }}
   {{- else if kindIs "string" $elemVal }}
-  {{ $elem }} = {{ tpl $elemVal $ }}
+  {{ $elem }} = {{ tpl ($elemVal | toString) $ }}
   {{- else }}
   {{ $elem }} = {{ $elemVal }}
   {{- end }}
@@ -31,7 +31,7 @@ grafana.ini: |
   {{- else if kindIs "slice" $elemVal }}
   {{ $elem }} = {{ toJson $elemVal }}
   {{- else if kindIs "string" $elemVal }}
-  {{ $elem }} = {{ tpl $elemVal $ }}
+  {{ $elem }} = {{ tpl ($elemVal | toString) $ }}
   {{- else }}
   {{ $elem }} = {{ $elemVal }}
   {{- end }}


### PR DESCRIPTION
If grafana.ini in grafana/values.yaml contains a number field, it causes helm templating to fail.
To test this, checkout latest and add grafana.ini.server.http_port: 3000 to values.yaml, and try and render the template locally. Helm gives the following error:

```
❯ helm template charts/grafana --output-dir rendered --name-template=release-name
Error: template: grafana/templates/deployment.yaml:36:28: executing "grafana/templates/deployment.yaml" at <include "grafana.configData" .>: error calling include: template: grafana/templates/_config.tpl:34:23: executing "grafana.configData" at <$elemVal>: wrong type for value; expected string; got json.Number
```

Full grafana.ini config in values.yaml with http_port added for reference:

```yaml
grafana.ini:
  paths:
    data: /var/lib/grafana/
    logs: /var/log/grafana
    plugins: /var/lib/grafana/plugins
    provisioning: /etc/grafana/provisioning
  analytics:
    check_for_updates: true
  log:
    mode: console
  grafana_net:
    url: https://grafana.net
  server:
    domain: "{{ if (and .Values.ingress.enabled .Values.ingress.hosts) }}{{ tpl (.Values.ingress.hosts | first) . }}{{ else }}''{{ end }}"

Helm Info:
```
❯ helm version
version.BuildInfo{Version:"v3.18.0", GitCommit:"cc58e3f5a3aa615c6a86275e6f4444b5fdd3cc4e", GitTreeState:"clean", GoVersion:"go1.24.3"}
```

Even though we check if the field is a string, this is a Helm String but the field is a yaml number, leading to the confusion. Ensuring we convert all Helm strings to yaml strings ensures we do not hit the issue.