### PR TITLE
[grafana] Add app.kubernetes.io/component to secrets

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 10.1.1
+version: 10.1.2
 appVersion: 12.2.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/secret-env.yaml
+++ b/charts/grafana/templates/secret-env.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "grafana.namespace" . }}
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
+    app.kubernetes.io/component: env-secret
 type: Opaque
 data:
 {{- range $key, $val := .Values.envRenderSecret }}

--- a/charts/grafana/templates/secret.yaml
+++ b/charts/grafana/templates/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "grafana.namespace" . }}
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
+    app.kubernetes.io/component: admin-secret
   {{- with .Values.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
This PR assists https://github.com/prometheus-community/helm-charts/pull/5679

Once implemented, the admin secret can be fetched with `kubectl get secrets -l app.kubernetes.io/component=admin-secret`