### PR TITLE
[tempo-distributed] fix: Add missing namespace metadata

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.56.1
+version: 1.56.2
 appVersion: 2.9.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.56.1](https://img.shields.io/badge/Version-1.56.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.0](https://img.shields.io/badge/AppVersion-2.9.0-informational?style=flat-square)
+![Version: 1.56.2](https://img.shields.io/badge/Version-1.56.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.0](https://img.shields.io/badge/AppVersion-2.9.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 

--- a/charts/tempo-distributed/templates/enterprise-federation-frontend/hpa.yaml
+++ b/charts/tempo-distributed/templates/enterprise-federation-frontend/hpa.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "tempo.resourceName" (dict "ctx" . "component" "enterprise-federation-frontend") }}
   labels:
     {{- include "tempo.labels" (dict "ctx" . "component" "enterprise-federation-frontend") | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/tempo-distributed/templates/enterprise-federation-frontend/poddisruptionbudget-federation-frontend.yaml
+++ b/charts/tempo-distributed/templates/enterprise-federation-frontend/poddisruptionbudget-federation-frontend.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{ include "tempo.resourceName" $dict }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/charts/tempo-distributed/templates/metrics-generator/poddisruptionbudget-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/poddisruptionbudget-metrics-generator.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{ include "tempo.resourceName" $dict }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
I know there are other PRs for some of these, but I wanted to include them all for completeness' sake.

One HPA and two PDB's were missing the namespace metadata. This adds them. As far as I could tell, these were the only missing namespaces.