### PR TITLE
[rollout-operator] - bump to v0.38.0

### DIFF
--- a/charts/rollout-operator/Chart.yaml
+++ b/charts/rollout-operator/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: rollout-operator
 description: "Grafana rollout-operator"
 type: application
-version: 0.49.0
-appVersion: v0.36.2
+version: 0.50.0
+appVersion: v0.38.0
 home: https://github.com/grafana/rollout-operator
 kubeVersion: ^1.10.0-0
 dependencies:
   - name: crds
-    version: "0.0.0"
+    version: "0.1.0"
     condition: crds.enabled

--- a/charts/rollout-operator/README.md
+++ b/charts/rollout-operator/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana rollout-operator](https://github.com/grafana/r
 
 # rollout-operator
 
-![Version: 0.49.0](https://img.shields.io/badge/Version-0.49.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.36.2](https://img.shields.io/badge/AppVersion-v0.36.2-informational?style=flat-square)
+![Version: 0.50.0](https://img.shields.io/badge/Version-0.50.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.38.0](https://img.shields.io/badge/AppVersion-v0.38.0-informational?style=flat-square)
 
 Grafana rollout-operator
 
@@ -14,7 +14,7 @@ Kubernetes: `^1.10.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-|  | crds | 0.0.0 |
+|  | crds | 0.1.0 |
 
 ## Installation
 
@@ -39,7 +39,17 @@ helm install  -n <namespace> <release> grafana/rollout-operator
 The Grafana rollout-operator should be installed in the same namespace as the statefulsets it is operating upon.
 It is not a highly available application and runs as a single pod.
 
-### Upgrade of Grafana Rollout Operator
+### Upgrade of Grafana Rollout Operator <= v0.38.0
+
+v0.38.0 of the rollout-operator introduced a new option for enforcing a "fixed delay" in partition aware PDB evictions.
+
+This requires an updated CRD and an additional role for the rollout-operator to patch pods.
+
+***Before upgrading to this version, make sure that the CustomResourceDefinitions (CRDs) shipped with the chart are applied to your cluster.***
+
+Additionally, make sure that the updated roles have been assigned.
+
+### Upgrade of Grafana Rollout Operator <= v0.32.0
 
 Starting with v0.33.0 of the rollout-operator chart, the rollout-operator webhooks are enabled. See https://github.com/grafana/rollout-operator/#webhooks.
 

--- a/charts/rollout-operator/README.md.gotmpl
+++ b/charts/rollout-operator/README.md.gotmpl
@@ -35,7 +35,17 @@ helm install  -n <namespace> <release> grafana/rollout-operator
 The Grafana rollout-operator should be installed in the same namespace as the statefulsets it is operating upon.
 It is not a highly available application and runs as a single pod.
 
-### Upgrade of Grafana Rollout Operator
+### Upgrade of Grafana Rollout Operator <= v0.38.0
+
+v0.38.0 of the rollout-operator introduced a new option for enforcing a "fixed delay" in partition aware PDB evictions.
+
+This requires an updated CRD and an additional role for the rollout-operator to patch pods.
+
+***Before upgrading to this version, make sure that the CustomResourceDefinitions (CRDs) shipped with the chart are applied to your cluster.***
+
+Additionally, make sure that the updated roles have been assigned.
+
+### Upgrade of Grafana Rollout Operator <= v0.32.0
 
 Starting with v0.33.0 of the rollout-operator chart, the rollout-operator webhooks are enabled. See https://github.com/grafana/rollout-operator/#webhooks.
 

--- a/charts/rollout-operator/charts/crds/Chart.yaml
+++ b/charts/rollout-operator/charts/crds/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: crds
 description: Grafana rollout-operator CRDs
-version: 0.0.0
+version: 0.1.0
 type: application

--- a/charts/rollout-operator/charts/crds/README.md
+++ b/charts/rollout-operator/charts/crds/README.md
@@ -1,6 +1,6 @@
 # crds
 
-![Version: 0.0.0](https://img.shields.io/badge/Version-0.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Grafana rollout-operator CRDs
 

--- a/charts/rollout-operator/charts/crds/crds/zone-aware-pod-disruption-budget-custom-resource-definition.yaml
+++ b/charts/rollout-operator/charts/crds/crds/zone-aware-pod-disruption-budget-custom-resource-definition.yaml
@@ -42,7 +42,10 @@ spec:
                 podNameRegexGroup:
                   type: integer
                   minimum: 1
-                  description: The regular expression group number that contains the partition name. This field is only required when the podNamePartitionRegex field is set and has more then one subexpression grouping. The default value is 1.
+                  description: The regular expression capture group number that contains the partition name. This field is only required when the podNamePartitionRegex field is set and has more then one grouping. The default value is 1 and 1-based indexing is used.
+                crossZoneEvictionDelay:
+                  type: string
+                  description: An optional duration that defines the minimum time that must elapse after a pod returns to a ready state before another pod for the same partition can be evicted. The value must be a valid Go duration string (e.g. "20m", "1h"). This field is only applicable when podNamePartitionRegex is set.
       subresources:
         status: {}
   scope: Namespaced
@@ -51,4 +54,4 @@ spec:
     plural: zoneawarepoddisruptionbudgets
     singular: zoneawarepoddisruptionbudget
     shortNames:
-      - zdpb
+      - zpdb

--- a/charts/rollout-operator/templates/deployment.yaml
+++ b/charts/rollout-operator/templates/deployment.yaml
@@ -58,6 +58,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - -kubernetes.namespace={{ .Release.Namespace }}
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           {{- if .Values.webhooks.enabled }}
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name={{ .Values.webhooks.selfSignedCertSecretName }}

--- a/charts/rollout-operator/templates/role.yaml
+++ b/charts/rollout-operator/templates/role.yaml
@@ -15,6 +15,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:


### PR DESCRIPTION
This PR bumps the rollout-operator chart to v0.38.0.

Note that this bump includes an updated CRD and the sub-chart has been updated accordingly.