### PR TITLE
feat(tempo-distributed): add unhealthyPodEvictionPolicy support to PodDisruptionBudget templates

### DIFF
--- a/charts/tempo-distributed/templates/compactor/poddisruptionbudget-compactor.yaml
+++ b/charts/tempo-distributed/templates/compactor/poddisruptionbudget-compactor.yaml
@@ -10,4 +10,7 @@ spec:
     matchLabels:
       {{- include "tempo.compactorSelectorLabels" . | nindent 6 }}
   maxUnavailable: 1
+  {{- with .Values.compactor.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
@@ -10,4 +10,7 @@ spec:
     matchLabels:
       {{- include "tempo.distributorSelectorLabels" . | nindent 6 }}
   maxUnavailable: 1
+  {{- with .Values.distributor.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/gateway/poddisruptionbudget-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/poddisruptionbudget-gateway.yaml
@@ -10,4 +10,7 @@ spec:
     matchLabels:
       {{- include "tempo.gatewaySelectorLabels" . | nindent 6 }}
   maxUnavailable: 1
+  {{- with .Values.gateway.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
@@ -10,4 +10,7 @@ spec:
     matchLabels:
       {{- include "tempo.ingesterSelectorLabels" . | nindent 6 }}
   maxUnavailable: 1
+  {{- with .Values.ingester.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/memcached/poddisruptionbudget-memcached.yaml
+++ b/charts/tempo-distributed/templates/memcached/poddisruptionbudget-memcached.yaml
@@ -10,4 +10,7 @@ spec:
     matchLabels:
       {{- include "tempo.memcachedSelectorLabels" . | nindent 6 }}
   maxUnavailable: 1
+  {{- with .Values.memcached.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/metrics-generator/poddisruptionbudget-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/poddisruptionbudget-metrics-generator.yaml
@@ -11,5 +11,8 @@ spec:
     matchLabels:
       {{- include "tempo.metricsGeneratorSelectorLabels" . | nindent 6 }}
   maxUnavailable: 1
+  {{- with .Values.metricsGenerator.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/querier/poddisruptionbudget-querier.yaml
+++ b/charts/tempo-distributed/templates/querier/poddisruptionbudget-querier.yaml
@@ -10,4 +10,7 @@ spec:
     matchLabels:
       {{- include "tempo.querierSelectorLabels" . | nindent 6 }}
   maxUnavailable: 1
+  {{- with .Values.querier.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/query-frontend/poddisruptionbudget-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/poddisruptionbudget-query-frontend.yaml
@@ -10,4 +10,7 @@ spec:
     matchLabels:
       {{- include "tempo.queryFrontendSelectorLabels" . | nindent 6 }}
   maxUnavailable: 1
+  {{- with .Values.queryFrontend.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -63,6 +63,9 @@ ingester:
   annotations: {}
   # -- Number of replicas for the ingester
   replicas: 3
+  podDisruptionBudget:
+    # -- Set unhealthyPodEvictionPolicy for the ingester PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
   autoscaling:
     # -- Enable autoscaling for the ingester
     enabled: false
@@ -157,6 +160,9 @@ metricsGenerator:
   annotations: {}
   # -- Number of replicas for the metrics-generator
   replicas: 1
+  podDisruptionBudget:
+    # -- Set unhealthyPodEvictionPolicy for the metrics-generator PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
   image:
     # -- The Docker registry for the metrics-generator image. Overrides `tempo.image.registry`
     registry: null
@@ -230,6 +236,9 @@ metricsGenerator:
 distributor:
   # -- Number of replicas for the distributor
   replicas: 1
+  podDisruptionBudget:
+    # -- Set unhealthyPodEvictionPolicy for the distributor PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
   autoscaling:
     # -- Enable autoscaling for the distributor
     enabled: false
@@ -306,6 +315,9 @@ distributor:
     search_tags_deny_list: []
 
 compactor:
+  podDisruptionBudget:
+    # -- Set unhealthyPodEvictionPolicy for the compactor PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
   image:
     # -- The Docker registry for the compactor image. Overrides `tempo.image.registry`
     registry: null
@@ -349,6 +361,9 @@ compactor:
 querier:
   # -- Number of replicas for the querier
   replicas: 1
+  podDisruptionBudget:
+    # -- Set unhealthyPodEvictionPolicy for the querier PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
   image:
     # -- The Docker registry for the querier image. Overrides `tempo.image.registry`
     registry: null
@@ -429,6 +444,9 @@ queryFrontend:
       backend: 127.0.0.1:3100
   # -- Number of replicas for the query-frontend
   replicas: 1
+  podDisruptionBudget:
+    # -- Set unhealthyPodEvictionPolicy for the query-frontend PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
   autoscaling:
     # -- Enable autoscaling for the query-frontend
     enabled: false
@@ -752,6 +770,9 @@ memcached:
   host: memcached
   # Number of replicas for memchached
   replicas: 1
+  podDisruptionBudget:
+    # -- Set unhealthyPodEvictionPolicy for the memcached PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
   service: memcached-client
   # -- Memcached Docker image repository
   repository: memcached
@@ -855,6 +876,9 @@ gateway:
   enabled: false
   # -- Number of replicas for the gateway
   replicas: 1
+  podDisruptionBudget:
+    # -- Set unhealthyPodEvictionPolicy for the gateway PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
   autoscaling:
     # -- Enable autoscaling for the gateway
     enabled: false


### PR DESCRIPTION
## What

Adds `podDisruptionBudget.unhealthyPodEvictionPolicy` values key to all components in the tempo-distributed chart (ingester, distributor, compactor, querier, query-frontend, metrics-generator, memcached, gateway).

The field is wired into each PDB template with `{{- with ... }}` so it is omitted entirely when empty, preserving backwards compatibility.

## Why

`unhealthyPodEvictionPolicy` was added to `policy/v1` PodDisruptionBudget in Kubernetes 1.26 (GA in 1.27). Without this field, linters and admission webhooks enforcing `AlwaysAllow` flag misconfigured PDBs.

## Usage

```yaml
ingester:
  podDisruptionBudget:
    unhealthyPodEvictionPolicy: AlwaysAllow
```

Valid values: `AlwaysAllow`, `IfHealthyBudget`, or omit (default, field not rendered).

## Notes

- Requires `policy/v1` (Kubernetes 1.21+). The templates currently use `policy/v1beta1` which was removed in 1.25 — a separate issue.
- Default is empty string (field omitted) for full backwards compatibility.