### PR TITLE
[grafana] - bump to version 12.1.1

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
-version: 9.4.0
-appVersion: 12.1.0
+version: 9.4.1
+appVersion: 12.1.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.com


### PR DESCRIPTION
bump Grafana to version [12.1.1](https://github.com/grafana/grafana/releases/tag/v12.1.1), released two weeks ago, as version 12.1.0 has a bug that prevents creating alerts as it shows no contact points