### PR TITLE
[tempo] Add full volumeClaimTemplate spec when persistence is enabled

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 1.24.2
+version: 1.24.3
 appVersion: 2.9.0
 engine: gotpl
 home: https://grafana.net

--- a/charts/tempo/README.md
+++ b/charts/tempo/README.md
@@ -1,6 +1,6 @@
 # tempo
 
-![Version: 1.24.2](https://img.shields.io/badge/Version-1.24.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.0](https://img.shields.io/badge/AppVersion-2.9.0-informational?style=flat-square)
+![Version: 1.24.3](https://img.shields.io/badge/Version-1.24.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.0](https://img.shields.io/badge/AppVersion-2.9.0-informational?style=flat-square)
 
 Grafana Tempo Single Binary Mode
 

--- a/charts/tempo/templates/statefulset.yaml
+++ b/charts/tempo/templates/statefulset.yaml
@@ -191,7 +191,9 @@ spec:
     type: {{- toYaml .Values.tempo.updateStrategy | nindent 6 }}
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: storage
         annotations: {{- toYaml .Values.persistence.annotations | nindent 10 }}
       spec:


### PR DESCRIPTION
When deploying the Tempo helm chart with argocd and persistence is enabled, there is a diff between the templated resources and what is applied on the server:


<img width="1222" height="732" alt="image" src="https://github.com/user-attachments/assets/8eae8c28-cb76-4420-89fb-afcef3b6b03d" />

---

This causes argocd to mark the resource as out of sync and can issues with sync policies. This PR adds the full spec when persistence is enabled in order to avoid the out of sync issue.