### PR TITLE
[tempo-distributed] replace kubectl default image with alpine/kubectl

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.46.4
+version: 1.46.5
 appVersion: 2.8.2
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -641,8 +641,8 @@ The memcached default args are removed and should be provided manually. The sett
 | ingress.paths.ingester[1].path | string | `"/shutdown"` |  |
 | ingress.paths.query-frontend[0].path | string | `"/api"` |  |
 | kubectlImage.pullPolicy | string | `"IfNotPresent"` |  |
-| kubectlImage.repository | string | `"registry.k8s.io/kubectl"` |  |
-| kubectlImage.tag | string | `"v1.33.3"` |  |
+| kubectlImage.repository | string | `"alpine/kubectl"` |  |
+| kubectlImage.tag | string | `"latest"` |  |
 | license.contents | string | `"NOTAVALIDLICENSE"` |  |
 | license.external | bool | `false` |  |
 | license.secretName | string | `"{{ include \"tempo.resourceName\" (dict \"ctx\" . \"component\" \"license\") }}"` |  |

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.46.4](https://img.shields.io/badge/Version-1.46.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
+![Version: 1.46.5](https://img.shields.io/badge/Version-1.46.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/provisioner/provisioner-job.yaml
+++ b/charts/tempo-distributed/templates/provisioner/provisioner-job.yaml
@@ -84,7 +84,7 @@ spec:
           image: {{ .Values.kubectlImage.repository }}:{{ .Values.kubectlImage.tag }}
           imagePullPolicy: {{ .Values.kubectlImage.pullPolicy | default "IfNotPresent" }}
           command:
-            - /bin/bash
+            - /bin/sh
             - -exuc
             - |
               # In this case, the admin resources have already been created, the provisioner job

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -2372,8 +2372,8 @@ provisioner:
 
 
 kubectlImage:
-  repository: registry.k8s.io/kubectl
-  tag: v1.33.3
+  repository: alpine/kubectl
+  tag: latest
   pullPolicy: IfNotPresent
 
 # Settings for the admin_api service providing authentication and authorization service.


### PR DESCRIPTION
The current image does not provide a suitable shell. Therefore, switching to the same image as the [mimir](https://github.com/grafana/mimir/pull/12498) 