### PR TITLE
chore(loki-distributed): add extraobjects support

### DIFF
--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -177,6 +177,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | distributor.serviceLabels | object | `{}` | Labels for distributor service |
 | distributor.terminationGracePeriodSeconds | int | `30` | Grace period to allow the distributor to shutdown before it is killed |
 | distributor.tolerations | list | `[]` | Tolerations for distributor pods |
+| extraObjects | list | `[]`| Extra manifests to run |
 | fullnameOverride | string | `nil` | Overrides the chart's computed fullname |
 | gateway.affinity | string | Hard node and soft zone anti-affinity | Affinity for gateway pods. Passed through `tpl` and, thus, to be configured as string |
 | gateway.autoscaling.behavior.enabled | bool | `false` | Enable autoscaling behaviours |

--- a/charts/loki-distributed/templates/extra-manifests.yaml
+++ b/charts/loki-distributed/templates/extra-manifests.yaml
@@ -1,0 +1,8 @@
+{{ range .Values.extraObjects }}
+---
+{{- if typeIs "string" . }}
+  {{ tpl . $ }}
+{{ else }}
+  {{ tpl (. | toYaml) $ }}
+{{- end }}
+{{ end }}

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -2098,3 +2098,28 @@ networkPolicy:
     podSelector: {}
     # -- Specifies the namespace the discovery Pods are running in
     namespaceSelector: {}
+# -- extraObjects could be utilized to add dynamic manifests via values
+extraObjects: []
+# Examples:
+# extraObjects:
+# - apiVersion: kubernetes-client.io/v1
+#   kind: ExternalSecret
+#   metadata:
+#     name: tempo-secrets-{{ .Release.Name }}
+#   spec:
+#     backendType: aws
+#     data:
+#     - key: secret-access-key
+#       name: awssm-secret
+# Alternatively, you can use strings, which lets you use additional templating features:
+# extraObjects:
+# - |
+#   apiVersion: kubernetes-client.io/v1
+#   kind: ExternalSecret
+#   metadata:
+#     name: tempo-secrets-{{ .Release.Name }}
+#   spec:
+#     backendType: aws
+#     data:
+#     - key: secret-access-key
+#       name: {{ include "some-other-template" }}    


### PR DESCRIPTION
Add extraobjects to be able to run manifests as part of loki-distributed deployment