### PR TITLE
[tempo-distributed] add config support for query_backend_after and query_ingesters_until

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.45.0
+version: 1.46.0
 appVersion: 2.8.1
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.45.0](https://img.shields.io/badge/Version-1.45.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.1](https://img.shields.io/badge/AppVersion-2.8.1-informational?style=flat-square)
+![Version: 1.46.0](https://img.shields.io/badge/Version-1.46.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.1](https://img.shields.io/badge/AppVersion-2.8.1-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -862,6 +862,8 @@ The memcached default args are removed and should be provided manually. The sett
 | queryFrontend.config.search.concurrent_jobs | int | `1000` | The number of concurrent jobs to execute when searching the backend |
 | queryFrontend.config.search.max_spans_per_span_set | int | `100` | The maximum allowed value of spans per span set. 0 disables this limit. |
 | queryFrontend.config.search.target_bytes_per_job | int | `104857600` | The target number of bytes for each job to handle when performing a backend search |
+| queryFrontend.config.search.query_backend_after | string | `15m` | query_backend_after and query_ingesters_until together control where the query-frontend searches for traces. Time ranges before query_ingesters_until will be searched in the ingesters only. Time ranges after query_backend_after will be searched in the backend/object storage only. Time ranges from query_backend_after through query_ingesters_until will be queried from both locations. query_backend_after must be less than or equal to query_ingesters_until. |
+| queryFrontend.config.search.query_ingesters_until | string | `30m` |
 | queryFrontend.config.trace_by_id | object | `{"query_shards":50}` | Trace by ID lookup configuration |
 | queryFrontend.config.trace_by_id.query_shards | int | `50` | The number of shards to split a trace by id query into. |
 | queryFrontend.extraArgs | list | `[]` | Additional CLI args for the query-frontend |

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -905,6 +905,13 @@ queryFrontend:
       target_bytes_per_job: 104857600
       # -- The maximum allowed value of spans per span set. 0 disables this limit.
       max_spans_per_span_set: 100
+      # query_backend_after and query_ingesters_until together control where the query-frontend searches for traces.
+      # Time ranges before query_ingesters_until will be searched in the ingesters only.
+      # Time ranges after query_backend_after will be searched in the backend/object storage only.
+      # Time ranges from query_backend_after through query_ingesters_until will be queried from both locations.
+      # query_backend_after must be less than or equal to query_ingesters_until.
+      query_backend_after: 15m
+      query_ingesters_until: 30m
     # -- Trace by ID lookup configuration
     trace_by_id:
       # -- The number of shards to split a trace by id query into.
@@ -1449,6 +1456,8 @@ config: |
       target_bytes_per_job: {{ .Values.queryFrontend.config.search.target_bytes_per_job }}
       concurrent_jobs: {{ .Values.queryFrontend.config.search.concurrent_jobs }}
       max_spans_per_span_set: {{ .Values.queryFrontend.config.search.max_spans_per_span_set }}
+      query_backend_after: {{ .Values.queryFrontend.config.search.query_backend_after }}
+      query_ingesters_until: {{ .Values.queryFrontend.config.search.query_ingesters_until }}
     trace_by_id:
       query_shards: {{ .Values.queryFrontend.config.trace_by_id.query_shards }}
     metrics:


### PR DESCRIPTION
This PR introduces optional configuration support for the query_backend_after and query_ingesters_until settings in the Tempo Helm chart, specifically for the queryFrontend component.

These options allow fine-tuning how the query-frontend component handles querying backends and ingesters, enabling better performance control and customization for advanced use cases.

Changes Introduced

- Added query_backend_after and query_ingesters_until as optional Helm values.
- Updated the queryFrontend config template to conditionally render these values.
- Default behavior is unchanged if the values are not specified.