### PR TITLE
ci: fix typo in update-helm-repo workflow

### DIFF
--- a/.github/workflows/update-helm-repo.yaml
+++ b/.github/workflows/update-helm-repo.yaml
@@ -143,7 +143,7 @@ jobs:
         env:
           HELM_REPO_TOKEN: ${{ secrets.helm_repo_token }}
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
-          GATB_TOKEN: ${{ steps.get-github-app-token.outputs.github_token }}
+          GATB_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
           GITHUB_APP_INPUT: ${{ inputs.github_app }}
         run: |
           if [[ -n "${GITHUB_APP_INPUT}" ]]; then


### PR DESCRIPTION
Fixup for https://github.com/grafana/helm-charts/pull/4164

The original PR came with a typo: the output of the "create-github-app-token" action is `token` — not `github_token` (ref https://github.com/grafana/shared-workflows/blob/7ae85085c0bed854b41785ba266604b08e50abe0/actions/create-github-app-token/action.yaml#L14-L17)

cc @simaarfania 

Testing the changes in this Mimir branch https://github.com/grafana/mimir/tree/refs/heads/vrnkn/push-txxkzlzrvmvv — everything works now ([example][1] ✅ )

[1]: https://github.com/grafana/mimir/actions/runs/26229349411/job/77185200639