### PR TITLE
[loki-distributed] Add index-gateway container lifecycle

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.9.13
-version: 0.80.5
+version: 0.80.6
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.80.5](https://img.shields.io/badge/Version-0.80.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.13](https://img.shields.io/badge/AppVersion-2.9.13-informational?style=flat-square)
+![Version: 0.80.6](https://img.shields.io/badge/Version-0.80.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.13](https://img.shields.io/badge/AppVersion-2.9.13-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 
@@ -262,6 +262,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | indexGateway.image.tag | string | `nil` | Docker image tag for the index-gateway image. Overrides `loki.image.tag` |
 | indexGateway.initContainers | list | `[]` | Init containers to add to the index-gateway pods |
 | indexGateway.joinMemberlist | bool | `true` | Whether the index gateway should join the memberlist hashring |
+| indexGateway.lifecycle | object | `{}` | Lifecycle for the index-gateway container |
 | indexGateway.maxUnavailable | string | `nil` | Pod Disruption Budget maxUnavailable |
 | indexGateway.minAvailable | string | `nil` | Pod Disruption Budget minAvailable |
 | indexGateway.nodeSelector | object | `{}` | Node selector for index-gateway pods |

--- a/charts/loki-distributed/templates/index-gateway/statefulset-index-gateway.yaml
+++ b/charts/loki-distributed/templates/index-gateway/statefulset-index-gateway.yaml
@@ -115,6 +115,10 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.indexGateway.resources | nindent 12 }}
+          {{- with .Values.indexGateway.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- if .Values.indexGateway.extraContainers }}
         {{- toYaml .Values.indexGateway.extraContainers | nindent 8}}
         {{- end }}

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -1676,6 +1676,8 @@ indexGateway:
   initContainers: []
   # -- Grace period to allow the index-gateway to shutdown before it is killed.
   terminationGracePeriodSeconds: 300
+  # -- Lifecycle for the index-gateway container
+  lifecycle: {}
   # -- Affinity for index-gateway pods. Passed through `tpl` and, thus, to be configured as string
   # @default -- Hard node and soft zone anti-affinity
   affinity: |


### PR DESCRIPTION
We want to be able to set a `postStart` lifecycle in the index-gateways.

The reason for it is that, with a few queries, the index-gateway pods run out of memory, and on top of setting a timeout for the queries ([query_timeout](https://grafana.com/docs/loki/latest/configure/#limits_config#:~:text=query_timeout)), we also want to clean up the tsdb-cache folder on restarts of the pods.

Docs about this:
- https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
- https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#lifecycle-v1-core

The same thing was done for the `ingester` at https://github.com/grafana/helm-charts/pull/2527