### PR TITLE
[grafana] SSL issue with dashboard/datasource sidecards caused by bug on kiwigrid

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 9.2.9
+version: 9.2.10
 appVersion: 12.0.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -959,7 +959,7 @@ sidecar:
     # -- The Docker registry
     registry: quay.io
     repository: kiwigrid/k8s-sidecar
-    tag: 1.30.5
+    tag: 1.30.3
     sha: ""
   imagePullPolicy: IfNotPresent
   resources: {}


### PR DESCRIPTION
The latest change causes issues to sidecars running kiwigrid. downgrading kiwigrid to 1.30.3 will fix the issue.

- Kiwigrid has an issue with SSL, which deletes all dashboards from grafana.
- Downgrading to a working version (from 1.30.5 to 1.30.3)
- Link of the bug: https://github.com/kiwigrid/k8s-sidecar/issues/400