### PR TITLE
feat[pdc-agent]: support for readOnlyRootFilesystem

### DIFF
--- a/charts/pdc-agent/README.md
+++ b/charts/pdc-agent/README.md
@@ -38,6 +38,7 @@ PDC agent is an agent for connecting to Grafana Private Data source Connect
 | securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | securityContext.privileged | bool | `false` |  |
+| securityContext.readOnlyRootFilesystem | bool | `false` |  |
 | securityContext.runAsNonRoot | bool | `true` |  |
 | tokenSecretName | string | `""` | secretName Expects a secret with key `token` which contains the Access Policy token you generated |
 | tolerations | list | `[]` | not required, but left in as a choice |

--- a/charts/pdc-agent/templates/deployment.yaml
+++ b/charts/pdc-agent/templates/deployment.yaml
@@ -75,6 +75,17 @@ spec:
             {{- range .Values.extraArgs }}
             - {{ . }}
             {{- end }}
+          {{- if .Values.securityContext.readOnlyRootFilesystem }}
+          volumeMounts:
+            - mountPath: /home/pdc/
+              name: ssh-cache
+          {{- end }}
+      {{- if .Values.securityContext.readOnlyRootFilesystem }}
+      volumes:
+        - name: ssh-cache
+          emptyDir:
+            sizeLimit: 50Mi
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/pdc-agent/values.yaml
+++ b/charts/pdc-agent/values.yaml
@@ -35,6 +35,7 @@ securityContext:
   runAsNonRoot: true
   privileged: false
   allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
 
 resources:
   requests:


### PR DESCRIPTION
Allows to run on a read only root filesystem.

Disabled by default to be backwards compatible