### PR TITLE
[rollout-operator] Enable webhooks for rollout-operator

### DIFF
--- a/charts/rollout-operator/Chart.yaml
+++ b/charts/rollout-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-operator
 description: "Grafana rollout-operator"
 type: application
-version: 0.32.0
+version: 0.33.0
 appVersion: v0.29.0
 home: https://github.com/grafana/rollout-operator
 kubeVersion: ^1.10.0-0

--- a/charts/rollout-operator/README.md
+++ b/charts/rollout-operator/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana rollout-operator](https://github.com/grafana/r
 
 # rollout-operator
 
-![Version: 0.32.0](https://img.shields.io/badge/Version-0.32.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.0](https://img.shields.io/badge/AppVersion-v0.29.0-informational?style=flat-square)
+![Version: 0.33.0](https://img.shields.io/badge/Version-0.33.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.0](https://img.shields.io/badge/AppVersion-v0.29.0-informational?style=flat-square)
 
 Grafana rollout-operator
 
@@ -34,6 +34,14 @@ helm install  -n <namespace> <release> grafana/rollout-operator
 
 The Grafana rollout-operator should be installed in the same namespace as the statefulsets it is operating upon.
 It is not a highly available application and runs as a single pod.
+
+### Upgrade of Grafana Rollout Operator
+
+Starting with v0.33.0 of the rollout-operator chart, the rollout-operator webhooks are enabled. See https://github.com/grafana/rollout-operator/#webhooks.
+
+Before upgrading to this version, make sure that the CustomResourceDefinitions (CRDs) in the rollout-operator/crds directory are applied to your cluster.
+
+Manually applying these CRDs is only required if upgrading from a chart <= v0.32.0.
 
 ## Values
 
@@ -72,3 +80,6 @@ It is not a highly available application and runs as a single pod.
 | serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig |
 | serviceMonitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | tolerations | list | `[]` |  |
+| webhooks.enabled | bool | `true` | Enable the rollout-operator webhooks. See https://github.com/grafana/rollout-operator/#webhooks. Note that the webhooks require custom resource definitions. If upgrading, manually apply the files in the charts/rollout-operator/crds/ directory. |
+| webhooks.failurePolicy | string | `"Fail"` | Validating and mutating webhook failure policy. `Ignore` or `Fail`. |
+| webhooks.selfSignedCertSecretName | string | `"certificate"` | Secret resource name for the TLS certificate to be used with the webhooks |

--- a/charts/rollout-operator/README.md
+++ b/charts/rollout-operator/README.md
@@ -39,7 +39,7 @@ It is not a highly available application and runs as a single pod.
 
 Starting with v0.33.0 of the rollout-operator chart, the rollout-operator webhooks are enabled. See https://github.com/grafana/rollout-operator/#webhooks.
 
-Before upgrading to this version, make sure that the CustomResourceDefinitions (CRDs) in the rollout-operator/crds directory are applied to your cluster.
+Before upgrading to this version, make sure that the CustomResourceDefinitions (CRDs) in the `crds` directory are applied to your cluster.
 
 Manually applying these CRDs is only required if upgrading from a chart <= v0.32.0.
 
@@ -80,6 +80,6 @@ Manually applying these CRDs is only required if upgrading from a chart <= v0.32
 | serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig |
 | serviceMonitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | tolerations | list | `[]` |  |
-| webhooks.enabled | bool | `true` | Enable the rollout-operator webhooks. See https://github.com/grafana/rollout-operator/#webhooks. Note that the webhooks require custom resource definitions. If upgrading, manually apply the files in the charts/rollout-operator/crds/ directory. |
+| webhooks.enabled | bool | `true` | Enable the rollout-operator webhooks. See https://github.com/grafana/rollout-operator/#webhooks. Note that the webhooks require custom resource definitions. If upgrading, manually apply the files in the `crds` directory. |
 | webhooks.failurePolicy | string | `"Fail"` | Validating and mutating webhook failure policy. `Ignore` or `Fail`. |
 | webhooks.selfSignedCertSecretName | string | `"certificate"` | Secret resource name for the TLS certificate to be used with the webhooks |

--- a/charts/rollout-operator/README.md.gotmpl
+++ b/charts/rollout-operator/README.md.gotmpl
@@ -39,7 +39,7 @@ It is not a highly available application and runs as a single pod.
 
 Starting with v0.33.0 of the rollout-operator chart, the rollout-operator webhooks are enabled. See https://github.com/grafana/rollout-operator/#webhooks.
 
-Before upgrading to this version, make sure that the CustomResourceDefinitions (CRDs) in the rollout-operator/crds directory are applied to your cluster.
+Before upgrading to this version, make sure that the CustomResourceDefinitions (CRDs) in the `crds` directory are applied to your cluster.
 
 Manually applying these CRDs is only required if upgrading from a chart <= v0.32.0.
 

--- a/charts/rollout-operator/README.md.gotmpl
+++ b/charts/rollout-operator/README.md.gotmpl
@@ -35,4 +35,12 @@ helm install  -n <namespace> <release> grafana/rollout-operator
 The Grafana rollout-operator should be installed in the same namespace as the statefulsets it is operating upon.
 It is not a highly available application and runs as a single pod.
 
+### Upgrade of Grafana Rollout Operator
+
+Starting with v0.33.0 of the rollout-operator chart, the rollout-operator webhooks are enabled. See https://github.com/grafana/rollout-operator/#webhooks.
+
+Before upgrading to this version, make sure that the CustomResourceDefinitions (CRDs) in the rollout-operator/crds directory are applied to your cluster.
+
+Manually applying these CRDs is only required if upgrading from a chart <= v0.32.0.
+
 {{ template "chart.valuesSection" . }}

--- a/charts/rollout-operator/crds/replica-templates-custom-resource-definition.yaml
+++ b/charts/rollout-operator/crds/replica-templates-custom-resource-definition.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: replicatemplates.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - description: Status replicas
+          jsonPath: .status.replicas
+          name: StatusReplicas
+          type: string
+        - description: Spec replicas
+          jsonPath: .spec.replicas
+          name: SpecReplicas
+          type: string
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                replicas:
+                  type: integer
+                  default: 1
+                  minimum: 0
+                labelSelector:
+                  type: string
+            status:
+              type: object
+              properties:
+                replicas:
+                  type: integer
+      subresources:
+        status: { }
+        scale:
+          specReplicasPath: .spec.replicas
+          statusReplicasPath: .status.replicas
+          labelSelectorPath: .spec.labelSelector
+  scope: Namespaced
+  names:
+    plural: replicatemplates
+    singular: replicatemplate
+    kind: ReplicaTemplate
+    categories:
+      # Include in "kubectl get all" output
+      - all

--- a/charts/rollout-operator/crds/zone-aware-pod-disruption-budget-custom-resource-definition.yaml
+++ b/charts/rollout-operator/crds/zone-aware-pod-disruption-budget-custom-resource-definition.yaml
@@ -1,0 +1,54 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: zoneawarepoddisruptionbudgets.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - selector
+              properties:
+                maxUnavailable:
+                  type: integer
+                  description: The number of pods that can be unavailable within a zone or partition.
+                  minimum: 0
+                maxUnavailablePercentage:
+                  type: integer
+                  description: Calculate the maxUnavailable value as a percentage of the StatefulSet's spec.Replica count. This option is not supported when using podNamePartitionRegex.
+                  minimum: 0
+                  maximum: 100
+                selector:
+                  type: object
+                  description: A selector for finding pods and statefulsets that this ZoneAwarePodDisruptionBudget applies to.
+                  required:
+                    - matchLabels
+                  properties:
+                    matchLabels:
+                      type: object
+                      additionalProperties:
+                        type: string
+                podNamePartitionRegex:
+                  type: string
+                  description: A regular expression for returning a partition name given a pod name. This field is optional and should only be used when the ZoneAwarePodDisruptionBudget is to be scoped to a partition, such as a multi-zone ingester deployment with ingest_storage_enabled. Enabling this changes the ZPDB functionality such that minAvailability is applied across ALL zones for a given partition. When not enabled, the minAvailability is applied to pods within the eviction zone assuming there are no disruptions in the other zones.
+                podNameRegexGroup:
+                  type: integer
+                  minimum: 1
+                  description: The regular expression group number that contains the partition name. This field is only required when the podNamePartitionRegex field is set and has more then one subexpression grouping. The default value is 1.
+      subresources:
+        status: {}
+  scope: Namespaced
+  names:
+    kind: ZoneAwarePodDisruptionBudget
+    plural: zoneawarepoddisruptionbudgets
+    singular: zoneawarepoddisruptionbudget
+    shortNames:
+      - zdpb

--- a/charts/rollout-operator/templates/deployment.yaml
+++ b/charts/rollout-operator/templates/deployment.yaml
@@ -62,6 +62,11 @@ spec:
             - name: http-metrics
               containerPort: 8001
               protocol: TCP
+              {{- if .Values.webhooks.enabled }}
+            - name: https
+              containerPort: 8443
+              protocol: TCP
+              {{- end }}
           readinessProbe:
             httpGet:
               path: /ready

--- a/charts/rollout-operator/templates/deployment.yaml
+++ b/charts/rollout-operator/templates/deployment.yaml
@@ -51,6 +51,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - -kubernetes.namespace={{ .Release.Namespace }}
+          {{- if .Values.webhooks.enabled }}
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name={{ .Values.webhooks.selfSignedCertSecretName }}
+          {{- end }}
           {{- range .Values.extraArgs  }}
           - {{ . }}
           {{- end }}

--- a/charts/rollout-operator/templates/no-downscale-webhook.yaml
+++ b/charts/rollout-operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.webhooks.enabled -}}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-{{ .Release.Namespace }}
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: {{ .Release.Namespace | quote }}
+    {{- include "rollout-operator.labels" . | nindent 4 }}
+webhooks:
+  - name: no-downscale-{{ .Release.Namespace }}.grafana.com
+    clientConfig:
+      service:
+        namespace: {{ .Release.Namespace | quote }}
+        name: {{ include "rollout-operator.fullname" . }}
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
+    sideEffects: None
+    failurePolicy: {{.Values.webhooks.failurePolicy}}
+{{- end -}}

--- a/charts/rollout-operator/templates/pod-eviction-webhook.yaml
+++ b/charts/rollout-operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.webhooks.enabled -}}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-{{ .Release.Namespace }}
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: {{ .Release.Namespace | quote }}
+    {{- include "rollout-operator.labels" . | nindent 4 }}
+webhooks:
+  - name: pod-eviction-{{ .Release.Namespace }}.grafana.com
+    clientConfig:
+      service:
+        namespace: {{ .Release.Namespace | quote }}
+        name: {{ include "rollout-operator.fullname" . }}
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
+    sideEffects: None
+    failurePolicy: {{.Values.webhooks.failurePolicy}}
+{{- end -}}

--- a/charts/rollout-operator/templates/prepare-downscale-webhook.yaml
+++ b/charts/rollout-operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.webhooks.enabled -}}
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-{{ .Release.Namespace }}
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: {{ .Release.Namespace | quote }}
+    {{- include "rollout-operator.labels" . | nindent 4 }}
+webhooks:
+  - name: prepare-downscale-{{ .Release.Namespace }}.grafana.com
+    clientConfig:
+      service:
+        namespace: {{ .Release.Namespace | quote }}
+        name: {{ include "rollout-operator.fullname" . }}
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: {{.Values.webhooks.failurePolicy}}
+{{- end -}}

--- a/charts/rollout-operator/templates/role.yaml
+++ b/charts/rollout-operator/templates/role.yaml
@@ -30,6 +30,7 @@ rules:
   - statefulsets/status
   verbs:
   - update
+{{- if .Values.webhooks.enabled }}
 - apiGroups:
   - rollout-operator.grafana.com
   resources:
@@ -38,3 +39,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch
+  {{- end }}

--- a/charts/rollout-operator/templates/role.yaml
+++ b/charts/rollout-operator/templates/role.yaml
@@ -30,3 +30,11 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch

--- a/charts/rollout-operator/templates/service.yaml
+++ b/charts/rollout-operator/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceMonitor.enabled }}
+{{- if or (eq .Values.serviceMonitor.enabled  true) (eq .Values.webhooks.enabled true) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,12 +8,22 @@ metadata:
     {{- include "rollout-operator.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
+  {{- if eq .Values.webhooks.enabled false }}
   clusterIP: None
+  {{- end }}
   ports:
+    {{- if .Values.serviceMonitor.enabled }}
     - port: 8001
       targetPort: http-metrics
       protocol: TCP
       name: http-metrics
+    {{- end }}
+    {{- if .Values.webhooks.enabled }}
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+    {{- end }}
   selector:
     {{- include "rollout-operator.selectorLabels" . | nindent 4 }}
 {{- end -}}

--- a/charts/rollout-operator/templates/service.yaml
+++ b/charts/rollout-operator/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.serviceMonitor.enabled  true) (eq .Values.webhooks.enabled true) }}
+{{- if or (eq .Values.serviceMonitor.enabled true) (eq .Values.webhooks.enabled true) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/rollout-operator/templates/webhook-clusterrole-binding.yaml
+++ b/charts/rollout-operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.webhooks.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "rollout-operator.fullname" . }}-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "rollout-operator.fullname" . }}-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "rollout-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
+{{- end -}}

--- a/charts/rollout-operator/templates/webhook-clusterrole.yaml
+++ b/charts/rollout-operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.webhooks.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "rollout-operator.fullname" . }}-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch
+{{- end -}}

--- a/charts/rollout-operator/templates/webhook-role-binding.yaml
+++ b/charts/rollout-operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.webhooks.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "rollout-operator.fullname" . }}-webhook-rolebinding
+  namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "rollout-operator.fullname" . }}-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "rollout-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
+{{- end -}}

--- a/charts/rollout-operator/templates/webhook-role.yaml
+++ b/charts/rollout-operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.webhooks.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "rollout-operator.fullname" . }}-webhook-role
+  namespace: {{ .Release.Namespace | quote }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - {{ .Values.webhooks.selfSignedCertSecretName }}
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+{{- end -}}

--- a/charts/rollout-operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/charts/rollout-operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.webhooks.enabled -}}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-{{ .Release.Namespace }}
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: {{ .Release.Namespace | quote }}
+    {{- include "rollout-operator.labels" . | nindent 4 }}
+webhooks:
+  - name: zpdb-validation-{{ .Release.Namespace }}.grafana.com
+    clientConfig:
+      service:
+        namespace: {{ .Release.Namespace | quote }}
+        name: {{ include "rollout-operator.fullname" . }}
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
+    sideEffects: None
+    failurePolicy: {{.Values.webhooks.failurePolicy}}
+{{- end -}}

--- a/charts/rollout-operator/values.yaml
+++ b/charts/rollout-operator/values.yaml
@@ -95,7 +95,7 @@ serviceMonitor:
 
 webhooks:
   # -- Enable the rollout-operator webhooks. See https://github.com/grafana/rollout-operator/#webhooks.
-  # Note that the webhooks require custom resource definitions. If upgrading, manually apply the files in the charts/rollout-operator/crds/ directory.
+  # Note that the webhooks require custom resource definitions. If upgrading, manually apply the files in the `crds` directory.
   enabled: true
   # -- Validating and mutating webhook failure policy. `Ignore` or `Fail`.
   failurePolicy: "Fail"

--- a/charts/rollout-operator/values.yaml
+++ b/charts/rollout-operator/values.yaml
@@ -92,3 +92,12 @@ serviceMonitor:
   # -- ServiceMonitor relabel configs to apply to samples before scraping
   # https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
   relabelings: []
+
+webhooks:
+  # -- Enable the rollout-operator webhooks. See https://github.com/grafana/rollout-operator/#webhooks.
+  # Note that the webhooks require custom resource definitions. If upgrading, manually apply the files in the charts/rollout-operator/crds/ directory.
+  enabled: true
+  # -- Validating and mutating webhook failure policy. `Ignore` or `Fail`.
+  failurePolicy: "Fail"
+  # -- Secret resource name for the TLS certificate to be used with the webhooks
+  selfSignedCertSecretName: "certificate"


### PR DESCRIPTION
This PR relates to https://github.com/grafana/mimir-squad/issues/2365

This PR adds support to the helm rollout-operator chart for enabling the rollout-operator webhooks. This includes;

* no-downscale validating webhook configuration
* prepare-downscale mutating webhook configuration
* pod-eviction validating webhook configuration
* zpdb-validation validating webhook configuration
* zpdb custom resource definition
* replica templates custom resource definition

Note - this PR is also related to https://github.com/grafana/mimir-squad/issues/3179 - where by the jsonnet specific to the rollout-operator will be moved from mimir to the rollout-operator repo. 

This is a new version of https://github.com/grafana/helm-charts/pull/3859