### PR TITLE
[cloudcost-exporter] Update cloudcost exporter helm version

### DIFF
--- a/charts/cloudcost-exporter/Chart.yaml
+++ b/charts/cloudcost-exporter/Chart.yaml
@@ -5,10 +5,10 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.5
+version: 1.0.6
 
 # This is the version of cloudcost-exporter to be deployed, which should be incremented
 # with each release.
-appVersion: "0.9.0"
+appVersion: "0.10.0"
 
 home: https://github.com/grafana/cloudcost-exporter

--- a/charts/cloudcost-exporter/README.md
+++ b/charts/cloudcost-exporter/README.md
@@ -2,7 +2,7 @@
 
 Cloud Cost Exporter exports cloud provider agnostic cost metrics to Prometheus.
 
-![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
+![Version: 1.0.6](https://img.shields.io/badge/Version-1.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.0](https://img.shields.io/badge/AppVersion-0.10.0-informational?style=flat-square)
 
 ## Installing the Chart
 


### PR DESCRIPTION
Updated with https://github.com/grafana/cloudcost-exporter/releases/tag/v0.10.0