### PR TITLE
[grafana] fix print statefulset pvc claim accessmode as list

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 9.3.0
+version: 9.3.1
 appVersion: 12.1.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/statefulset.yaml
+++ b/charts/grafana/templates/statefulset.yaml
@@ -44,7 +44,10 @@ spec:
     metadata:
       name: storage
     spec:
-      accessModes: {{ .Values.persistence.accessModes }}
+      accessModes:
+        {{- range .Values.persistence.accessModes }}
+        - {{ . | quote }}
+        {{- end }}
       storageClassName: {{ .Values.persistence.storageClassName }}
       {{- with .Values.persistence.volumeName }}
       volumeName: {{ . | quote }}


### PR DESCRIPTION
I want to run a scheduled backup of the Grafana database and for that I need to be able to mount the PVC to the backup runner pod in readonly mode, however the default ReadWriteOnce mode prevents this. Adding ReadOnlyMany accessMode in `values.yaml` results in

```yaml
accessModes:
  - ReadWriteOnce ReadOnlyMany
```

Instead of
```yaml
accessModes:
  - ReadWriteOnce
  - ReadOnlyMany
```

I reused the template from `pvc.yaml`


