### PR TITLE
[tempo-distributed] Add missing .Value.global.extraArgs for the deployment version of metrics generator

### DIFF
--- a/charts/tempo-distributed/templates/metrics-generator/deployment-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/deployment-metrics-generator.yaml
@@ -61,6 +61,9 @@ spec:
             {{- with .Values.metricsGenerator.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- with .Values.global.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           image: {{ include "tempo.imageReference" $dict }}
           imagePullPolicy: {{ .Values.tempo.image.pullPolicy }}
           name: metrics-generator


### PR DESCRIPTION
* Fix the deployment version of the Tempo Metrics Generator chart that has missing extra args.
* Exists in the stateful set version