### PR TITLE
[grafana] Update kiwigrid/k8s-sidecar tag to 2.2.1

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 10.5.0
+version: 10.5.1
 appVersion: 12.3.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -965,7 +965,7 @@ sidecar:
     # -- The Docker registry
     registry: quay.io
     repository: kiwigrid/k8s-sidecar
-    tag: 2.1.2
+    tag: 2.2.1
     sha: ""
   imagePullPolicy: IfNotPresent
   resources: {}


### PR DESCRIPTION
The v2 release of this image came paired with a very significant memory usage increase (see https://github.com/kiwigrid/k8s-sidecar/issues/462), which has subsequently been fixed (see https://github.com/kiwigrid/k8s-sidecar/pull/490) and released (see https://github.com/kiwigrid/k8s-sidecar/releases/tag/2.2.0).

Therefore I propose to update the tag to use the latest release.