### PR TITLE
Sign the index.yaml commit pushed to gh-pages

### DIFF
--- a/.github/workflows/update-helm-repo.yaml
+++ b/.github/workflows/update-helm-repo.yaml
@@ -154,6 +154,22 @@ jobs:
             echo "AUTHTOKEN=${APP_TOKEN}" >> $GITHUB_ENV
           fi
 
+      # The cr tool requires a checkout of the target repository so that it can `git worktree
+      # add origin/<pages-branch>`. We check the gh-pages branch out at the workspace root so
+      # that planetscale/ghcommit-action (which runs from $GITHUB_WORKSPACE) can later commit
+      # the regenerated index.yaml via the GitHub API.
+      #
+      # This step runs BEFORE the source checkout because actions/checkout with no `path:`
+      # empties the target directory before cloning, which would otherwise wipe source/.
+      - name: Checkout helm-charts gh-pages
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          fetch-depth: 0
+          repository: grafana/helm-charts
+          ref: gh-pages
+          token: ${{ env.AUTHTOKEN }}
+          persist-credentials: false
+
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6 # zizmor: ignore[artipacked] without this ignore comment, zizmor would complain that persist-credentials is not explicitly set to false. We need it set to true (default) to be able to push the release tags later on in this workflow
         with:
@@ -163,21 +179,6 @@ jobs:
       - name: Configure Git
         run: |
           cd source
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Checkout helm-charts
-        # The cr tool only works if the target repository is already checked out
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6 # zizmor: ignore[artipacked] without this ignore comment, zizmor would complain that persist-credentials is not explicitly set to false. We need it set to true (default) to be able to push the release tags later on in this workflow
-        with:
-          fetch-depth: 0
-          repository: grafana/helm-charts
-          path: helm-charts
-          token: ${{ env.AUTHTOKEN }}
-
-      - name: Configure Git for helm-charts
-        run: |
-          cd helm-charts
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
@@ -272,10 +273,28 @@ jobs:
           echo "Pushing tag ${TAGNAME}"
           git push origin "${TAGNAME}"
 
-      - name: Update helm repo index.yaml
+      # Generate the new index.yaml without pushing — cr writes the merged file to
+      # ${CR_INDEX_PATH}/index.yaml, leaving the gh-pages working tree (at the workspace root)
+      # untouched. We then stage it for ghcommit-action below.
+      - name: Generate helm repo index.yaml
         run: |
-          cd helm-charts
-          "${CR_TOOL_PATH}/cr" index --config "${CR_CONFIGFILE}" --token "${{ env.AUTHTOKEN }}" --index-path "${CR_INDEX_PATH}" --package-path "${CR_PACKAGE_PATH}" --push
+          "${CR_TOOL_PATH}/cr" index --config "${CR_CONFIGFILE}" --token "${{ env.AUTHTOKEN }}" --index-path "${CR_INDEX_PATH}" --package-path "${CR_PACKAGE_PATH}"
+          cp "${CR_INDEX_PATH}/index.yaml" index.yaml
+
+      # Publish index.yaml to gh-pages via the GitHub GraphQL `createCommitOnBranch` mutation
+      # so the commit is signed by GitHub's web-flow key (shown as Verified). The cr tool's
+      # built-in `--push` produces an unsigned commit, which breaks for repositories with
+      # "Require signed commits" branch protection. See https://github.com/helm/chart-releaser/issues/625
+      # for upstream tracking of a `cr` flag that would make this workaround unnecessary.
+      - name: Publish index.yaml to gh-pages
+        uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20
+        with:
+          commit_message: "Update index.yaml for ${{ steps.parse-chart.outputs.tagname }}"
+          repo: grafana/helm-charts
+          branch: gh-pages
+          file_pattern: index.yaml
+        env:
+          GITHUB_TOKEN: ${{ env.AUTHTOKEN }}
 
       - name: Login to GHCR
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0


### PR DESCRIPTION
## Summary

Replace `cr index --push` with `cr index` (no push) + `planetscale/ghcommit-action`, so the resulting commit on `gh-pages` is signed by GitHub's web-flow key and shows as **Verified**.

## Why

`cr index --push` calls `git commit` + `git push` internally (see `pkg/git/git.go` in `helm/chart-releaser`), producing an unsigned commit. This breaks for consumers of this reusable workflow whose `gh-pages` branch has "Require signed commits" branch protection enabled, and weakens the audit/provenance story for any consumer that requires Verified commits across the artifact-publishing chain.

## How

- Reorder the checkouts so the gh-pages branch is checked out first, at the workspace root. `actions/checkout` with no `path:` empties the target directory before cloning, so doing it second would wipe the `source/` subdir checked out earlier. With it first, the source checkout into `path: source` happens into a sibling subdir and both coexist.
- Drop the now-unneeded `path: helm-charts` checkout (which previously held the default-branch clone that `cr index --push` worked from) and its `Configure Git for helm-charts` step. cr will still find `origin/gh-pages` because the workspace-root checkout is on that branch with full history.
- Drop `--push` from the `cr index` invocation so it only regenerates `index.yaml` locally at `${CR_INDEX_PATH}/index.yaml`; copy the file to the workspace-root `index.yaml` so it appears as a modification to the gh-pages working tree.
- Use `planetscale/ghcommit-action` with `file_pattern: index.yaml` to commit just that one file via `createCommitOnBranch`.

Token, permissions, and the source-tree checkout used for chart packaging are unchanged.

## Tracking the upstream improvement

Filed helm/chart-releaser#625 asking whether the `cr` maintainers would take a `--sign-commits` flag that does this same thing inside the tool. If that lands, this workflow can drop the manual file-copy + ghcommit-action and go back to one-line cr usage.

## Test plan

Tested end-to-end in https://github.com/pracucci/helm-charts-test (sandbox, no secrets):

1. **Sandbox set up** by cloning this PR's workflow into the test repo, replacing the three hardcoded `grafana/helm-charts` refs with `pracucci/helm-charts-test`.
2. **Tiny chart added** at `charts/test-chart/` (Chart.yaml, single ConfigMap template, values.yaml) plus matching `cr.yaml` / `ct.yaml` at the root.
3. **Caller workflow added** at `.github/workflows/release.yml` invoking the reusable workflow on `workflow_dispatch`, passing `helm_repo_token: ${{ secrets.GITHUB_TOKEN }}`.
4. **`gh-pages` seeded** as an orphan branch with a minimal `index.yaml`.
5. **Chart version bumped** so `ct list-changed` detects a diff vs the root commit (without a bump it sees nothing and the release job is skipped).
6. **Workflow triggered** with `gh workflow run release.yml` and watched green end-to-end.
7. **Bot commit verified** at https://github.com/pracucci/helm-charts-test/commit/ba6b2f439d on `gh-pages`: `verification.verified: true`, `reason: valid`; committer `GitHub <noreply@github.com>`, author `github-actions[bot]`; only `index.yaml` modified (+13/-2); content matches what `cr index` produced.

### Notable findings

- **`ct list-changed` saw no diff** initially because the chart was added in the same commit as `since` — fix: bump chart version on a follow-up commit.
- **`Parse Chart.yaml` step lost `source/`** because `actions/checkout` at the workspace root empties the target before cloning (regardless of `clean:`). Fix in this PR: reorder checkouts so gh-pages runs first; source then lands into the empty `source/` subdir untouched.