### PR TITLE
fix(tempo-distributed): order of the registry and pullSecrets to be i…

### DIFF
--- a/charts/tempo-distributed/templates/_helpers.tpl
+++ b/charts/tempo-distributed/templates/_helpers.tpl
@@ -28,7 +28,7 @@ If release name contains chart name it will be used as a full name.
 Docker image selector for Tempo. Hierachy based on global, component, and tempo values.
 */}}
 {{- define "tempo.tempoImage" -}}
-{{- $registry := coalesce .global.registry .component.registry .tempo.registry -}}
+{{- $registry := coalesce .component.registry .tempo.registry .global.registry -}}
 {{- $repository := coalesce .component.repository .tempo.repository -}}
 {{- $tag := coalesce .component.tag .tempo.tag .defaultVersion | toString -}}
 {{- printf "%s/%s:%s" $registry $repository $tag -}}
@@ -38,7 +38,7 @@ Docker image selector for Tempo. Hierachy based on global, component, and tempo 
 Optional list of imagePullSecrets for Tempo docker images
 */}}
 {{- define "tempo.imagePullSecrets" -}}
-{{- $imagePullSecrets := coalesce .global.pullSecrets .component.pullSecrets .tempo.pullSecrets -}}
+{{- $imagePullSecrets := coalesce .component.pullSecrets .tempo.pullSecrets .global.pullSecrets -}}
 {{- if $imagePullSecrets  -}}
 imagePullSecrets:
 {{- range $imagePullSecrets }}


### PR DESCRIPTION
…njected

### Description
**Problem**
The coalesce function in _helpers.tpl had an incorrect priority order for registry and pullSecrets values. The global values were taking precedence over more specific tempo and component values, preventing proper overrides.

**Solution**
Changed the priority order in the helper functions to follow a logical hierarchy from most specific to least specific:

- component (highest priority) - Component-specific configuration (e.g., ingester, distributor)
- tempo - Tempo-wide configuration
- global (lowest priority) - Shared configuration across all charts

**Changes**
- tempo.tempoImage: Updated $registry coalesce order from .global.registry → .component.registry → .tempo.registry to .component.registry → .tempo.registry → .global.registry
tempo.imagePullSecrets: Updated $imagePullSecrets coalesce order from .global.pullSecrets → .component.pullSecrets → - .tempo.pullSecrets to .component.pullSecrets → .tempo.pullSecrets → .global.pullSecrets

**Impact**
This fix allows users to properly override global registry and pullSecrets settings at the tempo or component level, which is the expected behavior for Helm chart value inheritance.