### PR TITLE
fix(tempo-distributed): recreate job superfluous quotes, wrong rbac

### DIFF
--- a/charts/tempo-distributed/templates/_helpers.tpl
+++ b/charts/tempo-distributed/templates/_helpers.tpl
@@ -389,7 +389,7 @@ spec:
             - pvc
             - --namespace={{ $newStatefulSet.metadata.namespace }}
             - {{ printf "%s-%s-%d" $template $newStatefulSet.metadata.name $index }}
-            - --type='json'
+            - --type=json
             - '-p=[{"op": "replace", "path": "/spec/resources/requests/storage", "value": "{{ $size }}"}]'
           {{- end }}
         {{- end }}

--- a/charts/tempo-distributed/templates/_helpers.tpl
+++ b/charts/tempo-distributed/templates/_helpers.tpl
@@ -441,6 +441,7 @@ rules:
     {{- end }}
     verbs:
       - patch
+      - get
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/tempo-distributed/templates/_helpers.tpl
+++ b/charts/tempo-distributed/templates/_helpers.tpl
@@ -430,7 +430,7 @@ rules:
       - delete
   {{- if $templates }}
   - apiGroups:
-      - v1
+      - ""
     resources:
       - persistentvolumeclaims
     resourceNames:


### PR DESCRIPTION
This removes the superfluous and wrong quotes; kubectl doesn't accept them

Additionally; this fixes the RBAC needed for the job