### PR TITLE
[grafana] Grafana Operator configuration support

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 10.0.0
+version: 10.0.1
 appVersion: 12.1.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -284,6 +284,11 @@ This ensures the expressions are preserved for Alertmanager instead of being ren
 | `serviceMonitor.labels`                   | Labels for the servicemonitor passed to Prometheus Operator      |  `{}`                                |
 | `serviceMonitor.scrapeTimeout`            | Timeout after which the scrape is ended       | `30s`                                                   |
 | `serviceMonitor.relabelings`              | RelabelConfigs to apply to samples before scraping.     | `[]`                                      |
+| `grafanaOperator.enabled`                 | If true, a Grafana CR is created for a grafana operator                 | `false`     |                 |
+| `grafanaOperator.labels`                  | Additional Labels for `Grafana` CR `instanceSelector`s to match against | `{}`        |                 |
+| `grafanaOperator.path`                    | string                                                                  | `"/"`       |                 |
+| `grafanaOperator.scheme`                  | Override the default path                                               | `"http"`    |                 |
+| `grafanaOperator.client`                  | Configures the Grafana Operator HTTP Client when reconciling resources  | `{}`        |                 |
 | `serviceMonitor.metricRelabelings`        | MetricRelabelConfigs to apply to samples before ingestion.  | `[]`                                      |
 | `revisionHistoryLimit`                    | Number of old ReplicaSets to retain           | `10`                                                    |
 | `imageRenderer.enabled`                    | Enable the image-renderer deployment & service                                     | `false`                          |

--- a/charts/grafana/templates/grafanaoperator.yaml
+++ b/charts/grafana/templates/grafanaoperator.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.grafanaOperator.enabled }}
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: {{ include "grafana.fullname" . }}
+  namespace: {{ include "grafana.namespace" . }}
+  labels:
+    {{- include "grafana.labels" . | nindent 4 }}
+    {{- with .Values.grafanaOperator.labels }}
+    {{- tpl (toYaml . | nindent 4) $ }}
+    {{- end }}
+spec:
+  external:
+    url: "{{ .Values.grafanaOperator.scheme }}://{{ include "grafana.fullname" . }}.{{ include "grafana.namespace" . }}.svc.cluster.local:{{ .Values.service.port }}{{ .Values.grafanaOperator.path }}"
+    adminUser:
+      name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
+      key: {{ .Values.admin.userKey | default "admin-user" }}
+    adminPassword:
+      name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
+      key: {{ .Values.admin.passwordKey | default "admin-password" }}
+  {{- with .Values.grafanaOperator.client }}
+  client:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -266,6 +266,22 @@ serviceMonitor:
   basicAuth: {}
   targetLabels: []
 
+## Grafana Operator is an alternative solution for provisioning resources to Grafana instances
+##
+grafanaOperator:
+  ## If true, a Grafana CR is created for a grafana operator
+  ## https://github.com/grafana/grafana-operator
+  ##
+  enabled: false
+  ## Additional Labels for `Grafana` CR `instanceSelector`s to match against
+  labels: {}
+  scheme: http
+  ## Override the default path
+  path: /
+  ## Configures the Grafana Operator HTTP Client when reconciling resources
+  ## Allows: TLS, timeouts, headers..
+  client: {}
+
 extraExposePorts: []
  # - name: keycloak
  #   port: 8080


### PR DESCRIPTION
In the Grafana-Operator project we've have seen users having some difficulty configuring Grafana created via Helm.
As this is a documentation problem as well as a usability problem, we're now looking to close that gap.

One of the ideas is making it more convenient for users to get started with existing Grafana instances!
If you believe this absolutely does not belong here, you're more than welcome to decline this PR 😄.

I tried following the existing conventions I found in other templates, namely `deployment.yaml`, `_pod.tpl`, `service.yaml`, and `servicemonitor.yaml`, but I've likely overlooked something?