### PR TITLE
[rollout-operator] Replace default webhooks.selfSignedCertSecretName with fullname

### DIFF
--- a/charts/rollout-operator/README.md
+++ b/charts/rollout-operator/README.md
@@ -85,5 +85,5 @@ Manually applying these CRDs is only required if upgrading from a chart <= v0.32
 | tolerations | list | `[]` |  |
 | webhooks.enabled | bool | `true` | Enable the rollout-operator webhooks. See https://github.com/grafana/rollout-operator/#webhooks. Note that the webhooks require custom resource definitions. If upgrading, manually apply the files in the `crds` directory. |
 | webhooks.failurePolicy | string | `"Fail"` | Validating and mutating webhook failure policy. `Ignore` or `Fail`. |
-| webhooks.selfSignedCertSecretName | string | `""` | Secret resource name for the TLS certificate to be used with the webhooks |
+| webhooks.selfSignedCertSecretName | string | `""` | Secret resource name for the TLS certificate to be used with the webhooks. If not set, a secret's name will be generated using the fullname template. |
 | webhooks.objectSelector | object | `{}` | objectSelector to filter which objects the webhooks apply to. |

--- a/charts/rollout-operator/templates/_helpers.tpl
+++ b/charts/rollout-operator/templates/_helpers.tpl
@@ -92,3 +92,11 @@ Create the image name
 {{- (printf "%s:%s" .Values.image.repository $imageTag) }}
 {{- end -}}
 {{- end -}}
+
+{{- define "rollout-operator.secretName" -}}
+{{- if .Values.webhook.selfSignedCertSecretName }}
+{{- .Values.webhook.selfSignedCertSecretName }}
+{{- else }}
+{{- include "rollout-operator.fullname" . }}
+{{- end }}
+{{- end }}

--- a/charts/rollout-operator/templates/deployment.yaml
+++ b/charts/rollout-operator/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
           - -kubernetes.namespace={{ .Release.Namespace }}
           {{- if .Values.webhooks.enabled }}
           - -server-tls.enabled=true
-          - -server-tls.self-signed-cert.secret-name={{ .Values.webhooks.selfSignedCertSecretName | default (include "rollout-operator.fullname" . )  }}
+          - -server-tls.self-signed-cert.secret-name={{ include "rollout-operator.secretName" . }}
           - -server-tls.self-signed-cert.dns-name={{ include "rollout-operator.fullname" . }}.{{ .Release.Namespace }}.svc
           {{- end }}
           {{- range .Values.extraArgs  }}

--- a/charts/rollout-operator/templates/webhook-role.yaml
+++ b/charts/rollout-operator/templates/webhook-role.yaml
@@ -13,7 +13,7 @@ rules:
       - update
       - get
     resourceNames:
-      - {{ .Values.webhooks.selfSignedCertSecretName | default (include "rollout-operator.fullname" . )  }}
+      - {{ include "rollout-operator.secretName" . }}
   - apiGroups:
       - ""
     resources:

--- a/charts/rollout-operator/values.yaml
+++ b/charts/rollout-operator/values.yaml
@@ -106,7 +106,7 @@ webhooks:
   enabled: true
   # -- Validating and mutating webhook failure policy. `Ignore` or `Fail`.
   failurePolicy: "Fail"
-  # -- Secret resource name for the TLS certificate to be used with the webhooks
+  # -- Secret resource name for the TLS certificate to be used with the webhooks. If not set, a secret's name will be generated using the fullname template.
   selfSignedCertSecretName: ""
   # -- objectSelector to filter which objects the webhooks apply to.
   objectSelector: {}


### PR DESCRIPTION
Certificate secret's default name `certificate` is too general name, so I made it chart's fullname to match with the other resources.

Changing cert secret name doesn't break existing installations. It will recreate rollout-operator pod and cert secret will be recreated as well.