### PR TITLE
[grafana] Add default label for Grafana ServiceMonitor

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 10.5.2
+version: 10.5.3
 appVersion: 12.3.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/servicemonitor.yaml
+++ b/charts/grafana/templates/servicemonitor.yaml
@@ -10,6 +10,7 @@ metadata:
   namespace: {{ include "grafana.namespace" . }}
   {{- end }}
   labels:
+    release: {{ $.Release.Name | quote }}
     {{- include "grafana.labels" . | nindent 4 }}
     {{- with .Values.serviceMonitor.labels }}
     {{- tpl (toYaml . | nindent 4) $ }}


### PR DESCRIPTION
#### What this PR does / why we need it

This change helps integration with other Helm charts that uses Prometheus.

This essentially fixes `kube-prometheus-stack`'s Grafana metrics scraping. When using the `grafana` chart as a subchart in `kube-prometheus-stack` , it was noticed that Grafana metrics are missing even though its corresponding `ServiceMonitor` [is enabled by default](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml#L1500-L1504). Prometheus instance in `kube-prometheus-stack` targets ServiceMonitors based on `release: {{ $.Release.Name | quote }}` label (check [here](https://github.com/prometheus-community/helm-charts/blob/005c29119ae48b901e0802190128c70edb13db71/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml#L189-L192)), but there is no label added accordingly by default to Grafana ServiceMonitor, causing failure to scrape Grafana metrics. One could argue that this label should be added on the `kube-prometheus-stack`'s side through values.yaml as Grafana ServiceMonitor enables templating labels from values.yaml, but this doesn't work as the label requires value from `.Release`. Adding this default label shouldn't hurt, and it would facilitate metrics scraping for other dependent instances.

Thank you!