### PR TITLE
[grafana] Fix formatting for sizeLimit on emptyDir volumes

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 9.2.3
+version: 9.2.4
 appVersion: 12.0.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1063,7 +1063,7 @@ sidecar:
     # Additional alerts sidecar volume mounts
     extraMounts: []
     # Sets the size limit of the alert sidecar emptyDir volume
-    sizeLimit: {}
+    sizeLimit: ""
   dashboards:
     enabled: false
     # Additional environment variables for the dashboards sidecar
@@ -1167,7 +1167,7 @@ sidecar:
     # Additional dashboards sidecar volume mounts
     extraMounts: []
     # Sets the size limit of the dashboard sidecar emptyDir volume
-    sizeLimit: {}
+    sizeLimit: ""
   datasources:
     enabled: false
     # Additional environment variables for the datasourcessidecar
@@ -1248,7 +1248,7 @@ sidecar:
     # Additional datasources sidecar volume mounts
     extraMounts: []
     # Sets the size limit of the datasource sidecar emptyDir volume
-    sizeLimit: {}
+    sizeLimit: ""
   plugins:
     enabled: false
     # Additional environment variables for the plugins sidecar
@@ -1316,7 +1316,7 @@ sidecar:
     # Additional plugins sidecar volume mounts
     extraMounts: []
     # Sets the size limit of the plugin sidecar emptyDir volume
-    sizeLimit: {}
+    sizeLimit: ""
   notifiers:
     enabled: false
     # Additional environment variables for the notifierssidecar
@@ -1384,7 +1384,7 @@ sidecar:
     # Additional notifiers sidecar volume mounts
     extraMounts: []
     # Sets the size limit of the notifier sidecar emptyDir volume
-    sizeLimit: {}
+    sizeLimit: ""
 
 ## Override the deployment namespace
 ##


### PR DESCRIPTION
I received this log when using emptyDir volumes on grafana :
`coalesce.go:298: warning: cannot overwrite table with non table for grafana.sidecar.....sizeLimit (map[])`

so it's not map/dictionary. [xref](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir)