### PR TITLE
Replace docker:// super-linter reference with GitHub Action format

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -31,7 +31,7 @@ jobs:
           fi
 
       - name: Lint Code Base
-        uses: docker://github/super-linter:v3.12.0
+        uses: github/super-linter@1977cb86e0809581e47de35c8adb22035e708ba9 # v3.12.0
         env:
           FILTER_REGEX_EXCLUDE: .*(README\.md|Chart\.yaml|NOTES.txt).*
           FILTER_REGEX_INCLUDE: ${{ inputs.filter_regex_include }}


### PR DESCRIPTION
## Summary

- Replaces `docker://github/super-linter:v3.12.0` with `github/super-linter@1977cb86e0809581e47de35c8adb22035e708ba9`
- The `docker://` action format is incompatible with org-level action allowlist policies
- Same image, same version, just using the standard `owner/repo@SHA` format