### PR TITLE
[grafana] allow to use sidecar without probes

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 10.5.1
+version: 10.5.2
 appVersion: 12.3.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_helpers.tpl
+++ b/charts/grafana/templates/_helpers.tpl
@@ -143,11 +143,11 @@ Return the appropriate apiVersion for ingress.
 Return the appropriate apiVersion for Horizontal Pod Autoscaler.
 */}}
 {{- define "grafana.hpa.apiVersion" -}}
-{{- if .Capabilities.APIVersions.Has "autoscaling/v2" }}  
-{{- print "autoscaling/v2" }}  
-{{- else }}  
-{{- print "autoscaling/v2beta2" }}  
-{{- end }} 
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2" }}
+{{- print "autoscaling/v2" }}
+{{- else }}
+{{- print "autoscaling/v2beta2" }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -271,4 +271,68 @@ sensitiveKeys:
         {{- end -}}
       {{- end -}}
   {{- end -}}
+{{- end -}}
+
+{{/*
+ Sidecars health port
+ */}}
+
+{{/*
+ Give health port for alerts sidecar
+ */}}
+{{- define "grafana.sidecar.alerts.healthPort" -}}
+{{- $healthPort := 8081 -}}
+{{- if hasKey .Values.sidecar.alerts "startupProbe" -}}
+  {{- if hasKey .Values.sidecar.alerts.startupProbe "httpGet" -}}
+    {{- if hasKey .Values.sidecar.alerts.startupProbe.httpGet "port" -}}
+      {{- $healthPort = .Values.sidecar.alerts.startupProbe.httpGet.port -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $healthPort | quote -}}
+{{- end -}}
+
+{{/*
+ Give health port for datasources sidecar
+ */}}
+{{- define "grafana.sidecar.datasources.healthPort" -}}
+{{- $healthPort := 8082 -}}
+{{- if hasKey .Values.sidecar.datasources "startupProbe" -}}
+  {{- if hasKey .Values.sidecar.datasources.startupProbe "httpGet" -}}
+    {{- if hasKey .Values.sidecar.datasources.startupProbe.httpGet "port" -}}
+      {{- $healthPort = .Values.sidecar.datasources.startupProbe.httpGet.port -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $healthPort | quote -}}
+{{- end -}}
+
+{{/*
+ Give health port for notifiers sidecar
+ */}}
+{{- define "grafana.sidecar.notifiers.healthPort" -}}
+{{- $healthPort := 8083 -}}
+{{- if hasKey .Values.sidecar.notifiers "startupProbe" -}}
+  {{- if hasKey .Values.sidecar.notifiers.startupProbe "httpGet" -}}
+    {{- if hasKey .Values.sidecar.notifiers.startupProbe.httpGet "port" -}}
+      {{- $healthPort = .Values.sidecar.notifiers.startupProbe.httpGet.port -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $healthPort | quote -}}
+{{- end -}}
+
+{{/*
+ Give health port for dashboards sidecar
+ */}}
+{{- define "grafana.sidecar.dashboards.healthPort" -}}
+{{- $healthPort := 8084 -}}
+{{- if hasKey .Values.sidecar.dashboards "startupProbe" -}}
+  {{- if hasKey .Values.sidecar.dashboards.startupProbe "httpGet" -}}
+    {{- if hasKey .Values.sidecar.dashboards.startupProbe.httpGet "port" -}}
+      {{- $healthPort = .Values.sidecar.dashboards.startupProbe.httpGet.port -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $healthPort | quote -}}
 {{- end -}}

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -139,7 +139,7 @@ initContainers:
           {{- tpl (toYaml $value) $ | nindent 10 }}
       {{- end }}
       - name: HEALTH_PORT
-        value: "{{ .Values.sidecar.alerts.startupProbe.httpGet.port | default "8081" }}"
+        value: {{ include "grafana.sidecar.alerts.healthPort" . }}
       {{- if .Values.sidecar.alerts.ignoreAlreadyProcessed }}
       - name: IGNORE_ALREADY_PROCESSED
         value: "true"
@@ -235,7 +235,7 @@ initContainers:
           {{- tpl (toYaml $value) $ | nindent 10 }}
       {{- end }}
       - name: HEALTH_PORT
-        value: "{{ .Values.sidecar.datasources.startupProbe.httpGet.port | default "8082" }}"
+        value: {{ include "grafana.sidecar.datasources.healthPort" . }}
       {{- if .Values.sidecar.datasources.ignoreAlreadyProcessed }}
       - name: IGNORE_ALREADY_PROCESSED
         value: "true"
@@ -371,7 +371,7 @@ initContainers:
         value: "{{ $value }}"
       {{- end }}
       - name: HEALTH_PORT
-        value: "{{ .Values.sidecar.notifiers.startupProbe.httpGet.port | default "8083" }}"
+        value: {{ include "grafana.sidecar.notifiers.healthPort" . }}
       {{- if .Values.sidecar.notifiers.ignoreAlreadyProcessed }}
       - name: IGNORE_ALREADY_PROCESSED
         value: "true"
@@ -467,7 +467,7 @@ initContainers:
           {{- tpl (toYaml $value) $ | nindent 10 }}
       {{- end }}
       - name: HEALTH_PORT
-        value: "{{ .Values.sidecar.dashboards.startupProbe.httpGet.port | default "8084" }}"
+        value: {{ include "grafana.sidecar.dashboards.healthPort" . }}
       {{- if .Values.sidecar.dashboards.ignoreAlreadyProcessed }}
       - name: IGNORE_ALREADY_PROCESSED
         value: "true"


### PR DESCRIPTION
with #4046, sidecars mode works only if `startupProbe` is defined. this PR allows to use it without `startupProbe`.

Closes #4071 