### PR TITLE
[cloudcost-exporter] Upgrade cloudcost-exporter to v0.11.1

### DIFF
--- a/charts/cloudcost-exporter/Chart.yaml
+++ b/charts/cloudcost-exporter/Chart.yaml
@@ -5,10 +5,10 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.5
+version: 1.0.6
 
 # This is the version of cloudcost-exporter to be deployed, which should be incremented
 # with each release.
-appVersion: "0.9.0"
+appVersion: "0.11.1"
 
 home: https://github.com/grafana/cloudcost-exporter

--- a/charts/cloudcost-exporter/README.md
+++ b/charts/cloudcost-exporter/README.md
@@ -2,7 +2,7 @@
 
 Cloud Cost Exporter exports cloud provider agnostic cost metrics to Prometheus.
 
-![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
+![Version: 1.0.6](https://img.shields.io/badge/Version-1.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.1](https://img.shields.io/badge/AppVersion-0.11.1-informational?style=flat-square)
 
 ## Installing the Chart
 


### PR DESCRIPTION
Skipping `v0.10.0` because it contains virtually no changes - there was a bug in the release process that needed to be tested/fixed (caused by breaking changes upstream): https://github.com/grafana/cloudcost-exporter/releases/tag/v0.10.0

`v0.11.1` is the next version with feature additions: https://github.com/grafana/cloudcost-exporter/releases