### PR TITLE
feat: allow control of DNS config for the pods

### DIFF
--- a/charts/pdc-agent/README.md
+++ b/charts/pdc-agent/README.md
@@ -18,6 +18,7 @@ PDC agent is an agent for connecting to Grafana Private Data source Connect
 | annotations | object | `{}` | custom deployment annotations |
 | cluster | string | `""` | The cluster where your Hosted Grafana stack is running |
 | debug | bool | `false` | Enable debug logging for the agent. Useful for seeing SSH debug logs |
+| dnsConfig | object | `{}` |  Allows more control on the DNS settings for the Pod |
 | extraArgs | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | hostedGrafanaId | string | `""` | The numeric ID of your Hosted Grafana stack |

--- a/charts/pdc-agent/templates/deployment.yaml
+++ b/charts/pdc-agent/templates/deployment.yaml
@@ -109,3 +109,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/pdc-agent/values.yaml
+++ b/charts/pdc-agent/values.yaml
@@ -70,6 +70,9 @@ tolerations: []
 # --  not required, but left in as a choice
 affinity: {}
 
+# -- not required, but left in as a choice. DNS config for the agent pods. See https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config for more details.
+dnsConfig: {}
+
 # -- The port where metrics are served from the pdc agent
 metricsPort: 8090
 


### PR DESCRIPTION
This PR adds support for the dnsPolicy setting in PDC agent pods. This change serves two main purposes: first, it enables the use of custom DNS servers, which is often a requirement for on-premise compliance. Second, it helps mitigate well-documented DNS query issues encountered when using Alpine Linux images within Kubernetes environments.