### PR TITLE
[pdc-agent] Add deployment labels, secret-based cluster/hostedGrafanaId config, and extraEnv

### DIFF
--- a/charts/pdc-agent/Chart.yaml
+++ b/charts/pdc-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pdc-agent
 description: PDC agent is an agent for connecting to Grafana Private Data source Connect
 type: application
-appVersion: "0.0.45"
-version: 0.1.0
+appVersion: "0.0.57"
+version: 0.2.0
 home: https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/
 sources:
   - https://github.com/grafana/pdc-agent

--- a/charts/pdc-agent/README.md
+++ b/charts/pdc-agent/README.md
@@ -1,6 +1,6 @@
 # pdc-agent
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.45](https://img.shields.io/badge/AppVersion-0.0.45-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.57](https://img.shields.io/badge/AppVersion-0.0.57-informational?style=flat-square)
 
 PDC agent is an agent for connecting to Grafana Private Data source Connect
 
@@ -15,22 +15,28 @@ PDC agent is an agent for connecting to Grafana Private Data source Connect
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | not required, but left in as a choice |
-| annotations | object | `{}` | custom deployment annotations |
+| annotations | object | `{}` | Annotations to add the Deployment resource |
 | cluster | string | `""` | The cluster where your Hosted Grafana stack is running |
+| clusterSecretKey | string | `"cluster"` | Defines the key used to lookup the cluster value in the secret defined by `clusterSecretName`. |
+| clusterSecretName | string | `""` | If set, CLUSTER is read from this secret instead of the cluster value above |
 | debug | bool | `false` | Enable debug logging for the agent. Useful for seeing SSH debug logs |
 | extraArgs | list | `[]` |  |
+| extraEnv | list | `[]` | Extra environment variables to set on the pdc-agent container. Useful for configuring HTTP/HTTPS proxies or other runtime settings. |
 | fullnameOverride | string | `""` |  |
 | hostedGrafanaId | string | `""` | The numeric ID of your Hosted Grafana stack |
+| hostedGrafanaIdSecretKey | string | `"hosted-grafana-id"` | Defines the key used to lookup the hosted Grafana ID value in the secret defined by `hostedGrafanaIdSecretName`. |
+| hostedGrafanaIdSecretName | string | `""` | If set, HOSTED_GRAFANA_ID is read from this secret instead of the hostedGrafanaId value above |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"grafana/pdc-agent"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | insecureTokenValue | string | `""` | insecureTokenValue is used to set the token value directly in the deployment.yaml file. This is useful for testing purposes. |
+| labels | object | `{}` | Labels to add to the Deployment resource |
 | metricsPort | int | `8090` | The port where metrics are served from the pdc agent |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | not required, but left in as a choice |
-| podAnnotations | object | `{}` | custom pod annotations |
-| podLabels | object | `{}` |  |
+| podAnnotations | object | `{}` | Annotations to add to the Pod resource For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
+| podLabels | object | `{}` | Labels to add to the Pod resource For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ |
 | podSecurityContext.fsGroup | int | `30000` |  |
 | podSecurityContext.runAsGroup | int | `30000` |  |
 | podSecurityContext.runAsUser | int | `30000` |  |

--- a/charts/pdc-agent/templates/deployment.yaml
+++ b/charts/pdc-agent/templates/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "pdc-agent.fullname" . }}
   labels:
     {{- include "pdc-agent.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -69,9 +72,26 @@ spec:
               {{- fail "Either tokenSecretName or insecureTokenValue must be provided" }}
               {{- end }}
             - name: CLUSTER
+              {{- if .Values.clusterSecretName }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.clusterSecretName }}
+                  key: {{ default "cluster" .Values.clusterSecretKey | quote }}
+              {{- else }}
               value: {{ required "A cluster name is required" .Values.cluster | quote }}
+              {{- end }}
             - name: HOSTED_GRAFANA_ID
+              {{- if .Values.hostedGrafanaIdSecretName }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.hostedGrafanaIdSecretName }}
+                  key: {{ default "hosted-grafana-id" .Values.hostedGrafanaIdSecretKey | quote }}
+              {{- else }}
               value: {{ required "A Hosted Grafana stack ID is required" .Values.hostedGrafanaId | quote }}
+              {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           args:
             - -cluster
             - $(CLUSTER)

--- a/charts/pdc-agent/values.yaml
+++ b/charts/pdc-agent/values.yaml
@@ -19,15 +19,19 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-# This is for setting Kubernetes Labels to a Pod.
+# -- Annotations to add to the Pod resource
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+
+# -- Labels to add to the Pod resource
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
 
-# -- custom pod annotations
-podAnnotations: {}
-
-# -- custom deployment annotations
+# -- Annotations to add the Deployment resource
 annotations: {}
+
+# -- Labels to add to the Deployment resource
+labels: {}
 
 podSecurityContext:
   runAsUser: 30000
@@ -79,8 +83,16 @@ debug: false
 # For these values, see https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/configure-pdc/#pdc-connection-steps
 # -- The cluster where your Hosted Grafana stack is running
 cluster: ""
+# -- If set, CLUSTER is read from this secret instead of the cluster value above
+clusterSecretName: ""
+# -- Defines the key used to lookup the cluster value in the secret defined by `clusterSecretName`.
+clusterSecretKey: "cluster"
 # -- The numeric ID of your Hosted Grafana stack
 hostedGrafanaId: ""
+# -- If set, HOSTED_GRAFANA_ID is read from this secret instead of the hostedGrafanaId value above
+hostedGrafanaIdSecretName: ""
+# -- Defines the key used to lookup the hosted Grafana ID value in the secret defined by `hostedGrafanaIdSecretName`.
+hostedGrafanaIdSecretKey: "hosted-grafana-id"
 # -- tokenSecretName Expects a secret which contains the Access Policy token you generated. See `tokenSecretKey` for the key name under which the value is expected.
 tokenSecretName: ""
 # -- tokenSecretKey Defines the key that is used to lookup the token value in the secret defined by `tokenSecretName`.
@@ -93,3 +105,9 @@ insecureTokenValue: ""
 # https://github.com/grafana/pdc-agent/blob/main/pkg/pdc/client.go
 # https://github.com/grafana/pdc-agent/blob/main/cmd/pdc/main.go
 extraArgs: []
+
+# -- Extra environment variables to set on the pdc-agent container.
+# Useful for configuring HTTP/HTTPS proxies or other runtime settings.
+extraEnv: []
+# - name: HTTP_PROXY
+#   value: "http://proxy.example.com:8080"


### PR DESCRIPTION
## Summary

- Add `labels` value to set custom labels on the Deployment resource (closes #4021)
- Add `clusterSecretName`/`clusterSecretKey` to load `CLUSTER` from a Kubernetes secret (closes #4043)
- Add `hostedGrafanaIdSecretName`/`hostedGrafanaIdSecretKey` to load `HOSTED_GRAFANA_ID` from a Kubernetes secret (closes #4043)
- Add `extraEnv` to inject additional environment variables into the pdc-agent container, e.g. for HTTP proxy configuration (closes #4048)
- Bump appVersion to `0.0.57`, chart version to `0.2.0`

## Notes

All new values are optional with empty/default values, so this is fully backwards compatible.

Users who want all three configuration values from a single secret can point `tokenSecretName`, `clusterSecretName`, and `hostedGrafanaIdSecretName` at the same secret name with their respective keys.