### PR TITLE
[grafana] fix(unified): set default index_path in chart

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 10.5.4
+version: 10.5.5
 appVersion: 12.3.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -1476,6 +1476,8 @@ containers:
         value: {{ (get .Values "grafana.ini").paths.plugins }}
       - name: GF_PATHS_PROVISIONING
         value: {{ (get .Values "grafana.ini").paths.provisioning }}
+      - name: GF_UNIFIED_STORAGE_INDEX_PATH
+        value: {{ (get .Values "grafana.ini").unified_storage.index_path }}
       {{- if (.Values.resources.limits).memory }}
       - name: GOMEMLIMIT
         valueFrom:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -893,6 +893,8 @@ grafana.ini:
     url: https://grafana.net
   server:
     domain: "{{ if (and .Values.ingress.enabled .Values.ingress.hosts) }}{{ tpl (.Values.ingress.hosts | first) . }}{{ else if (and .Values.route.main.enabled .Values.route.main.hostnames) }}{{ tpl (.Values.route.main.hostnames | first) . }}{{ else }}''{{ end }}"
+  unified_storage:
+    index_path: /var/lib/grafana-search/bleve
 ## grafana Authentication can be enabled with the following values on grafana.ini
  # server:
       # The full public facing url you use in browser, used for redirects and emails


### PR DESCRIPTION
Environment variables take precedence over config files, setting `index_path` this way guarantees that the ephemeral storage path is used even when a custom config file is provided.

The setting remains configurable via the `grafana.ini` section.

Follow-up from: https://github.com/grafana/helm-charts/pull/4073