### PR TITLE
[rollout-operator] update chart for v0.36.0

### DIFF
--- a/charts/rollout-operator/Chart.yaml
+++ b/charts/rollout-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-operator
 description: "Grafana rollout-operator"
 type: application
-version: 0.45.0
-appVersion: v0.35.0
+version: 0.46.0
+appVersion: v0.36.0
 home: https://github.com/grafana/rollout-operator
 kubeVersion: ^1.10.0-0

--- a/charts/rollout-operator/README.md
+++ b/charts/rollout-operator/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana rollout-operator](https://github.com/grafana/r
 
 # rollout-operator
 
-![Version: 0.45.0](https://img.shields.io/badge/Version-0.45.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.35.0](https://img.shields.io/badge/AppVersion-v0.35.0-informational?style=flat-square)
+![Version: 0.46.0](https://img.shields.io/badge/Version-0.46.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.36.0](https://img.shields.io/badge/AppVersion-v0.36.0-informational?style=flat-square)
 
 Grafana rollout-operator
 


### PR DESCRIPTION
This updates the rollout-operator chart to correspond with the v0.36.0 release: https://github.com/grafana/rollout-operator/releases/tag/v0.36.0