### PR TITLE
[grafana-mcp] Set api token env conditionally

### DIFF
--- a/charts/grafana-mcp/Chart.yaml
+++ b/charts/grafana-mcp/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana-mcp
-version: 0.1.2
+version: 0.1.3
 appVersion: latest
 kubeVersion: "^1.8.0-0"
 description: MCP server for Grafana.

--- a/charts/grafana-mcp/templates/deployment.yaml
+++ b/charts/grafana-mcp/templates/deployment.yaml
@@ -101,7 +101,8 @@ spec:
           env:
             - name: GRAFANA_URL
               value: {{ .Values.grafana.url | quote }}
-            - name: GRAFANA_API_KEY
+            {{- if or .Values.grafana.apiKey .Values.grafana.apiKeySecret.name }}
+            - name: GRAFANA_SERVICE_ACCOUNT_TOKEN
               valueFrom:
                 secretKeyRef:
                   {{- if .Values.grafana.apiKey }}
@@ -111,6 +112,7 @@ spec:
                   name: {{ .Values.grafana.apiKeySecret.name }}
                   key: {{ .Values.grafana.apiKeySecret.key }}
                   {{- end }}
+            {{- end }}
             {{- range $key, $value := .Values.env }}
             - name: {{ $key | quote }}
               value: {{ $value | quote }}


### PR DESCRIPTION
It should be possible to leave authentication part exclusively on the client side using `X-Grafana-API-Key` header. Also renaming env var as `GRAFANA_API_KEY` is deprecated.