### PR TITLE
[grafana] fix(unified): add ephemeral storage for search

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 10.5.3
+version: 10.5.4
 appVersion: 12.3.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -1294,6 +1294,8 @@ containers:
         {{- with .Values.persistence.subPath }}
         subPath: {{ tpl . $root }}
         {{- end }}
+      - name: search
+        mountPath: "/var/lib/grafana-search"
       {{- with .Values.dashboards }}
       {{- range $provider, $dashboards := . }}
       {{- range $key, $value := $dashboards }}
@@ -1618,6 +1620,8 @@ volumes:
     emptyDir: {}
     {{- end }}
   {{- end }}
+  - name: search
+    emptyDir: {}
   {{- if .Values.sidecar.alerts.enabled }}
   - name: sc-alerts-volume
     {{- if .Values.sidecar.alerts.sizeLimit }}


### PR DESCRIPTION
Newer Grafana versions enable Unified Search by default, which uses Bleve for indexing. Bleve locks its index files when using filesystem mode, causing pods to hang at startup when multiple replicas share the same PVC.

We temporally worked around that by falling back to in-memory indexing if the file locks cannot be obtained (https://github.com/grafana/grafana/pull/115720).

This change adds an `emptyDir` volume mounted at `/var/lib/grafana-search/bleve` (the default index path) so each pod gets its own ephemeral index storage, fixing the filesystem mode (no fallback to in-memory and no hanging behavior at startup).

Adjacent PR: https://github.com/grafana/grafana/pull/115953

Ticket: https://github.com/grafana/search-and-storage-team/issues/611