### PR TITLE
feat(pdc-agent): add extraVolumes and extraVolumeMounts support

### DIFF
--- a/charts/pdc-agent/Chart.yaml
+++ b/charts/pdc-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: pdc-agent
 description: PDC agent is an agent for connecting to Grafana Private Data source Connect
 type: application
 appVersion: "0.0.57"
-version: 0.2.0
+version: 0.3.0
 home: https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/
 sources:
   - https://github.com/grafana/pdc-agent

--- a/charts/pdc-agent/README.md
+++ b/charts/pdc-agent/README.md
@@ -1,6 +1,6 @@
 # pdc-agent
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.57](https://img.shields.io/badge/AppVersion-0.0.57-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.57](https://img.shields.io/badge/AppVersion-0.0.57-informational?style=flat-square)
 
 PDC agent is an agent for connecting to Grafana Private Data source Connect
 
@@ -22,6 +22,8 @@ PDC agent is an agent for connecting to Grafana Private Data source Connect
 | debug | bool | `false` | Enable debug logging for the agent. Useful for seeing SSH debug logs |
 | extraArgs | list | `[]` |  |
 | extraEnv | list | `[]` | Extra environment variables to set on the pdc-agent container. Useful for configuring HTTP/HTTPS proxies or other runtime settings. |
+| extraVolumeMounts | list | `[]` | Additional volume mounts to add to the pdc-agent container. Corresponds to `extraVolumes`. |
+| extraVolumes | list | `[]` | Additional volumes to add to the Pod. Use this to mount Secrets, ConfigMaps or other volumes. |
 | fullnameOverride | string | `""` |  |
 | hostedGrafanaId | string | `""` | The numeric ID of your Hosted Grafana stack |
 | hostedGrafanaIdSecretKey | string | `"hosted-grafana-id"` | Defines the key used to lookup the hosted Grafana ID value in the secret defined by `hostedGrafanaIdSecretName`. |

--- a/charts/pdc-agent/templates/deployment.yaml
+++ b/charts/pdc-agent/templates/deployment.yaml
@@ -106,16 +106,26 @@ spec:
             {{- range .Values.extraArgs }}
             - {{ . }}
             {{- end }}
-          {{- if .Values.securityContext.readOnlyRootFilesystem }}
+          {{- if or .Values.securityContext.readOnlyRootFilesystem .Values.extraVolumeMounts }}
           volumeMounts:
+            {{- if .Values.securityContext.readOnlyRootFilesystem }}
             - mountPath: /home/pdc/
               name: ssh-cache
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
-      {{- if .Values.securityContext.readOnlyRootFilesystem }}
+      {{- if or .Values.securityContext.readOnlyRootFilesystem .Values.extraVolumes }}
       volumes:
+        {{- if .Values.securityContext.readOnlyRootFilesystem }}
         - name: ssh-cache
           emptyDir:
             sizeLimit: 50Mi
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/pdc-agent/values.yaml
+++ b/charts/pdc-agent/values.yaml
@@ -111,3 +111,16 @@ extraArgs: []
 extraEnv: []
 # - name: HTTP_PROXY
 #   value: "http://proxy.example.com:8080"
+
+# -- Additional volumes to add to the Pod. Use this to mount Secrets, ConfigMaps or other volumes.
+extraVolumes: []
+# - name: custom-ca
+#   secret:
+#     secretName: custom-ca
+
+# -- Additional volume mounts to add to the pdc-agent container. Corresponds to `extraVolumes`.
+extraVolumeMounts: []
+# - name: custom-ca
+#   mountPath: /etc/ssl/certs/custom-ca.pem
+#   subPath: ca.pem
+#   readOnly: true


### PR DESCRIPTION
Add support for mounting additional volumes (e.g. Secrets, ConfigMaps) into the pdc-agent pod and container, following the convention used by other charts in this repo (promtail, enterprise-logs).

The new extraVolumeMounts/extraVolumes values merge with the existing ssh-cache volume that is mounted when securityContext.readOnlyRootFilesystem is enabled, and the volumes/volumeMounts blocks are omitted entirely when neither source is set, preserving existing behavior.

Bumps chart version 0.2.0 -> 0.3.0.