### PR TITLE
[grafana] Add additional default value for HTTRoute backend

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 9.2.8
+version: 9.2.9
 appVersion: 12.0.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/route.yaml
+++ b/charts/grafana/templates/route.yaml
@@ -34,6 +34,7 @@ spec:
           port: {{ $.Values.service.port }}
           group: ''
           kind: Service
+          weight: 1
       {{- with $route.filters }}
       filters:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b41508f2-acb1-4707-810b-36b853468c3c)

We deploy this chart using ArgoCD and the application remains out-of-sync due to a missing default value.

This PR aligns with the [httproute spec](https://gateway-api.sigs.k8s.io/reference/spec/#backendref)