### PR TITLE
[synthetic-monitoring-agent] Add disclaimer around official support

### DIFF
--- a/charts/synthetic-monitoring-agent/Chart.yaml
+++ b/charts/synthetic-monitoring-agent/Chart.yaml
@@ -1,6 +1,11 @@
 apiVersion: v2
 appVersion: v0.38.3
-description: Grafana's Synthetic Monitoring application. The agent provides probe functionality and executes network checks for monitoring remote targets.
+description: |
+  Grafana's Synthetic Monitoring application. The agent provides probe functionality and executes network checks for monitoring remote targets.
+
+  > [!NOTE]
+  > Grafana Cloud Synthetic Monitoring does not officially support this chart.
+  > If you are a Grafana Cloud customer and require support, please follow the [recommended installation methods](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/set-up/set-up-private-probes/#deployment-with-kubernetes) listed in the public docs.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png
 maintainers:
@@ -14,4 +19,4 @@ name: synthetic-monitoring-agent
 sources:
   - https://github.com/grafana/synthetic-monitoring-agent
 type: application
-version: 1.1.0
+version: 1.1.1

--- a/charts/synthetic-monitoring-agent/README.md
+++ b/charts/synthetic-monitoring-agent/README.md
@@ -1,8 +1,12 @@
 # synthetic-monitoring-agent
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.38.3](https://img.shields.io/badge/AppVersion-v0.38.3-informational?style=flat-square)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.38.3](https://img.shields.io/badge/AppVersion-v0.38.3-informational?style=flat-square)
 
 Grafana's Synthetic Monitoring application. The agent provides probe functionality and executes network checks for monitoring remote targets.
+
+> [!NOTE]
+> Grafana Cloud Synthetic Monitoring does not officially support this chart.
+> If you are a Grafana Cloud customer and require support, please follow the [recommended installation methods](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/set-up/set-up-private-probes/#deployment-with-kubernetes) listed in the public docs.
 
 **Homepage:** <https://grafana.net>
 


### PR DESCRIPTION
Updates the synthetic monitoring agent to highlight that the helm chart is not covered by support and direct users towards the official documentation to setup a private probe in kubernetes.