### PR TITLE
Add action to the servicemonitor relabling for the cluster label

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.48.0
+version: 1.48.1
 appVersion: 2.8.2
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.48.0](https://img.shields.io/badge/Version-1.48.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
+![Version: 1.48.1](https://img.shields.io/badge/Version-1.48.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/lib/service-monitor.tpl
+++ b/charts/tempo-distributed/templates/lib/service-monitor.tpl
@@ -52,7 +52,8 @@ spec:
           replacement: "{{ $.ctx.Release.Namespace }}/{{ $.component }}"
           targetLabel: job
         {{- if kindIs "string" .clusterLabel }}
-        - replacement: "{{ .clusterLabel | default (include "tempo.clusterName" $.ctx) }}"
+        - action: replace
+          replacement: "{{ .clusterLabel | default (include "tempo.clusterName" $.ctx) }}"
           targetLabel: cluster
         {{- end }}
         {{- with .relabelings }}


### PR DESCRIPTION
Currently the servicemonitor template is missing the action on the `targetLabel: cluster` relabelings.

Whilst this is valid, k8s adds in the default `action: replace` when the servicemonitor is deployed.

If you use ArgoCD to deploy tempo, with the servicemonitors enabled, this results in a delta between the desired state and the live state. Thus argo is constantly in a sync loop, trying to remediate the on-cluster state.

This PR adds `action: replace` to the servicemonitor template, allowing argocd to successfully apply the desired configuration.