### PR TITLE
[tempo-distributed] add unhealthyPodEvictionPolicy support to PodDisruptionBudget

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.61.3
+version: 1.62.0
 appVersion: 2.9.0
 deprecated: true
 engine: gotpl

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.61.3](https://img.shields.io/badge/Version-1.61.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.0](https://img.shields.io/badge/AppVersion-2.9.0-informational?style=flat-square)
+![Version: 1.62.0](https://img.shields.io/badge/Version-1.62.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.0](https://img.shields.io/badge/AppVersion-2.9.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -356,8 +356,9 @@ The memcached default args are removed and should be provided manually. The sett
 | compactor.minReadySeconds | int | `10` | Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing/terminating |
 | compactor.nodeSelector | object | `{}` | Node selector for compactor pods |
 | compactor.podAnnotations | object | `{}` | Annotations for compactor pods |
-| compactor.podDisruptionBudget | object | `{"enabled":true}` | Pod Disruption Budget configuration |
+| compactor.podDisruptionBudget | object | `{"enabled":true,"unhealthyPodEvictionPolicy":""}` | Pod Disruption Budget configuration |
 | compactor.podDisruptionBudget.enabled | bool | `true` | Enable PodDisruptionBudget for compactor |
+| compactor.podDisruptionBudget.unhealthyPodEvictionPolicy | string | `""` | Set unhealthyPodEvictionPolicy for the compactor PodDisruptionBudget. Requires policy/v1. |
 | compactor.podLabels | object | `{}` | Labels for compactor pods |
 | compactor.priorityClassName | string | `nil` | The name of the PriorityClass for compactor pods |
 | compactor.replicas | int | `1` | Number of replicas for the compactor |
@@ -406,8 +407,9 @@ The memcached default args are removed and should be provided manually. The sett
 | distributor.minReadySeconds | int | `10` | Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing/terminating |
 | distributor.nodeSelector | object | `{}` | Node selector for distributor pods |
 | distributor.podAnnotations | object | `{}` | Annotations for distributor pods |
-| distributor.podDisruptionBudget | object | `{"enabled":true}` | Pod Disruption Budget configuration |
+| distributor.podDisruptionBudget | object | `{"enabled":true,"unhealthyPodEvictionPolicy":""}` | Pod Disruption Budget configuration |
 | distributor.podDisruptionBudget.enabled | bool | `true` | Enable PodDisruptionBudget for distributor |
+| distributor.podDisruptionBudget.unhealthyPodEvictionPolicy | string | `""` | Set unhealthyPodEvictionPolicy for the distributor PodDisruptionBudget. Requires policy/v1. |
 | distributor.podLabels | object | `{}` | Labels for distributor pods |
 | distributor.priorityClassName | string | `nil` | The name of the PriorityClass for distributor pods |
 | distributor.replicas | int | `1` | Number of replicas for the distributor |
@@ -559,8 +561,9 @@ The memcached default args are removed and should be provided manually. The sett
 | gateway.nginxConfig.serverSnippet | string | `""` | Allows appending custom configuration to the server block |
 | gateway.nodeSelector | object | `{}` | Node selector for gateway pods |
 | gateway.podAnnotations | object | `{}` | Annotations for gateway pods |
-| gateway.podDisruptionBudget | object | `{"enabled":true}` | Pod Disruption Budget configuration |
+| gateway.podDisruptionBudget | object | `{"enabled":true,"unhealthyPodEvictionPolicy":""}` | Pod Disruption Budget configuration |
 | gateway.podDisruptionBudget.enabled | bool | `true` | Enable PodDisruptionBudget for gateway |
+| gateway.podDisruptionBudget.unhealthyPodEvictionPolicy | string | `""` | Set unhealthyPodEvictionPolicy for the gateway PodDisruptionBudget. Requires policy/v1. |
 | gateway.podLabels | object | `{}` | Labels for gateway pods |
 | gateway.priorityClassName | string | `nil` | The name of the PriorityClass for gateway pods |
 | gateway.readinessProbe.httpGet.path | string | `"/"` |  |
@@ -636,8 +639,9 @@ The memcached default args are removed and should be provided manually. The sett
 | ingester.persistentVolumeClaimRetentionPolicy.whenDeleted | string | `"Retain"` | Volume retention behavior that applies when the StatefulSet is deleted |
 | ingester.persistentVolumeClaimRetentionPolicy.whenScaled | string | `"Retain"` | Volume retention behavior when the replica count of the StatefulSet is reduced |
 | ingester.podAnnotations | object | `{}` | Annotations for ingester pods |
-| ingester.podDisruptionBudget | object | `{"enabled":true}` | Pod Disruption Budget configuration |
+| ingester.podDisruptionBudget | object | `{"enabled":true,"unhealthyPodEvictionPolicy":""}` | Pod Disruption Budget configuration |
 | ingester.podDisruptionBudget.enabled | bool | `true` | Enable PodDisruptionBudget for ingester |
+| ingester.podDisruptionBudget.unhealthyPodEvictionPolicy | string | `""` | Set unhealthyPodEvictionPolicy for the ingester PodDisruptionBudget. Requires policy/v1. |
 | ingester.podLabels | object | `{}` | Labels for ingester pods |
 | ingester.priorityClassName | string | `nil` | The name of the PriorityClass for ingester pods |
 | ingester.replicas | int | `3` | Number of replicas for the ingester |
@@ -709,8 +713,9 @@ The memcached default args are removed and should be provided manually. The sett
 | memcached.livenessProbe | object | `{"failureThreshold":6,"initialDelaySeconds":30,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | configuration for liveness probe for memcached statefulset |
 | memcached.maxUnavailable | int | `1` | Pod Disruption Budget maxUnavailable |
 | memcached.podAnnotations | object | `{}` | Annotations for memcached pods |
-| memcached.podDisruptionBudget | object | `{"enabled":true}` | Pod Disruption Budget configuration |
+| memcached.podDisruptionBudget | object | `{"enabled":true,"unhealthyPodEvictionPolicy":""}` | Pod Disruption Budget configuration |
 | memcached.podDisruptionBudget.enabled | bool | `true` | Enable PodDisruptionBudget for memcached |
+| memcached.podDisruptionBudget.unhealthyPodEvictionPolicy | string | `""` | Set unhealthyPodEvictionPolicy for the memcached PodDisruptionBudget. Requires policy/v1. |
 | memcached.podLabels | object | `{}` | Labels for memcached pods |
 | memcached.readinessProbe | object | `{"failureThreshold":6,"initialDelaySeconds":5,"periodSeconds":5,"successThreshold":1,"tcpSocket":{"port":"client"},"timeoutSeconds":3}` | configuration for readiness probe for memcached statefulset |
 | memcached.replicas | int | `1` |  |
@@ -795,8 +800,9 @@ The memcached default args are removed and should be provided manually. The sett
 | metricsGenerator.persistentVolumeClaimRetentionPolicy.whenDeleted | string | `"Retain"` | Volume retention behavior that applies when the StatefulSet is deleted |
 | metricsGenerator.persistentVolumeClaimRetentionPolicy.whenScaled | string | `"Retain"` | Volume retention behavior when the replica count of the StatefulSet is reduced |
 | metricsGenerator.podAnnotations | object | `{}` | Annotations for metrics-generator pods |
-| metricsGenerator.podDisruptionBudget | object | `{"enabled":true}` | Pod Disruption Budget configuration |
+| metricsGenerator.podDisruptionBudget | object | `{"enabled":true,"unhealthyPodEvictionPolicy":""}` | Pod Disruption Budget configuration |
 | metricsGenerator.podDisruptionBudget.enabled | bool | `true` | Enable PodDisruptionBudget for metrics-generator |
+| metricsGenerator.podDisruptionBudget.unhealthyPodEvictionPolicy | string | `""` | Set unhealthyPodEvictionPolicy for the metrics-generator PodDisruptionBudget. Requires policy/v1. |
 | metricsGenerator.podLabels | object | `{}` | Labels for metrics-generator pods |
 | metricsGenerator.ports | list | `[{"name":"grpc","port":9095,"service":true},{"name":"http-memberlist","port":7946,"service":false},{"name":"http-metrics","port":3200,"service":true}]` | Default ports |
 | metricsGenerator.priorityClassName | string | `nil` | The name of the PriorityClass for metrics-generator pods |
@@ -887,8 +893,9 @@ The memcached default args are removed and should be provided manually. The sett
 | querier.minReadySeconds | int | `10` | Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing/terminating |
 | querier.nodeSelector | object | `{}` | Node selector for querier pods |
 | querier.podAnnotations | object | `{}` | Annotations for querier pods |
-| querier.podDisruptionBudget | object | `{"enabled":true}` | Pod Disruption Budget configuration |
+| querier.podDisruptionBudget | object | `{"enabled":true,"unhealthyPodEvictionPolicy":""}` | Pod Disruption Budget configuration |
 | querier.podDisruptionBudget.enabled | bool | `true` | Enable PodDisruptionBudget for querier |
+| querier.podDisruptionBudget.unhealthyPodEvictionPolicy | string | `""` | Set unhealthyPodEvictionPolicy for the querier PodDisruptionBudget. Requires policy/v1. |
 | querier.podLabels | object | `{}` | Labels for querier pods |
 | querier.priorityClassName | string | `nil` | The name of the PriorityClass for querier pods |
 | querier.replicas | int | `1` | Number of replicas for the querier |
@@ -942,8 +949,9 @@ The memcached default args are removed and should be provided manually. The sett
 | queryFrontend.minReadySeconds | int | `10` | Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing/terminating |
 | queryFrontend.nodeSelector | object | `{}` | Node selector for query-frontend pods |
 | queryFrontend.podAnnotations | object | `{}` | Annotations for query-frontend pods |
-| queryFrontend.podDisruptionBudget | object | `{"enabled":true}` | Pod Disruption Budget configuration |
+| queryFrontend.podDisruptionBudget | object | `{"enabled":true,"unhealthyPodEvictionPolicy":""}` | Pod Disruption Budget configuration |
 | queryFrontend.podDisruptionBudget.enabled | bool | `true` | Enable PodDisruptionBudget for query-frontend |
+| queryFrontend.podDisruptionBudget.unhealthyPodEvictionPolicy | string | `""` | Set unhealthyPodEvictionPolicy for the query-frontend PodDisruptionBudget. Requires policy/v1. |
 | queryFrontend.podLabels | object | `{}` | Labels for queryFrontend pods |
 | queryFrontend.priorityClassName | string | `nil` | The name of the PriorityClass for query-frontend pods |
 | queryFrontend.query.config | string | `"backend: 127.0.0.1:3200\n"` |  |

--- a/charts/tempo-distributed/templates/compactor/poddisruptionbudget-compactor.yaml
+++ b/charts/tempo-distributed/templates/compactor/poddisruptionbudget-compactor.yaml
@@ -12,4 +12,7 @@ spec:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6 }}
   maxUnavailable: {{ .Values.compactor.maxUnavailable }}
+  {{- with .Values.compactor.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
@@ -12,4 +12,7 @@ spec:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6 }}
   maxUnavailable: {{ .Values.distributor.maxUnavailable }}
+  {{- with .Values.distributor.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/gateway/poddisruptionbudget-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/poddisruptionbudget-gateway.yaml
@@ -12,4 +12,7 @@ spec:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6 }}
   maxUnavailable: {{ .Values.gateway.maxUnavailable }}
+  {{- with .Values.gateway.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
@@ -12,4 +12,7 @@ spec:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6 }}
   maxUnavailable: {{ default (sub (.Values.ingester.replicas) (add (div .Values.ingester.config.replication_factor 2) 1)) .Values.ingester.maxUnavailable }}
+  {{- with .Values.ingester.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/memcached/poddisruptionbudget-memcached.yaml
+++ b/charts/tempo-distributed/templates/memcached/poddisruptionbudget-memcached.yaml
@@ -12,4 +12,7 @@ spec:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6 }}
   maxUnavailable: {{ .Values.memcached.maxUnavailable }}
+  {{- with .Values.memcached.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/metrics-generator/poddisruptionbudget-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/poddisruptionbudget-metrics-generator.yaml
@@ -13,5 +13,8 @@ spec:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6 }}
   maxUnavailable: {{ .Values.metricsGenerator.maxUnavailable }}
+  {{- with .Values.metricsGenerator.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/querier/poddisruptionbudget-querier.yaml
+++ b/charts/tempo-distributed/templates/querier/poddisruptionbudget-querier.yaml
@@ -12,4 +12,7 @@ spec:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6 }}
   maxUnavailable: {{ .Values.querier.maxUnavailable }}
+  {{- with .Values.querier.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/query-frontend/poddisruptionbudget-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/poddisruptionbudget-query-frontend.yaml
@@ -12,4 +12,7 @@ spec:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6 }}
   maxUnavailable: {{ .Values.queryFrontend.maxUnavailable }}
+  {{- with .Values.queryFrontend.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -226,6 +226,8 @@ ingester:
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for ingester
     enabled: true
+    # -- Set unhealthyPodEvictionPolicy for the ingester PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
   # -- Override Pod Disruption Budget maxUnavailable with a static value
   # maxUnavailable: 1
   # -- Node selector for ingester pods
@@ -433,6 +435,8 @@ metricsGenerator:
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for metrics-generator
     enabled: true
+    # -- Set unhealthyPodEvictionPolicy for the metrics-generator PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
   # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   # -- Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing/terminating
@@ -642,6 +646,8 @@ distributor:
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for distributor
     enabled: true
+    # -- Set unhealthyPodEvictionPolicy for the distributor PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
   # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   # -- Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing/terminating
@@ -787,6 +793,8 @@ compactor:
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for compactor
     enabled: true
+    # -- Set unhealthyPodEvictionPolicy for the compactor PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
   # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   # -- Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing/terminating
@@ -911,6 +919,8 @@ querier:
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for querier
     enabled: true
+    # -- Set unhealthyPodEvictionPolicy for the querier PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
   # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   # -- Max Surge for querier pods
@@ -1133,6 +1143,8 @@ queryFrontend:
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for query-frontend
     enabled: true
+    # -- Set unhealthyPodEvictionPolicy for the query-frontend PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
   # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   # -- Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing/terminating
@@ -1848,6 +1860,8 @@ memcached:
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for memcached
     enabled: true
+    # -- Set unhealthyPodEvictionPolicy for the memcached PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
   # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   # -- Init containers for the memcached pod
@@ -2146,6 +2160,8 @@ gateway:
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for gateway
     enabled: true
+    # -- Set unhealthyPodEvictionPolicy for the gateway PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
   # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   # -- Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing/terminating


### PR DESCRIPTION
## What

Adds optional `unhealthyPodEvictionPolicy` support to the `PodDisruptionBudget` resources for all components in `tempo-distributed`: ingester, distributor, compactor, querier, query-frontend, metrics-generator, memcached, and gateway.

The field is controlled via `<component>.podDisruptionBudget.unhealthyPodEvictionPolicy` in `values.yaml`. It defaults to `""` (empty string), which causes the `{{- with }}` block to be skipped entirely, preserving existing behavior for anyone not setting the field.

```yaml
ingester:
  podDisruptionBudget:
    enabled: true
    unhealthyPodEvictionPolicy: "AlwaysAllow"  # or "IfHealthyBudget"
```

## Why

`unhealthyPodEvictionPolicy` on `policy/v1` PodDisruptionBudgets (GA in Kubernetes 1.26) is required by certain linters (e.g. kube-linter `pdb-unhealthy-pod-eviction-policy` check) and is a useful safety knob when running Tempo components in production clusters with strict eviction policies.

Without this field being configurable via values, users cannot satisfy the check or tune eviction behavior without patching the templates themselves.

## Scope

- 8 PDB templates updated (one per component)
- `values.yaml`: `unhealthyPodEvictionPolicy: ""` added inside each existing `podDisruptionBudget:` block
- Chart version bumped: `1.61.3` → `1.62.0`