### PR TITLE
[rollout-operator] Handle fullnameOverride in webhooks self-signed-cert

### DIFF
--- a/charts/rollout-operator/Chart.yaml
+++ b/charts/rollout-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-operator
 description: "Grafana rollout-operator"
 type: application
-version: 0.33.1
+version: 0.33.2
 appVersion: v0.29.0
 home: https://github.com/grafana/rollout-operator
 kubeVersion: ^1.10.0-0

--- a/charts/rollout-operator/templates/deployment.yaml
+++ b/charts/rollout-operator/templates/deployment.yaml
@@ -54,6 +54,9 @@ spec:
           {{- if .Values.webhooks.enabled }}
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name={{ .Values.webhooks.selfSignedCertSecretName }}
+          {{- if .Values.fullnameOverride }}
+          - -server-tls.self-signed-cert.dns-name={{ include "rollout-operator.fullname" .}}.{{ .Release.Namespace }}.svc
+          {{- end }}
           {{- end }}
           {{- range .Values.extraArgs  }}
           - {{ . }}


### PR DESCRIPTION
Add handling of fullnameOverride to the webhooks self-signed-cert, so the SAN matches the service name.