### PR TITLE
[synthetic-monitoring-agent]: bump to 0.38.3

### DIFF
--- a/charts/synthetic-monitoring-agent/Chart.yaml
+++ b/charts/synthetic-monitoring-agent/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v0.34.4
+appVersion: v0.38.3
 description: Grafana's Synthetic Monitoring application. The agent provides probe functionality and executes network checks for monitoring remote targets.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png
@@ -14,4 +14,4 @@ name: synthetic-monitoring-agent
 sources:
   - https://github.com/grafana/synthetic-monitoring-agent
 type: application
-version: 1.0.0
+version: 1.1.0


### PR DESCRIPTION
Signed-off-by: AvivGuiser <avivguiser@gmail.com>

fixes a CVE https://grafana.com/blog/2025/07/02/grafana-security-update-critical-severity-security-release-for-cve-2025-5959-cve-2025-6554-cve-2025-6191-and-cve-2025-6192-in-grafana-image-renderer-plugin-and-synthetic-monitoring-agent/