### PR TITLE
[promtail] add target_config settings

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -3,7 +3,7 @@ name: promtail
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 3.5.1
-version: 6.17.0
+version: 6.17.1
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -1,6 +1,6 @@
 # promtail
 
-![Version: 6.17.0](https://img.shields.io/badge/Version-6.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.1](https://img.shields.io/badge/AppVersion-3.5.1-informational?style=flat-square)
+![Version: 6.17.1](https://img.shields.io/badge/Version-6.17.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.1](https://img.shields.io/badge/AppVersion-3.5.1-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 
@@ -85,6 +85,7 @@ The new release which will pick up again from the existing `positions.yaml`.
 | config.snippets.extraRelabelConfigs | list | `[]` | You can put here any additional relabel_configs to "kubernetes-pods" job |
 | config.snippets.extraScrapeConfigs | string | empty | You can put here any additional scrape configs you want to add to the config file. |
 | config.snippets.extraServerConfigs | string | empty | You can put here any keys that will be directly added to the config file's 'server' block. |
+| config.target_config | object | `{"sync_period":"10s"}` | A block configures controls the behavior of reading files from discovered targets. Must be referenced in `config.file` to configure `target_config` |
 | configmap.enabled | bool | `false` | If enabled, promtail config will be created as a ConfigMap instead of a secret |
 | containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The security context for containers |
 | daemonset.autoscaling.controlledResources | list | `[]` | List of resources that the vertical pod autoscaler can control. Defaults to cpu and memory |

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -428,6 +428,10 @@ config:
   # Must be referenced in `config.file` to configure `positions`
   positions:
     filename: /run/promtail/positions.yaml
+  # -- A block configures controls the behavior of reading files from discovered targets.
+  # Must be referenced in `config.file` to configure `target_config`
+  target_config:
+    sync_period: "10s"
   # -- The config to enable tracing
   enableTracing: false
   # -- A section of reusable snippets that can be reference in `config.file`.
@@ -565,6 +569,9 @@ config:
 
     limits_config:
       {{- tpl .Values.config.snippets.extraLimitsConfig . | nindent 2 }}
+
+    target_config:
+      {{- tpl (toYaml .Values.config.target_config) . | nindent 2 }}
 
     tracing:
       enabled: {{ .Values.config.enableTracing }}


### PR DESCRIPTION
The changes are necessary to allow for the overriding of the synchronization timeout for watched directories.
See [docs](https://grafana.com/docs/loki/latest/send-data/promtail/configuration/#target_config)