### PR TITLE
Adding commonLabels for tempo-distributed HC. With this we'll be able to add labels to all K8S resources the chart is creating.

### DIFF
--- a/charts/tempo-distributed/templates/_helpers.tpl
+++ b/charts/tempo-distributed/templates/_helpers.tpl
@@ -93,6 +93,13 @@ app.kubernetes.io/managed-by: {{ .ctx.Release.Service }}
 {{- end -}}
 
 {{/*
+Common labels to add to all resources
+*/}}
+{{ - define "tempo.commonLabels" -}}
+{{- toYaml .Values.commonLabels | nindent 0 }}
+{{- end -}}
+
+{{/*
 Simple service selector labels
 */}}
 {{- define "tempo.selectorLabels" -}}

--- a/charts/tempo-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/charts/tempo-distributed/templates/admin-api/admin-api-dep.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- toYaml .Values.adminApi.annotations | nindent 4 }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   name: {{ include "tempo.resourceName" $dict }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
@@ -21,6 +22,7 @@ spec:
     metadata:
       labels:
         {{- include "tempo.podLabels" $dict | nindent 8 }}
+        {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 8 }}
         {{- with .Values.adminApi.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/tempo-distributed/templates/admin-api/admin-api-svc.yaml
+++ b/charts/tempo-distributed/templates/admin-api/admin-api-svc.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "tempo.resourceName" (dict "ctx" . "component" "admin-api") }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "admin-api" "memberlist" true) | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
     {{- with .Values.adminApi.service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/tempo-distributed/templates/compactor/deployment-compactor.yaml
+++ b/charts/tempo-distributed/templates/compactor/deployment-compactor.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   {{- with .Values.compactor.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
@@ -27,6 +28,7 @@ spec:
     metadata:
       labels:
         {{- include "tempo.podLabels" $dict | nindent 8 }}
+        {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 8 }}
         {{- with .Values.tempo.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/tempo-distributed/templates/compactor/hpa.yaml
+++ b/charts/tempo-distributed/templates/compactor/hpa.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "compactor") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/tempo-distributed/templates/compactor/keda-scaledObject.yaml
+++ b/charts/tempo-distributed/templates/compactor/keda-scaledObject.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "compactor") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 spec:
   minReplicaCount: {{ .Values.compactor.autoscaling.minReplicas }}
   maxReplicaCount: {{ .Values.compactor.autoscaling.maxReplicas }}

--- a/charts/tempo-distributed/templates/compactor/poddisruptionbudget-compactor.yaml
+++ b/charts/tempo-distributed/templates/compactor/poddisruptionbudget-compactor.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/tempo-distributed/templates/compactor/service-compactor.yaml
+++ b/charts/tempo-distributed/templates/compactor/service-compactor.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "compactor") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   {{- with .Values.compactor.service.annotations }}
   annotations:
     {{- tpl (toYaml . | nindent 4) $ }}

--- a/charts/tempo-distributed/templates/configmap-runtime.yaml
+++ b/charts/tempo-distributed/templates/configmap-runtime.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ tpl .Values.externalRuntimeConfigName . }}
   labels:
     {{- include "tempo.labels" (dict "ctx" .) | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 data:
   overrides.yaml: |

--- a/charts/tempo-distributed/templates/configmap-tempo.yaml
+++ b/charts/tempo-distributed/templates/configmap-tempo.yaml
@@ -9,6 +9,7 @@ metadata:
   name: {{ tpl .Values.externalConfigSecretName . }}
   labels:
     {{- include "tempo.labels" (dict "ctx" .) | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 {{- if eq .Values.configStorageType "Secret" }}
 data:

--- a/charts/tempo-distributed/templates/distributor/deployment-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/deployment-distributor.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "tempo.labels" $dict | nindent 4 }}
+  {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   {{- with .Values.distributor.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
@@ -27,6 +28,7 @@ spec:
     metadata:
       labels:
         {{- include "tempo.podLabels" $dict | nindent 8 }}
+        {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 8 }}
         {{- with .Values.tempo.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/tempo-distributed/templates/distributor/hpa.yaml
+++ b/charts/tempo-distributed/templates/distributor/hpa.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "distributor") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/tempo-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/tempo-distributed/templates/distributor/service-distributor-discovery.yaml
+++ b/charts/tempo-distributed/templates/distributor/service-distributor-discovery.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
     {{- with .Values.distributor.serviceDiscovery.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/tempo-distributed/templates/distributor/service-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/service-distributor.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
     {{- with .Values.distributor.service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/tempo-distributed/templates/enterprise-federation-frontend/deployment-federation-frontend.yaml
+++ b/charts/tempo-distributed/templates/enterprise-federation-frontend/deployment-federation-frontend.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   {{- with .Values.enterpriseFederationFrontend.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
@@ -28,6 +29,7 @@ spec:
     metadata:
       labels:
         {{- include "tempo.podLabels" $dict | nindent 8 }}
+        {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 8 }}
         {{- with .Values.tempo.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/tempo-distributed/templates/enterprise-federation-frontend/hpa.yaml
+++ b/charts/tempo-distributed/templates/enterprise-federation-frontend/hpa.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "tempo.resourceName" (dict "ctx" . "component" "enterprise-federation-frontend") }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "enterprise-federation-frontend") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/tempo-distributed/templates/enterprise-federation-frontend/poddisruptionbudget-federation-frontend.yaml
+++ b/charts/tempo-distributed/templates/enterprise-federation-frontend/poddisruptionbudget-federation-frontend.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{ include "tempo.resourceName" $dict }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/tempo-distributed/templates/enterprise-federation-frontend/service-federation-frontend.yaml
+++ b/charts/tempo-distributed/templates/enterprise-federation-frontend/service-federation-frontend.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "enterprise-federation-frontend") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   {{- with .Values.enterpriseFederationFrontend.service.annotations }}
   annotations:
     {{- tpl (toYaml . | nindent 4) $ }}

--- a/charts/tempo-distributed/templates/enterprise-gateway/gateway-dep.yaml
+++ b/charts/tempo-distributed/templates/enterprise-gateway/gateway-dep.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- toYaml .Values.enterpriseGateway.annotations | nindent 4 }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   name: {{ include "tempo.resourceName" $dict }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
@@ -21,6 +22,7 @@ spec:
     metadata:
       labels:
         {{- include "tempo.podLabels" $dict | nindent 8 }}
+        {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 8 }}
         {{- with .Values.enterpriseGateway.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/tempo-distributed/templates/enterprise-gateway/gateway-ingress.yaml
+++ b/charts/tempo-distributed/templates/enterprise-gateway/gateway-ingress.yaml
@@ -10,6 +10,7 @@ metadata:
   name: {{ include "tempo.resourceName" $dict }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   {{- with .Values.enterpriseGateway.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/tempo-distributed/templates/enterprise-gateway/gateway-svc.yaml
+++ b/charts/tempo-distributed/templates/enterprise-gateway/gateway-svc.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "tempo.resourceName" $dict }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
     {{- with .Values.enterpriseGateway.service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/tempo-distributed/templates/gateway/configmap-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/configmap-gateway.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "gateway") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 data:
   nginx.conf: |
     {{- tpl .Values.gateway.nginxConfig.file . | nindent 4 }}

--- a/charts/tempo-distributed/templates/gateway/deployment-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/deployment-gateway.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   {{- with .Values.gateway.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -32,6 +33,7 @@ spec:
         {{- end }}
       labels:
         {{- include "tempo.selectorLabels" $dict | nindent 8 }}
+        {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 8 }}
         {{- with .Values.tempo.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/tempo-distributed/templates/gateway/hpa.yaml
+++ b/charts/tempo-distributed/templates/gateway/hpa.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "gateway") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/tempo-distributed/templates/gateway/ingress-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/ingress-gateway.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "gateway") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
     {{- with .Values.gateway.ingress.labels }}
     {{- toYaml . | nindent 4}}
     {{- end}}

--- a/charts/tempo-distributed/templates/gateway/poddisruptionbudget-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/poddisruptionbudget-gateway.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/tempo-distributed/templates/gateway/secret-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/secret-gateway.yaml
@@ -9,6 +9,7 @@ metadata:
   namespace: {{ $root.Release.Namespace | quote }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 stringData:
   .htpasswd: |
     {{- tpl .basicAuth.htpasswd $dict.ctx | nindent 4 }}

--- a/charts/tempo-distributed/templates/gateway/service-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/service-gateway.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "gateway") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
     {{- with .Values.gateway.service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/tempo-distributed/templates/gossip-ring/service-gossip-ring.yaml
+++ b/charts/tempo-distributed/templates/gossip-ring/service-gossip-ring.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "gossip-ring") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   annotations:
     {{- with .Values.tempo.memberlist.service.annotations | default dict }}
     {{- toYaml . | nindent 4}}

--- a/charts/tempo-distributed/templates/ingester/hpa.yaml
+++ b/charts/tempo-distributed/templates/ingester/hpa.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "ingester") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/tempo-distributed/templates/ingester/pdb.yaml
+++ b/charts/tempo-distributed/templates/ingester/pdb.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "ingester") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/tempo-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/tempo-distributed/templates/ingester/service-ingester-discovery.yaml
+++ b/charts/tempo-distributed/templates/ingester/service-ingester-discovery.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
     prometheus.io/service-monitor: "false"
   {{- with .Values.ingester.service.annotations }}
   annotations:

--- a/charts/tempo-distributed/templates/ingester/service-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/service-ingester.yaml
@@ -10,6 +10,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   {{- with .Values.ingester.service.annotations }}
   annotations:
     {{- tpl (toYaml . | nindent 4) $ }}

--- a/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
@@ -12,6 +12,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ingester.labels" $dict | indent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   {{- if .Values.ingester.zoneAwareReplication.enabled }}
   annotations:
     {{- include "ingester.Annotations" $dict | nindent 4}}
@@ -40,6 +41,7 @@ spec:
     metadata:
       labels:
         {{- include "ingester.podLabels" $dict | nindent 8 }}
+        {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 8 }}
         {{- with .Values.tempo.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/tempo-distributed/templates/ingress.yaml
+++ b/charts/tempo-distributed/templates/ingress.yaml
@@ -8,6 +8,7 @@ metadata:
   name: {{ include "tempo.fullname" . }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "gateway") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
     {{- with .Values.ingress.labels }}
     {{- toYaml . | nindent 4}}
     {{- end}}

--- a/charts/tempo-distributed/templates/lib/pdb.tpl
+++ b/charts/tempo-distributed/templates/lib/pdb.tpl
@@ -14,6 +14,7 @@ metadata:
   name: {{ include "tempo.resourceName" (dict "ctx" $.ctx "component" $.component) }}
   labels:
     {{- include "tempo.labels" (dict "ctx" $.ctx "component" $.component) | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   namespace: {{ $.ctx.Release.Namespace | quote }}
 spec:
   selector:

--- a/charts/tempo-distributed/templates/lib/service-monitor.tpl
+++ b/charts/tempo-distributed/templates/lib/service-monitor.tpl
@@ -15,6 +15,7 @@ metadata:
   namespace: {{ .namespace | default $.ctx.Release.Namespace | quote }}
   labels:
     {{- include "tempo.labels" $ | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
     {{- with .labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/tempo-distributed/templates/license-secret.yaml
+++ b/charts/tempo-distributed/templates/license-secret.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ tpl .Values.license.secretName . }}
   labels:
     {{- include "tempo.labels" (dict "ctx" .) | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 data:
   license.jwt: {{ .Values.license.contents | b64enc }}

--- a/charts/tempo-distributed/templates/memcached/poddisruptionbudget-memcached.yaml
+++ b/charts/tempo-distributed/templates/memcached/poddisruptionbudget-memcached.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/tempo-distributed/templates/memcached/service-memcached.yaml
+++ b/charts/tempo-distributed/templates/memcached/service-memcached.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "tempo.labels" (dict "ctx" . "component" "memcached") | nindent 4 }}
+  {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   {{- with .Values.memcached.service.annotations }}
   annotations:
     {{- tpl (toYaml . | nindent 4) $ }}

--- a/charts/tempo-distributed/templates/memcached/statefulset-memcached.yaml
+++ b/charts/tempo-distributed/templates/memcached/statefulset-memcached.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   {{- with .Values.memcached.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
@@ -30,6 +31,7 @@ spec:
       {{- end }}
       labels:
         {{- include "tempo.labels" $dict | nindent 8 }}
+        {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 8 }}
         {{- with .Values.tempo.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/tempo-distributed/templates/metamonitoring/grafana-agent-cluster-role-binding.yaml
+++ b/charts/tempo-distributed/templates/metamonitoring/grafana-agent-cluster-role-binding.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .namespace | default $.Release.Namespace | quote }}
   labels:
     {{- include "tempo.labels" (dict "ctx" $ "component" "meta-monitoring" ) | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/tempo-distributed/templates/metamonitoring/grafana-agent-cluster-role.yaml
+++ b/charts/tempo-distributed/templates/metamonitoring/grafana-agent-cluster-role.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .namespace | default $.Release.Namespace | quote }}
   labels:
     {{- include "tempo.labels" (dict "ctx" $ "component" "meta-monitoring" ) | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 rules:
   - apiGroups:
       - ""

--- a/charts/tempo-distributed/templates/metamonitoring/grafana-agent-service-account.yaml
+++ b/charts/tempo-distributed/templates/metamonitoring/grafana-agent-service-account.yaml
@@ -7,5 +7,6 @@ metadata:
   namespace: {{ .namespace | default $.Release.Namespace | quote }}
   labels:
     {{- include "tempo.labels" (dict "ctx" $ "component" "meta-monitoring" ) | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/metamonitoring/grafana-agent.yaml
+++ b/charts/tempo-distributed/templates/metamonitoring/grafana-agent.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .namespace | default $.Release.Namespace | quote }}
   labels:
     {{- include "tempo.labels" (dict "ctx" $ "component" "meta-monitoring" ) | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
     {{- with .labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/tempo-distributed/templates/metamonitoring/kube-state-metrics-servmon.yaml
+++ b/charts/tempo-distributed/templates/metamonitoring/kube-state-metrics-servmon.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: {{ .namespace | default $.Release.Namespace | quote }}
   labels:
     {{- include "tempo.labels" (dict "ctx" $ "component" "meta-monitoring") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
     {{- with .labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/tempo-distributed/templates/metamonitoring/kubelet-cadvisor-servmon.yaml
+++ b/charts/tempo-distributed/templates/metamonitoring/kubelet-cadvisor-servmon.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: {{ .namespace | default $.Release.Namespace | quote }}
   labels:
     {{- include "tempo.labels" (dict "ctx" $ "component" "meta-monitoring") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
     {{- with .labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/tempo-distributed/templates/metamonitoring/logs-instance-usernames-secret.yaml
+++ b/charts/tempo-distributed/templates/metamonitoring/logs-instance-usernames-secret.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ (($.Values.metaMonitoring).grafanaAgent).namespace | default $.Release.Namespace | quote }}
   labels:
     {{- include "tempo.labels" (dict "ctx" $ "component" "meta-monitoring") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 data:
   {{- range $i, $cfg := prepend (.additionalClientConfigs | default list) .remote }}
   {{- if (($cfg).auth).username }}

--- a/charts/tempo-distributed/templates/metamonitoring/logs-instance.yaml
+++ b/charts/tempo-distributed/templates/metamonitoring/logs-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ (($.Values.metaMonitoring).grafanaAgent).namespace | default $.Release.Namespace | quote }}
   labels:
     {{- include "tempo.labels" (dict "ctx" $ "component" "meta-monitoring" ) | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
     {{- with .labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/tempo-distributed/templates/metamonitoring/metrics-instance-usernames-secret.yaml
+++ b/charts/tempo-distributed/templates/metamonitoring/metrics-instance-usernames-secret.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ $.Values.metaMonitoring.grafanaAgent.namespace | default $.Release.Namespace | quote }}
   labels:
     {{- include "tempo.labels" (dict "ctx" $ "component" "meta-monitoring") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 data:
   {{- range $i, $cfg := prepend (.additionalRemoteWriteConfigs | default list) .remote }}
   {{- if (($cfg).auth).username }}

--- a/charts/tempo-distributed/templates/metamonitoring/metrics-instance.yaml
+++ b/charts/tempo-distributed/templates/metamonitoring/metrics-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ $.Values.metaMonitoring.grafanaAgent.namespace | default $.Release.Namespace | quote }}
   labels:
     {{- include "tempo.labels" (dict "ctx" $ "component" "meta-monitoring" ) | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
     {{- with .labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/tempo-distributed/templates/metamonitoring/pod-logs.yaml
+++ b/charts/tempo-distributed/templates/metamonitoring/pod-logs.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .namespace | default $.Release.Namespace | quote }}
   labels:
     {{- include "tempo.labels" (dict "ctx" $ "component" "meta-monitoring") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
     {{- with .labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/tempo-distributed/templates/metrics-generator/deployment-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/deployment-metrics-generator.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "tempo.labels" $dict | nindent 4 }}
+  {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   {{- with .Values.metricsGenerator.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
@@ -22,6 +23,7 @@ spec:
     metadata:
       labels:
         {{- include "tempo.podLabels" $dict | nindent 8 }}
+        {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 8 }}
         {{- with .Values.tempo.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/tempo-distributed/templates/metrics-generator/poddisruptionbudget-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/poddisruptionbudget-metrics-generator.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{ include "tempo.resourceName" $dict }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/tempo-distributed/templates/metrics-generator/service-metrics-generator-discovery.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/service-metrics-generator-discovery.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
     prometheus.io/service-monitor: "false"
   {{- with .Values.metricsGenerator.service.annotations }}
   annotations:

--- a/charts/tempo-distributed/templates/metrics-generator/service-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/service-metrics-generator.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   {{- with .Values.metricsGenerator.service.annotations }}
   annotations:
     {{- tpl (toYaml . | nindent 4) $ }}

--- a/charts/tempo-distributed/templates/metrics-generator/statefulset-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/statefulset-metrics-generator.yaml
@@ -9,6 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "tempo.labels" $dict | nindent 4 }}
+  {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   {{- with .Values.metricsGenerator.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
@@ -28,6 +29,7 @@ spec:
     metadata:
       labels:
         {{- include "tempo.podLabels" $dict | nindent 8 }}
+        {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 8 }}
         {{- with .Values.tempo.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/tempo-distributed/templates/podsecuritypolicy.yaml
+++ b/charts/tempo-distributed/templates/podsecuritypolicy.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" . | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 spec:
   privileged: false
   allowPrivilegeEscalation: false

--- a/charts/tempo-distributed/templates/prometheusrule.yaml
+++ b/charts/tempo-distributed/templates/prometheusrule.yaml
@@ -13,6 +13,7 @@ metadata:
   {{- end }}
   labels:
     {{- include "tempo.labels" (dict "ctx" $) | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   {{- with .labels }}
   {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/tempo-distributed/templates/provisioner/provisioner-job.yaml
+++ b/charts/tempo-distributed/templates/provisioner/provisioner-job.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "tempo.resourceName" (dict "ctx" . "component" "provisioner") }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "provisioner") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
     {{- with .Values.provisioner.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -25,6 +26,7 @@ spec:
     metadata:
       labels:
         {{- include "tempo.podLabels" (dict "ctx" . "component" "provisioner") | nindent 8 }}
+        {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 8 }}
       annotations:
         {{- include "tempo.podAnnotations" (dict "ctx" . "component" "provisioner") | nindent 8 }}
       namespace: {{ .Release.Namespace | quote }}

--- a/charts/tempo-distributed/templates/provisioner/provisioner-rbac.yaml
+++ b/charts/tempo-distributed/templates/provisioner/provisioner-rbac.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "tempo.resourceName" (dict "ctx" . "component" "provisioner") }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "provisioner") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 rules:
 - apiGroups: [""]
@@ -17,6 +18,7 @@ metadata:
   name: {{ include "tempo.resourceName" (dict "ctx" . "component" "provisioner") }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "provisioner") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/tempo-distributed/templates/provisioner/provisioner-serviceaccount.yaml
+++ b/charts/tempo-distributed/templates/provisioner/provisioner-serviceaccount.yaml
@@ -5,5 +5,6 @@ metadata:
   name: {{ include "tempo.resourceName" (dict "ctx" . "component" "provisioner") }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "provisioner") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 {{- end -}}

--- a/charts/tempo-distributed/templates/querier/deployment-querier.yaml
+++ b/charts/tempo-distributed/templates/querier/deployment-querier.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   {{- with .Values.querier.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
@@ -27,6 +28,7 @@ spec:
     metadata:
       labels:
         {{- include "tempo.podLabels" $dict | nindent 8 }}
+        {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 8 }}
         {{- with .Values.tempo.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/tempo-distributed/templates/querier/hpa.yaml
+++ b/charts/tempo-distributed/templates/querier/hpa.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "querier") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/tempo-distributed/templates/querier/poddisruptionbudget-querier.yaml
+++ b/charts/tempo-distributed/templates/querier/poddisruptionbudget-querier.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/tempo-distributed/templates/querier/service-querier.yaml
+++ b/charts/tempo-distributed/templates/querier/service-querier.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "querier") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   {{- with .Values.querier.service.annotations }}
   annotations:
     {{- tpl (toYaml . | nindent 4) $ }}

--- a/charts/tempo-distributed/templates/query-frontend/deployment-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/deployment-query-frontend.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   {{- with .Values.queryFrontend.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
@@ -27,6 +28,7 @@ spec:
     metadata:
       labels:
         {{- include "tempo.podLabels" $dict | nindent 8 }}
+        {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 8 }}
         {{- with .Values.tempo.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/tempo-distributed/templates/query-frontend/hpa.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/hpa.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "query-frontend") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/tempo-distributed/templates/query-frontend/ingress-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/ingress-query-frontend.yaml
@@ -10,6 +10,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   {{- with .Values.queryFrontend.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/tempo-distributed/templates/query-frontend/poddisruptionbudget-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/poddisruptionbudget-query-frontend.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/tempo-distributed/templates/query-frontend/service-query-frontend-discovery.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/service-query-frontend-discovery.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "query-frontend") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
     {{- with .Values.queryFrontend.serviceDiscovery.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/tempo-distributed/templates/query-frontend/service-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/service-query-frontend.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "query-frontend") | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
     {{- with .Values.queryFrontend.service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/tempo-distributed/templates/role.yaml
+++ b/charts/tempo-distributed/templates/role.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" .) | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 {{- if .Values.rbac.pspEnabled }}
 rules:
 - apiGroups:      ['extensions']

--- a/charts/tempo-distributed/templates/rolebinding.yaml
+++ b/charts/tempo-distributed/templates/rolebinding.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" (dict "ctx" .) | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/tempo-distributed/templates/serviceaccount.yaml
+++ b/charts/tempo-distributed/templates/serviceaccount.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "tempo.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
     {{- include "tempo.labels" (dict "ctx" .) | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:

--- a/charts/tempo-distributed/templates/tokengen/tokengen-job.yaml
+++ b/charts/tempo-distributed/templates/tokengen/tokengen-job.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "tempo.resourceName" $dict }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   annotations:
     {{- if .Values.tokengenJob.annotations }}
     {{- toYaml .Values.tokengenJob.annotations | nindent 4 }}
@@ -20,6 +21,7 @@ spec:
     metadata:
       labels:
         {{- include "tempo.podLabels" $dict | nindent 8 }}
+        {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 8 }}
         {{- with .Values.tokengenJob.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/tempo-distributed/templates/tokengen/tokengen-rbac.yaml
+++ b/charts/tempo-distributed/templates/tokengen/tokengen-rbac.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{ include "tempo.resourceName" $dict }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 rules:
 - apiGroups: [""]
@@ -19,6 +20,7 @@ metadata:
   name: {{ include "tempo.resourceName" $dict }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 subjects:
 - kind: ServiceAccount

--- a/charts/tempo-distributed/templates/tokengen/tokengen-serviceaccount.yaml
+++ b/charts/tempo-distributed/templates/tokengen/tokengen-serviceaccount.yaml
@@ -6,5 +6,6 @@ metadata:
   name: {{ include "tempo.resourceName" $dict }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- include "tempo.commonLabels" (dict "ctx" .) | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 {{- end -}}

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -8,6 +8,8 @@ global:
     # Example:
     # pullSecrets: [ my-dockerconfigjson-secret ]
     pullSecrets: []
+  # -- Adding common labels to all K8S resources
+  commonLabels: {}
   # -- Overrides the priorityClassName for all pods
   priorityClassName: null
   # -- configures cluster domain ("cluster.local" by default)


### PR DESCRIPTION
Enabling the tempo-distributed HelmChart to have commonLabels that will be added to all K8S created.

Signed-off-by: Martin Burgos <martin.burgos@qlik.com>
