### PR TITLE
[grafana] Add manualEgress option for network policies

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 10.0.0
+version: 10.1.0
 appVersion: 12.1.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/networkpolicy.yaml
+++ b/charts/grafana/templates/networkpolicy.yaml
@@ -24,9 +24,9 @@ spec:
   podSelector:
     matchLabels:
       {{- include "grafana.selectorLabels" . | nindent 6 }}
-
   {{- if .Values.networkPolicy.egress.enabled }}
   egress:
+    {{- if not .Values.networkPolicy.egress.manualEgress }}
     {{- if not .Values.networkPolicy.egress.blockDNSResolution }}
     - ports:
         - port: 53
@@ -38,6 +38,9 @@ spec:
       to:
         {{- toYaml . | nindent 12 }}
       {{- end }}
+    {{- else }}
+    {{- toYaml .Values.networkPolicy.egress.manualEgress | nindent 4 }}
+    {{- end }}
   {{- end }}
   {{- if .Values.networkPolicy.ingress }}
   ingress:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1606,12 +1606,18 @@ networkPolicy:
     ## to:
     ##  - namespaceSelector:
     ##    matchExpressions:
-  ##    - {key: role, operator: In, values: [grafana]}
-  ##
-  ##
-  ##
-  ##
-  ##
+    ##    - {key: role, operator: In, values: [grafana]}
+    ##
+    ## @param networkPolicy.egress.manualEgress Manually define all egress rules
+    manualEgress: []
+    ## E.X.
+    ##- to:
+    ##  - podSelector:
+    ##      matchLabels:
+    ##        app.kubernetes.io/name: other-pod
+    ##    ports:
+    ##    - protocol: TCP
+    ##      port: 3000
 
 # Enable backward compatibility of kubernetes where version below 1.13 doesn't have the enableServiceLinks option
 enableKubeBackwardCompatibility: false


### PR DESCRIPTION
Hey,

the current options one has regarding ingress and egress for Grafana in the helm chart is not really flexible, and didn't fit our needs. In the current state of the chart, when providing multiple ports and targets, everything gets rendered into a single rule which is more open than you need.

We wanted something like #3287 but for the egress rules. The problem was that as soon as you set `egress.enabled`, a rule gets rendered which given the default values, opens up all ports.

I tried to find a way to give the chart more flexibility but without breaking the chart for everyone else. With the new `manuelEgress` option, the user gets maximum flexibility if needed, but only if the new key is set.

Something like that would probably also be great on the ingress side, but here it's even harder to implement, given  the structure of the template and the values, without breaking the chart and requiring a major version bump. But if you are open for a rework of this part of the chart, I'm happy to help.

Best,
Felix
