### PR TITLE
[grafana-sampling] add receiver parameters

### DIFF
--- a/charts/grafana-sampling/Chart.lock
+++ b/charts/grafana-sampling/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: alloy
   repository: https://grafana.github.io/helm-charts
-  version: 0.12.5
+  version: 1.2.1
 - name: alloy
   repository: https://grafana.github.io/helm-charts
-  version: 0.12.5
-digest: sha256:e3981ad0a096fac88106d866d61a1cae09a0feec8f50e8f97bdaa0dee556e0a2
-generated: "2025-03-31T15:26:38.379304672+02:00"
+  version: 1.2.1
+digest: sha256:2d813ce905b1503d97444bb668aab27814e3dee45e68187d3b12601aa5ba06d0
+generated: "2025-08-11T11:05:07.041393-07:00"

--- a/charts/grafana-sampling/Chart.yaml
+++ b/charts/grafana-sampling/Chart.yaml
@@ -2,17 +2,17 @@ apiVersion: v2
 name: grafana-sampling
 description: A Helm chart for a layered OTLP tail sampling and metrics generation pipeline.
 type: application
-version: 1.1.5
-appVersion: "v1.7.5"
+version: 1.1.6
+appVersion: "v1.10.1"
 sources:
   - https://github.com/grafana/alloy
   - https://grafana.com/docs/grafana-cloud/monitor-applications/application-observability/setup/sampling/tail/
 dependencies:
   - name: alloy
-    version: 0.12.5
+    version: 1.2.1
     repository: https://grafana.github.io/helm-charts
     alias: alloy-deployment
   - name: alloy
-    version: 0.12.5
+    version: 1.2.1
     repository: https://grafana.github.io/helm-charts
     alias: alloy-statefulset

--- a/charts/grafana-sampling/README.md
+++ b/charts/grafana-sampling/README.md
@@ -1,6 +1,6 @@
 # grafana-sampling
 
-![Version: 1.1.5](https://img.shields.io/badge/Version-1.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.7.5](https://img.shields.io/badge/AppVersion-v1.7.5-informational?style=flat-square)
+![Version: 1.1.6](https://img.shields.io/badge/Version-1.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.10.1](https://img.shields.io/badge/AppVersion-v1.10.1-informational?style=flat-square)
 
 A Helm chart for a layered OTLP tail sampling and metrics generation pipeline.
 
@@ -143,21 +143,34 @@ A major chart version change indicates that there is an incompatible breaking ch
 | batch.statefulset.send_batch_max_size | int | `0` |  |
 | batch.statefulset.send_batch_size | int | `8192` |  |
 | batch.statefulset.timeout | string | `"200ms"` |  |
-| deployment.otlp.receiver | object | `{"grpc":{"max_recv_msg_size":"4MB"}}` | otlp receiver settings for deployment (loadbalancer) |
+| deployment.otlp.receiver | object | `{"grpc":{"keepalive":{"enforcementPolicy":{"minTime":"","permitWithoutStream":false},"serverParameters":{"maxConnectionAge":"","maxConnectionAgeGrace":"","maxConnectionIdle":"","time":"","timeout":""}},"max_recv_msg_size":"4MB"}}` | otlp receiver settings for deployment (loadbalancer) |
+| deployment.otlp.receiver.grpc.keepalive.enforcementPolicy.minTime | string | `""` | Minimum time clients should wait before sending a keepalive ping. Default is 5 minutes. @section -- Receivers: OTLP |
+| deployment.otlp.receiver.grpc.keepalive.enforcementPolicy.permitWithoutStream | bool | `false` | Allow clients to send keepalive pings when there are no active streams. @section -- Receivers: OTLP |
+| deployment.otlp.receiver.grpc.keepalive.serverParameters.maxConnectionAge | string | `""` | Maximum age for non-idle connections. Default is infinity. @section -- Receivers: OTLP |
+| deployment.otlp.receiver.grpc.keepalive.serverParameters.maxConnectionAgeGrace | string | `""` | Time to wait before forcibly closing connections. Default is infinity. @section -- Receivers: OTLP |
+| deployment.otlp.receiver.grpc.keepalive.serverParameters.maxConnectionIdle | string | `""` | Maximum age for idle connections. Default is infinity. @section -- Receivers: OTLP |
+| deployment.otlp.receiver.grpc.keepalive.serverParameters.time | string | `""` | How often to ping inactive clients to check for liveness. Default is 2 hours. @section -- Receivers: OTLP |
+| deployment.otlp.receiver.grpc.keepalive.serverParameters.timeout | string | `""` | Time to wait before closing inactive clients that don’t respond to liveness checks. Default is 20 seconds. @section -- Receivers: OTLP |
 | deployment.otlp.receiver.grpc.max_recv_msg_size | string | `"4MB"` | gRPC max message receive size. Default to 4MB |
 | liveDebugging.enabled | bool | `false` | Enable live debugging in the Alloy UI. |
 | metricsGeneration.dimensions | list | `["service.namespace","service.version","deployment.environment","k8s.cluster.name","k8s.pod.name"]` | Additional dimensions to add to generated metrics. |
 | metricsGeneration.enabled | bool | `true` | Toggle generation of spanmetrics and servicegraph metrics. |
-| metricsGeneration.legacy | bool | `true` | Use legacy metric names that match those used by the Tempo metrics generator. |
+| metricsGeneration.legacy | bool | `false` | Use legacy metric names that match those used by the Tempo metrics generator. |
 | metricsGeneration.serviceGraph.metricsFlushInterval | string | `"60s"` | The interval at which metrics are flushed to downstream components. |
 | metricsGeneration.spanMetrics.metricsExpiration | string | `"5m"` | Time period after which metrics are considered stale and are removed from the cache. |
 | sampling.decisionWait | string | `"15s"` | Wait time since the first span of a trace before making a sampling decision. |
 | sampling.enabled | bool | `true` | Toggle tail sampling. |
 | sampling.extraPolicies | string | A policy to sample long requests is added by default. | User-defined policies in alloy format. |
 | sampling.failedRequests.percentage | int | `50` | Percentage of failed requests to sample. |
-| sampling.failedRequests.sample | bool | `false` | Toggle sampling failed requests. |
 | sampling.successfulRequests.percentage | int | `10` | Percentage of successful requests to sample. |
 | sampling.successfulRequests.sample | bool | `true` | Toggle sampling successful requests. |
-| statefulset.otlp.receiver | object | `{"grpc":{"max_recv_msg_size":"4MB"}}` | otlp receiver settings for statefulset (sampler) |
+| statefulset.otlp.receiver | object | `{"grpc":{"keepalive":{"enforcementPolicy":{"minTime":"","permitWithoutStream":false},"serverParameters":{"maxConnectionAge":"","maxConnectionAgeGrace":"","maxConnectionIdle":"","time":"","timeout":""}},"max_recv_msg_size":"4MB"}}` | otlp receiver settings for statefulset (sampler) |
+| statefulset.otlp.receiver.grpc.keepalive.enforcementPolicy.minTime | string | `""` | Minimum time clients should wait before sending a keepalive ping. Default is 5 minutes. @section -- Receivers: OTLP |
+| statefulset.otlp.receiver.grpc.keepalive.enforcementPolicy.permitWithoutStream | bool | `false` | Allow clients to send keepalive pings when there are no active streams. @section -- Receivers: OTLP |
+| statefulset.otlp.receiver.grpc.keepalive.serverParameters.maxConnectionAge | string | `""` | Maximum age for non-idle connections. Default is infinity. @section -- Receivers: OTLP |
+| statefulset.otlp.receiver.grpc.keepalive.serverParameters.maxConnectionAgeGrace | string | `""` | Time to wait before forcibly closing connections. Default is infinity. @section -- Receivers: OTLP |
+| statefulset.otlp.receiver.grpc.keepalive.serverParameters.maxConnectionIdle | string | `""` | Maximum age for idle connections. Default is infinity. @section -- Receivers: OTLP |
+| statefulset.otlp.receiver.grpc.keepalive.serverParameters.time | string | `""` | How often to ping inactive clients to check for liveness. Default is 2 hours. @section -- Receivers: OTLP |
+| statefulset.otlp.receiver.grpc.keepalive.serverParameters.timeout | string | `""` | Time to wait before closing inactive clients that don’t respond to liveness checks. Default is 20 seconds. @section -- Receivers: OTLP |
 | statefulset.otlp.receiver.grpc.max_recv_msg_size | string | `"4MB"` | gRPC max message receive size. Default to 4MB |
 

--- a/charts/grafana-sampling/README.md
+++ b/charts/grafana-sampling/README.md
@@ -155,13 +155,14 @@ A major chart version change indicates that there is an incompatible breaking ch
 | liveDebugging.enabled | bool | `false` | Enable live debugging in the Alloy UI. |
 | metricsGeneration.dimensions | list | `["service.namespace","service.version","deployment.environment","k8s.cluster.name","k8s.pod.name"]` | Additional dimensions to add to generated metrics. |
 | metricsGeneration.enabled | bool | `true` | Toggle generation of spanmetrics and servicegraph metrics. |
-| metricsGeneration.legacy | bool | `false` | Use legacy metric names that match those used by the Tempo metrics generator. |
+| metricsGeneration.legacy | bool | `true` | Use legacy metric names that match those used by the Tempo metrics generator. |
 | metricsGeneration.serviceGraph.metricsFlushInterval | string | `"60s"` | The interval at which metrics are flushed to downstream components. |
 | metricsGeneration.spanMetrics.metricsExpiration | string | `"5m"` | Time period after which metrics are considered stale and are removed from the cache. |
 | sampling.decisionWait | string | `"15s"` | Wait time since the first span of a trace before making a sampling decision. |
 | sampling.enabled | bool | `true` | Toggle tail sampling. |
 | sampling.extraPolicies | string | A policy to sample long requests is added by default. | User-defined policies in alloy format. |
 | sampling.failedRequests.percentage | int | `50` | Percentage of failed requests to sample. |
+| sampling.failedRequests.sample | bool | `false` | Toggle sampling failed requests. |
 | sampling.successfulRequests.percentage | int | `10` | Percentage of successful requests to sample. |
 | sampling.successfulRequests.sample | bool | `true` | Toggle sampling successful requests. |
 | statefulset.otlp.receiver | object | `{"grpc":{"keepalive":{"enforcementPolicy":{"minTime":"","permitWithoutStream":false},"serverParameters":{"maxConnectionAge":"","maxConnectionAgeGrace":"","maxConnectionIdle":"","time":"","timeout":""}},"max_recv_msg_size":"4MB"}}` | otlp receiver settings for statefulset (sampler) |

--- a/charts/grafana-sampling/templates/_otelcol_receiver_otlp.alloy.txt
+++ b/charts/grafana-sampling/templates/_otelcol_receiver_otlp.alloy.txt
@@ -5,6 +5,43 @@ otelcol.receiver.otlp "default" {
   // configures the default grpc endpoint "0.0.0.0:4317"
   grpc {
     max_recv_msg_size = {{ .Values.deployment.otlp.receiver.grpc.max_recv_msg_size | quote }}
+
+    {{- $hasServerParameters := and .Values.deployment.otlp.receiver.grpc.keepalive.serverParameters (or .Values.deployment.otlp.receiver.grpc.keepalive.serverParameters.maxConnectionAge .Values.deployment.otlp.receiver.grpc.keepalive.serverParameters.maxConnectionAgeGrace .Values.deployment.otlp.receiver.grpc.keepalive.serverParameters.maxConnectionIdle) }}
+    {{- $hasEnforcementPolicy := and .Values.deployment.otlp.receiver.grpc.keepalive.enforcementPolicy (or .Values.deployment.otlp.receiver.grpc.keepalive.enforcementPolicy.minTime .Values.deployment.otlp.receiver.grpc.keepalive.enforcementPolicy.permitWithoutStream) }}
+    {{- if or $hasServerParameters $hasEnforcementPolicy }}
+    keepalive {
+      {{- if $hasServerParameters }}
+      server_parameters {
+        {{- if .Values.deployment.otlp.receiver.grpc.keepalive.serverParameters.maxConnectionAge }}
+        max_connection_age = {{ .Values.deployment.otlp.receiver.grpc.keepalive.serverParameters.maxConnectionAge | quote }}
+        {{- end }}
+        {{- if .Values.deployment.otlp.receiver.grpc.keepalive.serverParameters.maxConnectionAgeGrace }}
+        max_connection_age_grace = {{ .Values.deployment.otlp.receiver.grpc.keepalive.serverParameters.maxConnectionAgeGrace | quote }}
+        {{- end }}
+        {{- if .Values.deployment.otlp.receiver.grpc.keepalive.serverParameters.maxConnectionIdle }}
+        max_connection_idle = {{ .Values.deployment.otlp.receiver.grpc.keepalive.serverParameters.maxConnectionIdle | quote }}
+        {{- end }}
+        {{- if .Values.deployment.otlp.receiver.grpc.keepalive.serverParameters.time }}
+        time = {{ .Values.deployment.otlp.receiver.grpc.keepalive.serverParameters.time | quote }}
+        {{- end }}
+        {{- if .Values.deployment.otlp.receiver.grpc.keepalive.serverParameters.timeout }}
+        timeout = {{ .Values.deployment.otlp.receiver.grpc.keepalive.serverParameters.timeout | quote }}
+        {{- end }}
+      }
+      {{- end }}
+      {{- if $hasEnforcementPolicy }}
+      enforcement_policy {
+        {{- if .Values.deployment.otlp.receiver.grpc.keepalive.enforcementPolicy.maxConnectionAge }}
+        min_time = {{ .Values.deployment.otlp.receiver.grpc.keepalive.enforcementPolicy.minTime | quote }}
+        {{- end }}
+        {{- if .Values.deployment.otlp.receiver.grpc.keepalive.enforcementPolicy.permitWithoutStream }}
+        permit_without_stream = {{ .Values.deployment.otlp.receiver.grpc.keepalive.enforcementPolicy.permitWithoutStream }}
+        {{- end }}
+      }
+      {{- end }}
+    }
+    {{- end }}
+
   }
 
   // configures the default http/protobuf endpoint "0.0.0.0:4318"
@@ -24,6 +61,43 @@ otelcol.receiver.otlp "default" {
   // configures the default grpc endpoint "0.0.0.0:4317"
   grpc {
     max_recv_msg_size = {{ .Values.statefulset.otlp.receiver.grpc.max_recv_msg_size | quote }}
+
+    {{- $hasServerParameters := and .Values.statefulset.otlp.receiver.grpc.keepalive.serverParameters (or .Values.statefulset.otlp.receiver.grpc.keepalive.serverParameters.maxConnectionAge .Values.statefulset.otlp.receiver.grpc.keepalive.serverParameters.maxConnectionAgeGrace .Values.statefulset.otlp.receiver.grpc.keepalive.serverParameters.maxConnectionIdle) }}
+    {{- $hasEnforcementPolicy := and .Values.statefulset.otlp.receiver.grpc.keepalive.enforcementPolicy (or .Values.statefulset.otlp.receiver.grpc.keepalive.enforcementPolicy.minTime .Values.statefulset.otlp.receiver.grpc.keepalive.enforcementPolicy.permitWithoutStream) }}
+    {{- if or $hasServerParameters $hasEnforcementPolicy }}
+    keepalive {
+      {{- if $hasServerParameters }}
+      server_parameters {
+        {{- if .Values.statefulset.otlp.receiver.grpc.keepalive.serverParameters.maxConnectionAge }}
+        max_connection_age = {{ .Values.statefulset.otlp.receiver.grpc.keepalive.serverParameters.maxConnectionAge | quote }}
+        {{- end }}
+        {{- if .Values.statefulset.otlp.receiver.grpc.keepalive.serverParameters.maxConnectionAgeGrace }}
+        max_connection_age_grace = {{ .Values.statefulset.otlp.receiver.grpc.keepalive.serverParameters.maxConnectionAgeGrace | quote }}
+        {{- end }}
+        {{- if .Values.statefulset.otlp.receiver.grpc.keepalive.serverParameters.maxConnectionIdle }}
+        max_connection_idle = {{ .Values.statefulset.otlp.receiver.grpc.keepalive.serverParameters.maxConnectionIdle | quote }}
+        {{- end }}
+        {{- if .Values.statefulset.otlp.receiver.grpc.keepalive.serverParameters.time }}
+        time = {{ .Values.statefulset.otlp.receiver.grpc.keepalive.serverParameters.time | quote }}
+        {{- end }}
+        {{- if .Values.statefulset.otlp.receiver.grpc.keepalive.serverParameters.timeout }}
+        timeout = {{ .Values.statefulset.otlp.receiver.grpc.keepalive.serverParameters.timeout | quote }}
+        {{- end }}
+      }
+      {{- end }}
+      {{- if $hasEnforcementPolicy }}
+      enforcement_policy {
+        {{- if .Values.statefulset.otlp.receiver.grpc.keepalive.enforcementPolicy.maxConnectionAge }}
+        min_time = {{ .Values.statefulset.otlp.receiver.grpc.keepalive.enforcementPolicy.minTime | quote }}
+        {{- end }}
+        {{- if .Values.statefulset.otlp.receiver.grpc.keepalive.enforcementPolicy.permitWithoutStream }}
+        permit_without_stream = {{ .Values.statefulset.otlp.receiver.grpc.keepalive.enforcementPolicy.permitWithoutStream }}
+        {{- end }}
+      }
+      {{- end }}
+    }
+    {{- end }}
+
   }
 
   output {

--- a/charts/grafana-sampling/values.yaml
+++ b/charts/grafana-sampling/values.yaml
@@ -2,7 +2,7 @@ metricsGeneration:
   # -- Toggle generation of spanmetrics and servicegraph metrics.
   enabled: true
   # -- Use legacy metric names that match those used by the Tempo metrics generator.
-  legacy: true
+  legacy: false
   # -- Additional dimensions to add to generated metrics.
   dimensions:
     - service.namespace
@@ -28,8 +28,7 @@ sampling:
     # -- Percentage of successful requests to sample.
     percentage: 10
   failedRequests:
-    # -- Toggle sampling failed requests.
-    sample: false
+    # -- Toggle sampling failed requests. sample: false
     # -- Percentage of failed requests to sample.
     percentage: 50
   # -- User-defined policies in alloy format.
@@ -75,6 +74,34 @@ deployment:
       grpc:
         # -- gRPC max message receive size. Default to 4MB
         max_recv_msg_size: 4MB
+        keepalive:
+          serverParameters:
+            # -- Maximum age for non-idle connections. Default is infinity.
+            # @section -- Receivers: OTLP
+            maxConnectionAge: ""
+            # -- Time to wait before forcibly closing connections. Default is infinity.
+            # @section -- Receivers: OTLP
+            maxConnectionAgeGrace: ""
+            # -- Maximum age for idle connections. Default is infinity.
+            # @section -- Receivers: OTLP
+            maxConnectionIdle: ""
+            # -- How often to ping inactive clients to check for liveness. Default is 2 hours.
+            # @section -- Receivers: OTLP
+            time: ""
+            # -- Time to wait before closing inactive clients that don’t respond to liveness checks.
+            # Default is 20 seconds.
+            # @section -- Receivers: OTLP
+            timeout: ""
+
+          enforcementPolicy:
+            # -- Minimum time clients should wait before sending a keepalive ping. Default is 5 minutes.
+            # @section -- Receivers: OTLP
+            minTime: ""
+
+            # -- Allow clients to send keepalive pings when there are no active streams.
+            # @section -- Receivers: OTLP
+            permitWithoutStream: false
+
 
 statefulset:
   otlp:
@@ -83,6 +110,33 @@ statefulset:
       grpc:
         # -- gRPC max message receive size. Default to 4MB
         max_recv_msg_size: 4MB
+        keepalive:
+          serverParameters:
+            # -- Maximum age for non-idle connections. Default is infinity.
+            # @section -- Receivers: OTLP
+            maxConnectionAge: ""
+            # -- Time to wait before forcibly closing connections. Default is infinity.
+            # @section -- Receivers: OTLP
+            maxConnectionAgeGrace: ""
+            # -- Maximum age for idle connections. Default is infinity.
+            # @section -- Receivers: OTLP
+            maxConnectionIdle: ""
+            # -- How often to ping inactive clients to check for liveness. Default is 2 hours.
+            # @section -- Receivers: OTLP
+            time: ""
+            # -- Time to wait before closing inactive clients that don’t respond to liveness checks.
+            # Default is 20 seconds.
+            # @section -- Receivers: OTLP
+            timeout: ""
+
+          enforcementPolicy:
+            # -- Minimum time clients should wait before sending a keepalive ping. Default is 5 minutes.
+            # @section -- Receivers: OTLP
+            minTime: ""
+
+            # -- Allow clients to send keepalive pings when there are no active streams.
+            # @section -- Receivers: OTLP
+            permitWithoutStream: false
 
 # @ignored Ignore alloy deployment
 alloy-deployment:

--- a/charts/grafana-sampling/values.yaml
+++ b/charts/grafana-sampling/values.yaml
@@ -2,7 +2,7 @@ metricsGeneration:
   # -- Toggle generation of spanmetrics and servicegraph metrics.
   enabled: true
   # -- Use legacy metric names that match those used by the Tempo metrics generator.
-  legacy: false
+  legacy: true
   # -- Additional dimensions to add to generated metrics.
   dimensions:
     - service.namespace

--- a/charts/grafana-sampling/values.yaml
+++ b/charts/grafana-sampling/values.yaml
@@ -28,7 +28,8 @@ sampling:
     # -- Percentage of successful requests to sample.
     percentage: 10
   failedRequests:
-    # -- Toggle sampling failed requests. sample: false
+    # -- Toggle sampling failed requests.
+    sample: false
     # -- Percentage of failed requests to sample.
     percentage: 50
   # -- User-defined policies in alloy format.


### PR DESCRIPTION
This adds the ability to set grpc server keepalive parameters to otlp receivers used in the sampling chart.