### PR TITLE
[rollout-operator] - Enable webhooks in rollout-operator helm chart

### DIFF
--- a/charts/grafana-mcp/Chart.yaml
+++ b/charts/grafana-mcp/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana-mcp
-version: 0.1.1
+version: 0.1.2
 appVersion: latest
 kubeVersion: "^1.8.0-0"
 description: MCP server for Grafana.

--- a/charts/grafana-mcp/README.md
+++ b/charts/grafana-mcp/README.md
@@ -108,7 +108,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":false,"enabled":true,"labels":{},"name":""}` | Service account Configuration |
 | serviceAccount.annotations | object | `{}` | Annotations for the service account |
 | serviceAccount.automountServiceAccountToken | bool | `false` | Automount service account token |
-| serviceAccount.enabled | bool | `true` | Enable service account |
+| serviceAccount.create | bool | `true` | Enable service account |
 | serviceAccount.labels | object | `{}` | Labels for the service account |
 | serviceAccount.name | string | `""` | Name of the service account |
 | startupProbe | object | `{}` | MCP server Startup probe configuration |

--- a/charts/grafana-mcp/README.md
+++ b/charts/grafana-mcp/README.md
@@ -105,7 +105,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | service.sessionAffinity | string | `""` | Session affinity |
 | service.sessionAffinityConfig | object | `{}` | Session affinity config |
 | service.type | string | `"ClusterIP"` | Service type |
-| serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":false,"enabled":true,"labels":{},"name":""}` | Service account Configuration |
+| serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":false,"create":true,"labels":{},"name":""}` | Service account Configuration |
 | serviceAccount.annotations | object | `{}` | Annotations for the service account |
 | serviceAccount.automountServiceAccountToken | bool | `false` | Automount service account token |
 | serviceAccount.create | bool | `true` | Enable service account |

--- a/charts/grafana-mcp/templates/serviceaccount.yaml
+++ b/charts/grafana-mcp/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.enabled }}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}

--- a/charts/grafana-mcp/templates/serviceaccount.yaml
+++ b/charts/grafana-mcp/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.serviceAccount.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}

--- a/charts/grafana-mcp/values.yaml
+++ b/charts/grafana-mcp/values.yaml
@@ -66,7 +66,7 @@ startupProbe: {}
 # -- Service account Configuration
 serviceAccount:
   # -- Enable service account
-  enabled: true
+  create: true
   # -- Name of the service account
   name: ""
   # -- Annotations for the service account

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 9.3.4
-appVersion: 12.1.0
+version: 9.3.5
+appVersion: 12.0.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.com

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 9.3.5
-appVersion: 12.0.1
+version: 9.3.6
+appVersion: 12.1.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.com

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -175,6 +175,8 @@ need to instead set `global.imageRegistry`.
 | `sidecar.securityContext`                 | Sidecar securityContext                       | `{}`                                                    |
 | `sidecar.enableUniqueFilenames`           | Sets the kiwigrid/k8s-sidecar UNIQUE_FILENAMES environment variable. If set to `true` the sidecar will create unique filenames where duplicate data keys exist between ConfigMaps and/or Secrets within the same or multiple Namespaces. | `false`                           |
 | `sidecar.alerts.enabled`             | Enables the cluster wide search for alerts and adds/updates/deletes them in grafana |`false`       |
+| `sidecar.alerts.env`                 | Extra environment variables passed to pods    | `{}`                                                    |
+| `sidecar.alerts.envValueFrom`        | Environment variables from alternate sources. See the API docs on [EnvVarSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvarsource-v1-core) for format details. Can be templated | `{}` |
 | `sidecar.alerts.label`               | Label that config maps with alerts should have to be added (can be templated) | `grafana_alert`                               |
 | `sidecar.alerts.labelValue`          | Label value that config maps with alerts should have to be added (can be templated) | `""`                                |
 | `sidecar.alerts.searchNamespace`     | Namespaces list. If specified, the sidecar will search for alerts config-maps  inside these namespaces. Otherwise the namespace in which the sidecar is running will be used. It's also possible to specify ALL to search in all namespaces. | `nil`                               |
@@ -185,6 +187,8 @@ need to instead set `global.imageRegistry`.
 | `sidecar.alerts.initAlerts`          | Set to true to deploy the alerts sidecar as an initContainer. This is needed if skipReload is true, to load any alerts defined at startup time. | `false` |
 | `sidecar.alerts.extraMounts`         | Additional alerts sidecar volume mounts. | `[]`                               |
 | `sidecar.dashboards.enabled`              | Enables the cluster wide search for dashboards and adds/updates/deletes them in grafana | `false`       |
+| `sidecar.dashboards.env`                  | Extra environment variables passed to pods    | `{}`                                                    |
+| `sidecar.dashboards.envValueFrom`         | Environment variables from alternate sources. See the API docs on [EnvVarSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvarsource-v1-core) for format details. Can be templated | `{}` |
 | `sidecar.dashboards.SCProvider`           | Enables creation of sidecar provider          | `true`                                                  |
 | `sidecar.dashboards.provider.name`        | Unique name of the grafana provider           | `sidecarProvider`                                       |
 | `sidecar.dashboards.provider.orgid`       | Id of the organisation, to which the dashboards should be added | `1`                                   |

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -151,7 +151,7 @@ initContainers:
       {{- end }}
       {{- with .Values.sidecar.alerts.searchNamespace }}
       - name: NAMESPACE
-        value: {{ . | join "," | quote }}
+        value: "{{ tpl (. | join ",") $root }}"
       {{- end }}
       {{- with .Values.sidecar.alerts.skipTlsVerify }}
       - name: SKIP_TLS_VERIFY
@@ -352,6 +352,11 @@ containers:
       - name: "{{ $key }}"
         value: "{{ $value }}"
       {{- end }}
+      {{- range $key, $value := .Values.sidecar.alerts.envValueFrom }}
+      - name: {{ $key | quote }}
+        valueFrom:
+          {{- tpl (toYaml $value) $ | nindent 10 }}
+      {{- end }}
       {{- if .Values.sidecar.alerts.ignoreAlreadyProcessed }}
       - name: IGNORE_ALREADY_PROCESSED
         value: "true"
@@ -382,7 +387,7 @@ containers:
       {{- end }}
       {{- with .Values.sidecar.alerts.searchNamespace }}
       - name: NAMESPACE
-        value: {{ . | join "," | quote }}
+        value: "{{ tpl (. | join ",") $root }}"
       {{- end }}
       {{- with .Values.sidecar.alerts.skipTlsVerify }}
       - name: SKIP_TLS_VERIFY

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -151,7 +151,7 @@ initContainers:
       {{- end }}
       {{- with .Values.sidecar.alerts.searchNamespace }}
       - name: NAMESPACE
-        value: "{{ tpl (. | join ",") $root | quote }}"
+        value: "{{ tpl (. | join ",") $root }}"
       {{- end }}
       {{- with .Values.sidecar.alerts.skipTlsVerify }}
       - name: SKIP_TLS_VERIFY
@@ -387,7 +387,7 @@ containers:
       {{- end }}
       {{- with .Values.sidecar.alerts.searchNamespace }}
       - name: NAMESPACE
-        value: "{{ tpl (. | join ",") $root | quote }}"
+        value: "{{ tpl (. | join ",") $root }}"
       {{- end }}
       {{- with .Values.sidecar.alerts.skipTlsVerify }}
       - name: SKIP_TLS_VERIFY

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -151,7 +151,7 @@ initContainers:
       {{- end }}
       {{- with .Values.sidecar.alerts.searchNamespace }}
       - name: NAMESPACE
-        value: "{{ tpl (. | join ",") $root }}"
+        value: "{{ tpl (. | join ",") $root | quote }}"
       {{- end }}
       {{- with .Values.sidecar.alerts.skipTlsVerify }}
       - name: SKIP_TLS_VERIFY
@@ -387,7 +387,7 @@ containers:
       {{- end }}
       {{- with .Values.sidecar.alerts.searchNamespace }}
       - name: NAMESPACE
-        value: "{{ tpl (. | join ",") $root }}"
+        value: "{{ tpl (. | join ",") $root | quote }}"
       {{- end }}
       {{- with .Values.sidecar.alerts.skipTlsVerify }}
       - name: SKIP_TLS_VERIFY

--- a/charts/rollout-operator/Chart.yaml
+++ b/charts/rollout-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-operator
 description: "Grafana rollout-operator"
 type: application
-version: 0.32.0
+version: 0.33.0
 appVersion: v0.29.0
 home: https://github.com/grafana/rollout-operator
 kubeVersion: ^1.10.0-0

--- a/charts/rollout-operator/Chart.yaml
+++ b/charts/rollout-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-operator
 description: "Grafana rollout-operator"
 type: application
-version: 0.31.0
-appVersion: v0.28.0
+version: 0.32.0
+appVersion: v0.29.0
 home: https://github.com/grafana/rollout-operator
 kubeVersion: ^1.10.0-0

--- a/charts/rollout-operator/README.md
+++ b/charts/rollout-operator/README.md
@@ -35,6 +35,14 @@ helm install  -n <namespace> <release> grafana/rollout-operator
 The Grafana rollout-operator should be installed in the same namespace as the statefulsets it is operating upon.
 It is not a highly available application and runs as a single pod.
 
+### Upgrade of Grafana Rollout Operator
+
+Starting with v0.33.0 of the rollout-operator chart, the rollout-operator webhooks are enabled. See https://github.com/grafana/rollout-operator/#webhooks.
+
+Before upgrading to this version, make sure that the CustomResourceDefinitions (CRDs) in the rollout-operator/crds directory are applied to your cluster.
+
+Manually applying these CRDs is only required if upgrading from a chart <= v0.32.0.
+
 ## Values
 
 | Key | Type | Default | Description |
@@ -72,6 +80,6 @@ It is not a highly available application and runs as a single pod.
 | serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig |
 | serviceMonitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | tolerations | list | `[]` |  |
-| webhooks.enabled | bool | `false` | Enable the rollout-operator webhooks. See https://github.com/grafana/rollout-operator/#webhooks. Note that the webhooks require custom resource definitions. If upgrading, manually apply the files in the charts/rollout-operator/crds/ directory. |
+| webhooks.enabled | bool | `true` | Enable the rollout-operator webhooks. See https://github.com/grafana/rollout-operator/#webhooks. Note that the webhooks require custom resource definitions. If upgrading, manually apply the files in the charts/rollout-operator/crds/ directory. |
 | webhooks.failurePolicy | string | `"Fail"` | Validating and mutating webhook failure policy. `Ignore` or `Fail`. |
 | webhooks.selfSignedCertSecretName | string | `"certificate"` | Secret resource name for the TLS certificate to be used with the webhooks |

--- a/charts/rollout-operator/README.md
+++ b/charts/rollout-operator/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana rollout-operator](https://github.com/grafana/r
 
 # rollout-operator
 
-![Version: 0.32.0](https://img.shields.io/badge/Version-0.32.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.0](https://img.shields.io/badge/AppVersion-v0.29.0-informational?style=flat-square)
+![Version: 0.33.0](https://img.shields.io/badge/Version-0.33.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.0](https://img.shields.io/badge/AppVersion-v0.29.0-informational?style=flat-square)
 
 Grafana rollout-operator
 

--- a/charts/rollout-operator/README.md
+++ b/charts/rollout-operator/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana rollout-operator](https://github.com/grafana/r
 
 # rollout-operator
 
-![Version: 0.31.0](https://img.shields.io/badge/Version-0.31.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.28.0](https://img.shields.io/badge/AppVersion-v0.28.0-informational?style=flat-square)
+![Version: 0.32.0](https://img.shields.io/badge/Version-0.32.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.0](https://img.shields.io/badge/AppVersion-v0.29.0-informational?style=flat-square)
 
 Grafana rollout-operator
 

--- a/charts/rollout-operator/README.md
+++ b/charts/rollout-operator/README.md
@@ -72,3 +72,6 @@ It is not a highly available application and runs as a single pod.
 | serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig |
 | serviceMonitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | tolerations | list | `[]` |  |
+| webhooks.enabled | bool | `false` | Enable the rollout-operator webhooks. See https://github.com/grafana/rollout-operator/#webhooks. Note that the webhooks require custom resource definitions. If upgrading, manually apply the files in the charts/rollout-operator/crds/ directory. |
+| webhooks.failurePolicy | string | `"Fail"` | Validating and mutating webhook failure policy. `Ignore` or `Fail`. |
+| webhooks.selfSignedCertSecretName | string | `"certificate"` | Secret resource name for the TLS certificate to be used with the webhooks |

--- a/charts/rollout-operator/README.md.gotmpl
+++ b/charts/rollout-operator/README.md.gotmpl
@@ -35,4 +35,12 @@ helm install  -n <namespace> <release> grafana/rollout-operator
 The Grafana rollout-operator should be installed in the same namespace as the statefulsets it is operating upon.
 It is not a highly available application and runs as a single pod.
 
+### Upgrade of Grafana Rollout Operator
+
+Starting with v0.33.0 of the rollout-operator chart, the rollout-operator webhooks are enabled. See https://github.com/grafana/rollout-operator/#webhooks.
+
+Before upgrading to this version, make sure that the CustomResourceDefinitions (CRDs) in the rollout-operator/crds directory are applied to your cluster.
+
+Manually applying these CRDs is only required if upgrading from a chart <= v0.32.0.
+
 {{ template "chart.valuesSection" . }}

--- a/charts/rollout-operator/crds/replica-templates-custom-resource-definition.yaml
+++ b/charts/rollout-operator/crds/replica-templates-custom-resource-definition.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: replicatemplates.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - description: Status replicas
+          jsonPath: .status.replicas
+          name: StatusReplicas
+          type: string
+        - description: Spec replicas
+          jsonPath: .spec.replicas
+          name: SpecReplicas
+          type: string
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                replicas:
+                  type: integer
+                  default: 1
+                  minimum: 0
+                labelSelector:
+                  type: string
+            status:
+              type: object
+              properties:
+                replicas:
+                  type: integer
+      subresources:
+        status: { }
+        scale:
+          specReplicasPath: .spec.replicas
+          statusReplicasPath: .status.replicas
+          labelSelectorPath: .spec.labelSelector
+  scope: Namespaced
+  names:
+    plural: replicatemplates
+    singular: replicatemplate
+    kind: ReplicaTemplate
+    categories:
+      # Include in "kubectl get all" output
+      - all

--- a/charts/rollout-operator/crds/zone-aware-pod-disruption-budget-custom-resource-definition.yaml
+++ b/charts/rollout-operator/crds/zone-aware-pod-disruption-budget-custom-resource-definition.yaml
@@ -1,0 +1,54 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: zoneawarepoddisruptionbudgets.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - selector
+              properties:
+                maxUnavailable:
+                  type: integer
+                  description: The number of pods that can be unavailable within a zone or partition.
+                  minimum: 0
+                maxUnavailablePercentage:
+                  type: integer
+                  description: Calculate the maxUnavailable value as a percentage of the StatefulSet's spec.Replica count. This option is not supported when using podNamePartitionRegex.
+                  minimum: 0
+                  maximum: 100
+                selector:
+                  type: object
+                  description: A selector for finding pods and statefulsets that this ZoneAwarePodDisruptionBudget applies to.
+                  required:
+                    - matchLabels
+                  properties:
+                    matchLabels:
+                      type: object
+                      additionalProperties:
+                        type: string
+                podNamePartitionRegex:
+                  type: string
+                  description: A regular expression for returning a partition name given a pod name. This field is optional and should only be used when the ZoneAwarePodDisruptionBudget is to be scoped to a partition, such as a multi-zone ingester deployment with ingest_storage_enabled. Enabling this changes the ZPDB functionality such that minAvailability is applied across ALL zones for a given partition. When not enabled, the minAvailability is applied to pods within the eviction zone assuming there are no disruptions in the other zones.
+                podNameRegexGroup:
+                  type: integer
+                  minimum: 1
+                  description: The regular expression group number that contains the partition name. This field is only required when the podNamePartitionRegex field is set and has more then one subexpression grouping. The default value is 1.
+      subresources:
+        status: {}
+  scope: Namespaced
+  names:
+    kind: ZoneAwarePodDisruptionBudget
+    plural: zoneawarepoddisruptionbudgets
+    singular: zoneawarepoddisruptionbudget
+    shortNames:
+      - zdpb

--- a/charts/rollout-operator/templates/deployment.yaml
+++ b/charts/rollout-operator/templates/deployment.yaml
@@ -51,6 +51,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - -kubernetes.namespace={{ .Release.Namespace }}
+          {{- if .Values.webhooks.enabled }}
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name={{ .Values.webhooks.selfSignedCertSecretName }}
+          {{- end }}
           {{- range .Values.extraArgs  }}
           - {{ . }}
           {{- end }}

--- a/charts/rollout-operator/templates/no-downscale-webhook.yaml
+++ b/charts/rollout-operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.webhooks.enabled -}}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-{{ .Release.Namespace }}
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: {{ .Release.Namespace | quote }}
+    {{- include "rollout-operator.labels" . | nindent 4 }}
+webhooks:
+  - name: no-downscale-{{ .Release.Namespace }}.grafana.com
+    clientConfig:
+      service:
+        namespace: {{ .Release.Namespace | quote }}
+        name: {{ include "rollout-operator.fullname" . }}
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
+    sideEffects: None
+    failurePolicy: {{.Values.webhooks.failurePolicy}}
+{{- end -}}

--- a/charts/rollout-operator/templates/pod-eviction-webhook.yaml
+++ b/charts/rollout-operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.webhooks.enabled -}}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-{{ .Release.Namespace }}
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: {{ .Release.Namespace | quote }}
+    {{- include "rollout-operator.labels" . | nindent 4 }}
+webhooks:
+  - name: pod-eviction-{{ .Release.Namespace }}.grafana.com
+    clientConfig:
+      service:
+        namespace: {{ .Release.Namespace | quote }}
+        name: {{ include "rollout-operator.fullname" . }}
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
+    sideEffects: None
+    failurePolicy: {{.Values.webhooks.failurePolicy}}
+{{- end -}}

--- a/charts/rollout-operator/templates/prepare-downscale-webhook.yaml
+++ b/charts/rollout-operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.webhooks.enabled -}}
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-{{ .Release.Namespace }}
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: {{ .Release.Namespace | quote }}
+    {{- include "rollout-operator.labels" . | nindent 4 }}
+webhooks:
+  - name: prepare-downscale-{{ .Release.Namespace }}.grafana.com
+    clientConfig:
+      service:
+        namespace: {{ .Release.Namespace | quote }}
+        name: {{ include "rollout-operator.fullname" . }}
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: {{.Values.webhooks.failurePolicy}}
+{{- end -}}

--- a/charts/rollout-operator/templates/role.yaml
+++ b/charts/rollout-operator/templates/role.yaml
@@ -30,3 +30,11 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch

--- a/charts/rollout-operator/templates/service.yaml
+++ b/charts/rollout-operator/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceMonitor.enabled }}
+{{- if or (eq .Values.serviceMonitor.enabled  true) (eq .Values.webhooks.enabled true) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,12 +8,22 @@ metadata:
     {{- include "rollout-operator.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
+  {{- if eq .Values.webhooks.enabled false }}
   clusterIP: None
+  {{- end }}
   ports:
+    {{- if .Values.serviceMonitor.enabled }}
     - port: 8001
       targetPort: http-metrics
       protocol: TCP
       name: http-metrics
+    {{- end }}
+    {{- if .Values.webhooks.enabled }}
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+    {{- end }}
   selector:
     {{- include "rollout-operator.selectorLabels" . | nindent 4 }}
 {{- end -}}

--- a/charts/rollout-operator/templates/webhook-clusterrole-binding.yaml
+++ b/charts/rollout-operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.webhooks.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "rollout-operator.fullname" . }}-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "rollout-operator.fullname" . }}-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "rollout-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
+{{- end -}}

--- a/charts/rollout-operator/templates/webhook-clusterrole.yaml
+++ b/charts/rollout-operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.webhooks.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "rollout-operator.fullname" . }}-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch
+{{- end -}}

--- a/charts/rollout-operator/templates/webhook-role-binding.yaml
+++ b/charts/rollout-operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.webhooks.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "rollout-operator.fullname" . }}-webhook-rolebinding
+  namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "rollout-operator.fullname" . }}-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "rollout-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
+{{- end -}}

--- a/charts/rollout-operator/templates/webhook-role.yaml
+++ b/charts/rollout-operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.webhooks.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "rollout-operator.fullname" . }}-webhook-role
+  namespace: {{ .Release.Namespace | quote }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - {{ .Values.webhooks.selfSignedCertSecretName }}
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+{{- end -}}

--- a/charts/rollout-operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/charts/rollout-operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.webhooks.enabled -}}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-{{ .Release.Namespace }}
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: {{ .Release.Namespace | quote }}
+    {{- include "rollout-operator.labels" . | nindent 4 }}
+webhooks:
+  - name: zpdb-validation-{{ .Release.Namespace }}.grafana.com
+    clientConfig:
+      service:
+        namespace: {{ .Release.Namespace | quote }}
+        name: {{ include "rollout-operator.fullname" . }}
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
+    sideEffects: None
+    failurePolicy: {{.Values.webhooks.failurePolicy}}
+{{- end -}}

--- a/charts/rollout-operator/values.yaml
+++ b/charts/rollout-operator/values.yaml
@@ -96,7 +96,7 @@ serviceMonitor:
 webhooks:
   # -- Enable the rollout-operator webhooks. See https://github.com/grafana/rollout-operator/#webhooks.
   # Note that the webhooks require custom resource definitions. If upgrading, manually apply the files in the charts/rollout-operator/crds/ directory.
-  enabled: false
+  enabled: true
   # -- Validating and mutating webhook failure policy. `Ignore` or `Fail`.
   failurePolicy: "Fail"
   # -- Secret resource name for the TLS certificate to be used with the webhooks

--- a/charts/rollout-operator/values.yaml
+++ b/charts/rollout-operator/values.yaml
@@ -92,3 +92,12 @@ serviceMonitor:
   # -- ServiceMonitor relabel configs to apply to samples before scraping
   # https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
   relabelings: []
+
+webhooks:
+  # -- Enable the rollout-operator webhooks. See https://github.com/grafana/rollout-operator/#webhooks.
+  # Note that the webhooks require custom resource definitions. If upgrading, manually apply the files in the charts/rollout-operator/crds/ directory.
+  enabled: false
+  # -- Validating and mutating webhook failure policy. `Ignore` or `Fail`.
+  failurePolicy: "Fail"
+  # -- Secret resource name for the TLS certificate to be used with the webhooks
+  selfSignedCertSecretName: "certificate"

--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.46.5
+version: 1.47.1
 appVersion: 2.8.2
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.47.1
+version: 1.47.0
 appVersion: 2.8.2
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.46.4
+version: 1.46.5
 appVersion: 2.8.2
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.46.5](https://img.shields.io/badge/Version-1.46.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
+![Version: 1.47.0](https://img.shields.io/badge/Version-1.47.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.1](https://img.shields.io/badge/AppVersion-2.8.1-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -641,8 +641,8 @@ The memcached default args are removed and should be provided manually. The sett
 | ingress.paths.ingester[1].path | string | `"/shutdown"` |  |
 | ingress.paths.query-frontend[0].path | string | `"/api"` |  |
 | kubectlImage.pullPolicy | string | `"IfNotPresent"` |  |
-| kubectlImage.repository | string | `"registry.k8s.io/kubectl"` |  |
-| kubectlImage.tag | string | `"v1.33.3"` |  |
+| kubectlImage.repository | string | `"alpine/kubectl"` |  |
+| kubectlImage.tag | string | `"latest"` |  |
 | license.contents | string | `"NOTAVALIDLICENSE"` |  |
 | license.external | bool | `false` |  |
 | license.secretName | string | `"{{ include \"tempo.resourceName\" (dict \"ctx\" . \"component\" \"license\") }}"` |  |

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -555,7 +555,9 @@ The memcached default args are removed and should be provided manually. The sett
 | global.clusterDomain | string | `"cluster.local"` | configures cluster domain ("cluster.local" by default) |
 | global.dnsNamespace | string | `"kube-system"` | configures DNS service namespace |
 | global.dnsService | string | `"kube-dns"` | configures DNS service name |
+| global.extraArgs | list | `[]` | Common args to add to all pods directly managed by this chart. scope: admin-api, compactor, distributor, enterprise-federation-frontend, gateway, ingester, memcached, metrics-generator, querier, query-frontend, tokengen |
 | global.extraEnv | list | `[]` | Common environment variables to add to all pods directly managed by this chart. scope: admin-api, compactor, distributor, enterprise-federation-frontend, gateway, ingester, memcached, metrics-generator, querier, query-frontend, tokengen |
+| global.extraEnvFrom | list | `[]` | Common environment variables which come from a ConfigMap or Secret to add to all pods directly managed by this chart. scope: admin-api, compactor, distributor, enterprise-federation-frontend, gateway, ingester, memcached, metrics-generator, querier, query-frontend, tokengen |
 | global.image.pullSecrets | list | `[]` | Optional list of imagePullSecrets for all images, excluding enterprise. Names of existing secrets with private container registry credentials. Ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod Example: pullSecrets: [ my-dockerconfigjson-secret ] |
 | global.image.registry | string | `"docker.io"` | Overrides the Docker registry globally for all images, excluding enterprise. |
 | global.priorityClassName | string | `nil` | Overrides the priorityClassName for all pods |

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.47.0](https://img.shields.io/badge/Version-1.47.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.1](https://img.shields.io/badge/AppVersion-2.8.1-informational?style=flat-square)
+![Version: 1.47.1](https://img.shields.io/badge/Version-1.47.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.46.4](https://img.shields.io/badge/Version-1.46.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
+![Version: 1.46.5](https://img.shields.io/badge/Version-1.46.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.47.1](https://img.shields.io/badge/Version-1.47.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
+![Version: 1.47.0](https://img.shields.io/badge/Version-1.47.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/charts/tempo-distributed/templates/admin-api/admin-api-dep.yaml
@@ -53,6 +53,9 @@ spec:
             {{- range $key, $value := .Values.adminApi.extraArgs }}
             - "-{{ $key }}={{ $value }}"
             {{- end }}
+            {{- range $key, $value := .Values.global.extraArgs }}
+            - "-{{ $key }}={{ $value }}"
+            {{- end }}
           volumeMounts:
             - mountPath: /conf
               name: config

--- a/charts/tempo-distributed/templates/compactor/deployment-compactor.yaml
+++ b/charts/tempo-distributed/templates/compactor/deployment-compactor.yaml
@@ -66,6 +66,9 @@ spec:
             {{- with .Values.compactor.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- with .Values.global.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           image: {{ include "tempo.imageReference" $dict }}
           imagePullPolicy: {{ .Values.tempo.image.pullPolicy }}
           name: compactor
@@ -83,9 +86,14 @@ spec:
               {{ toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-          {{- with .Values.compactor.extraEnvFrom }}
+          {{- if or .Values.global.extraEnvFrom .Values.compactor.extraEnvFrom }}
           envFrom:
-            {{- toYaml . | nindent 12 }}
+            {{- with .Values.compactor.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           resources:
             {{- toYaml .Values.compactor.resources | nindent 12 }}

--- a/charts/tempo-distributed/templates/distributor/deployment-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/deployment-distributor.yaml
@@ -22,7 +22,7 @@ spec:
 {{- with .Values.distributor.strategy }}
   strategy:
 {{- toYaml . | nindent 4 }}
-{{- end }}      
+{{- end }}
   template:
     metadata:
       labels:
@@ -66,6 +66,9 @@ spec:
             - -config.file=/conf/tempo.yaml
             - -mem-ballast-size-mbs=1024
             {{- with .Values.distributor.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.global.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           image: {{ include "tempo.imageReference" $dict }}
@@ -126,9 +129,14 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-          {{- with .Values.distributor.extraEnvFrom }}
+          {{- if or .Values.global.extraEnvFrom .Values.distributor.extraEnvFrom }}
           envFrom:
-            {{- toYaml . | nindent 12 }}
+            {{- with .Values.distributor.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           readinessProbe:
             {{- toYaml .Values.tempo.readinessProbe | nindent 12 }}

--- a/charts/tempo-distributed/templates/enterprise-federation-frontend/deployment-federation-frontend.yaml
+++ b/charts/tempo-distributed/templates/enterprise-federation-frontend/deployment-federation-frontend.yaml
@@ -65,6 +65,9 @@ spec:
             {{- with .Values.enterpriseFederationFrontend.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- with .Values.global.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           image: {{ include "tempo.imageReference" $dict }}
           imagePullPolicy: {{ .Values.tempo.image.pullPolicy }}
           name: federation-frontend
@@ -80,9 +83,14 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-          {{- with .Values.enterpriseFederationFrontend.extraEnvFrom }}
+          {{- if or .Values.global.extraEnvFrom .Values.enterpriseFederationFrontend.extraEnvFrom }}
           envFrom:
-            {{- toYaml . | nindent 12 }}
+            {{- with .Values.enterpriseFederationFrontend.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           resources:
             {{- toYaml .Values.enterpriseFederationFrontend.resources | nindent 12 }}

--- a/charts/tempo-distributed/templates/enterprise-gateway/gateway-dep.yaml
+++ b/charts/tempo-distributed/templates/enterprise-gateway/gateway-dep.yaml
@@ -51,6 +51,9 @@ spec:
             {{- range $key, $value := .Values.enterpriseGateway.extraArgs }}
             - "-{{ $key }}={{ $value }}"
             {{- end }}
+            {{- range $key, $value := .Values.global.extraArgs }}
+            - "-{{ $key }}={{ $value }}"
+            {{- end }}
           volumeMounts:
             {{- if .Values.enterpriseGateway.extraVolumeMounts }}
               {{ toYaml .Values.enterpriseGateway.extraVolumeMounts | nindent 12}}

--- a/charts/tempo-distributed/templates/gateway/deployment-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/deployment-gateway.yaml
@@ -76,9 +76,14 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-          {{- with .Values.gateway.extraEnvFrom }}
+          {{- if or .Values.global.extraEnvFrom .Values.gateway.extraEnvFrom }}
           envFrom:
-            {{- toYaml . | nindent 12 }}
+            {{- with .Values.gateway.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           readinessProbe:
             {{- toYaml .Values.gateway.readinessProbe | nindent 12 }}

--- a/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
@@ -79,7 +79,7 @@ spec:
             {{- with .Values.ingester.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{ - with .Values.global.extraArgs }}
+            {{- with .Values.global.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           image: {{ include "tempo.imageReference" $dict }}

--- a/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
@@ -79,6 +79,9 @@ spec:
             {{- with .Values.ingester.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{ - with .Values.global.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           image: {{ include "tempo.imageReference" $dict }}
           imagePullPolicy: {{ .Values.tempo.image.pullPolicy }}
           name: ingester
@@ -98,9 +101,14 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-          {{- with .Values.ingester.extraEnvFrom }}
+          {{- if or .Values.global.extraEnvFrom .Values.ingester.extraEnvFrom }}
           envFrom:
-            {{- toYaml . | nindent 12 }}
+            {{- with .Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.ingester.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           readinessProbe:
             {{- toYaml .Values.tempo.readinessProbe | nindent 12 }}

--- a/charts/tempo-distributed/templates/memcached/statefulset-memcached.yaml
+++ b/charts/tempo-distributed/templates/memcached/statefulset-memcached.yaml
@@ -73,9 +73,14 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-          {{- with .Values.memcached.extraEnvFrom }}
+          {{- if or .Values.global.extraEnvFrom .Values.memcached.extraEnvFrom }}
           envFrom:
-            {{- toYaml . | nindent 12 }}
+            {{- with .Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.memcached.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- with .Values.memcached.readinessProbe }}
           readinessProbe:

--- a/charts/tempo-distributed/templates/metrics-generator/statefulset-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/statefulset-metrics-generator.yaml
@@ -67,6 +67,9 @@ spec:
             {{- with .Values.metricsGenerator.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- with .Values.global.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           image: {{ include "tempo.imageReference" $dict }}
           imagePullPolicy: {{ .Values.tempo.image.pullPolicy }}
           name: metrics-generator
@@ -84,9 +87,14 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-          {{- with .Values.metricsGenerator.extraEnvFrom }}
+          {{- if or .Values.global.extraEnvFrom .Values.metricsGenerator.extraEnvFrom }}
           envFrom:
-            {{- toYaml . | nindent 12 }}
+            {{- with .Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.metricsGenerator.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           readinessProbe:
             {{- toYaml .Values.tempo.readinessProbe | nindent 12 }}

--- a/charts/tempo-distributed/templates/provisioner/provisioner-job.yaml
+++ b/charts/tempo-distributed/templates/provisioner/provisioner-job.yaml
@@ -84,7 +84,7 @@ spec:
           image: {{ .Values.kubectlImage.repository }}:{{ .Values.kubectlImage.tag }}
           imagePullPolicy: {{ .Values.kubectlImage.pullPolicy | default "IfNotPresent" }}
           command:
-            - /bin/bash
+            - /bin/sh
             - -exuc
             - |
               # In this case, the admin resources have already been created, the provisioner job

--- a/charts/tempo-distributed/templates/querier/deployment-querier.yaml
+++ b/charts/tempo-distributed/templates/querier/deployment-querier.yaml
@@ -66,6 +66,9 @@ spec:
             {{- with .Values.querier.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- with .Values.global.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           image: {{ include "tempo.imageReference" $dict }}
           imagePullPolicy: {{ .Values.tempo.image.pullPolicy }}
           name: querier
@@ -84,9 +87,14 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-          {{- with .Values.querier.extraEnvFrom }}
+          {{- if or .Values.global.extraEnvFrom .Values.querier.extraEnvFrom }}
           envFrom:
-            {{- toYaml . | nindent 12 }}
+            {{- with .Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.querier.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           resources:
             {{- toYaml .Values.querier.resources | nindent 12 }}

--- a/charts/tempo-distributed/templates/query-frontend/deployment-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/deployment-query-frontend.yaml
@@ -83,9 +83,14 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-          {{- with .Values.queryFrontend.extraEnvFrom }}
+          {{- if or .Values.global.extraEnvFrom .Values.queryFrontend.extraEnvFrom }}
           envFrom:
-            {{- toYaml . | nindent 12 }}
+            {{- with .Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.queryFrontend.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           resources:
             {{- toYaml .Values.queryFrontend.resources | nindent 12 }}
@@ -111,6 +116,9 @@ spec:
         - args:
             - -config=/conf/tempo.yaml
             {{- with .Values.queryFrontend.query.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.global.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           image: {{ include "tempo.queryImage" . }}

--- a/charts/tempo-distributed/templates/tokengen/tokengen-job.yaml
+++ b/charts/tempo-distributed/templates/tokengen/tokengen-job.yaml
@@ -42,7 +42,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.tokengenJob.storeTokenInSecret }}
-      initContainers: 
+      initContainers:
       {{- if .Values.tokengenJob.initContainers }}
         {{- toYaml .Values.tokengenJob.initContainers | nindent 8 }}
         {{- end }}
@@ -58,6 +58,9 @@ spec:
             - "-config.file=/conf/tempo.yaml"
             - "-tokengen.token-file=/shared/admin-token"
             {{- range $key, $value := .Values.tokengenJob.extraArgs }}
+            - "-{{ $key }}={{ $value }}"
+            {{- end }}
+            {{- range $key, $value := .Values.global.extraArgs }}
             - "-{{ $key }}={{ $value }}"
             {{- end }}
           volumeMounts:

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -2372,8 +2372,8 @@ provisioner:
 
 
 kubectlImage:
-  repository: registry.k8s.io/kubectl
-  tag: v1.33.3
+  repository: alpine/kubectl
+  tag: latest
   pullPolicy: IfNotPresent
 
 # Settings for the admin_api service providing authentication and authorization service.

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -19,6 +19,12 @@ global:
   # -- Common environment variables to add to all pods directly managed by this chart.
   # scope: admin-api, compactor, distributor, enterprise-federation-frontend, gateway, ingester, memcached, metrics-generator, querier, query-frontend, tokengen
   extraEnv: []
+  # -- Common environment variables which come from a ConfigMap or Secret to add to all pods directly managed by this chart.
+  # scope: admin-api, compactor, distributor, enterprise-federation-frontend, gateway, ingester, memcached, metrics-generator, querier, query-frontend, tokengen
+  extraEnvFrom: []
+  # -- Common args to add to all pods directly managed by this chart.
+  # scope: admin-api, compactor, distributor, enterprise-federation-frontend, gateway, ingester, memcached, metrics-generator, querier, query-frontend, tokengen
+  extraArgs: []
   # -- Global storage class to be used for persisted components
   storageClass: null
 fullnameOverride: ''


### PR DESCRIPTION
This PR relates to https://github.com/grafana/mimir-squad/issues/2365

This PR adds support to the helm rollout-operator chart for enabling the rollout-operator webhooks. This includes;

* no-downscale validating webhook configuration
* prepare-downscale mutating webhook configuration
* pod-eviction validating webhook configuration
* zpdb-validation validating webhook configuration
* zpdb custom resource definition
* replica templates custom resource definition

Note - this PR is also related to https://github.com/grafana/mimir-squad/issues/3179 - where by the jsonnet specific to the rollout-operator will be moved from mimir to the rollout-operator repo. 

This is a new version of https://github.com/grafana/helm-charts/pull/3859