### PR TITLE
chore : use latest loki image from 2.x release

### DIFF
--- a/charts/loki-stack/values.yaml
+++ b/charts/loki-stack/values.yaml
@@ -20,6 +20,9 @@ loki:
   datasource:
     jsonData: "{}"
     uid: ""
+  image:
+    repository: grafana/loki
+    tag: 2.9.15
 
 
 promtail:


### PR DESCRIPTION

Fix #2873
Fix grafana/loki/issues/11557
