### PR TITLE
fix(tempo): use tempo-query config for query frontend sidecar

### DIFF
--- a/charts/tempo-distributed/templates/query-frontend/deployment-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/deployment-query-frontend.yaml
@@ -120,7 +120,7 @@ spec:
             {{- end }}
         {{- if .Values.queryFrontend.query.enabled }}
         - args:
-            - -config=/conf/tempo.yaml
+            - -config=/conf/tempo-query.yaml
             {{- with .Values.queryFrontend.query.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
The tempo-query sidecar in query-frontend was started with the main Tempo config:
-config=/conf/tempo.yaml

This is incorrect because tempo-query has its own generated configuration file:
/conf/tempo-query.yaml

The argument has been changed to:
-config=/conf/tempo-query.yaml

This ensures that the tempo-query container reads the configuration generated from
queryFrontend.query.config instead of the main Tempo configuration.