### PR TITLE
[promtail] make dnsPolicy and dnsConfig configurable

### DIFF
--- a/charts/promtail/Chart.yaml
+++ b/charts/promtail/Chart.yaml
@@ -4,7 +4,7 @@ deprecated: true
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 type: application
 appVersion: 3.5.1
-version: 6.17.1
+version: 6.18.0
 home: https://grafana.com/loki
 sources:
   - https://github.com/grafana/loki

--- a/charts/promtail/README.md
+++ b/charts/promtail/README.md
@@ -4,7 +4,7 @@
 
 # promtail
 
-![Version: 6.17.1](https://img.shields.io/badge/Version-6.17.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.1](https://img.shields.io/badge/AppVersion-3.5.1-informational?style=flat-square)
+![Version: 6.18.0](https://img.shields.io/badge/Version-6.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.1](https://img.shields.io/badge/AppVersion-3.5.1-informational?style=flat-square)
 
 Promtail is an agent which ships the contents of local logs to a Loki instance
 
@@ -106,6 +106,8 @@ The new release which will pick up again from the existing `positions.yaml`.
 | deployment.enabled | bool | `false` | Deploys Promtail as a Deployment |
 | deployment.replicaCount | int | `1` |  |
 | deployment.strategy | object | `{"type":"RollingUpdate"}` | Set deployment object update strategy |
+| dnsConfig | object | `{}` | Set dnsConfig for the pod. Read more about dnsConfig https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config |
+| dnsPolicy | string | `nil` | Set dnsPolicy for the pod. If not set k8s defaults to ClusterFirst when hostNetwork=false and Default when hostNetwork=true |
 | enableServiceLinks | bool | `true` | Configure enableServiceLinks in pod |
 | extraArgs | list | `[]` |  |
 | extraContainers | object | `{}` |  |

--- a/charts/promtail/templates/_pod.tpl
+++ b/charts/promtail/templates/_pod.tpl
@@ -22,6 +22,13 @@ spec:
   {{- with .Values.hostNetwork }}
   hostNetwork: {{ . }}
   {{- end }}
+  {{- with .Values.dnsPolicy }}
+  dnsPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.dnsConfig }}
+  dnsConfig:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.priorityClassName }}
   priorityClassName: {{ . }}
   {{- end }}

--- a/charts/promtail/values.yaml
+++ b/charts/promtail/values.yaml
@@ -116,6 +116,12 @@ hostAliases: []
 # -- Controls whether the pod has the `hostNetwork` flag set.
 hostNetwork: null
 
+# -- Set dnsPolicy for the pod. If not set k8s defaults to ClusterFirst when hostNetwork=false and Default when hostNetwork=true
+dnsPolicy: null
+
+# -- Set dnsConfig for the pod. Read more about dnsConfig https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+dnsConfig: {}
+
 # -- Annotations for the DaemonSet
 annotations: {}
 


### PR DESCRIPTION
What: add dnsPolicy and dnsConfig to promtail chart
Why: allow users to customize dns settings for promtail daemonset pods, helps in various use-cases
Breaking?: No