### PR TITLE
Fix the `git describe` in `update-helm-repo` to be Helm-centered

### DIFF
--- a/.github/workflows/update-helm-repo.yaml
+++ b/.github/workflows/update-helm-repo.yaml
@@ -73,7 +73,13 @@ jobs:
         run: |
           cd source
 
-          latest_tag=$( if ! git describe --tags --abbrev=0 2> /dev/null ; then git rev-list --max-parents=0 --first-parent HEAD ; fi )
+          # When a helm tag prefix is configured, restrict the comparison base
+          # to tags like "<prefix>-*". Otherwise, match any tag.
+          describe_match=()
+          if [[ -n "${HELM_TAG_PREFIX}" ]]; then
+            describe_match=(--match "${HELM_TAG_PREFIX}-*")
+          fi
+          latest_tag=$( if ! git describe --tags --abbrev=0 "${describe_match[@]}" 2> /dev/null ; then git rev-list --max-parents=0 --first-parent HEAD ; fi )
 
           echo "Running: ct list-changed --config ${CT_CONFIGFILE} --since ${latest_tag} --target-branch ${REF_NAME}"
           changed=$(ct list-changed --config "${CT_CONFIGFILE}" --since "${latest_tag}" --target-branch "${REF_NAME}")


### PR DESCRIPTION
Current `update-helm-repo` workflow decides whether to make a Helm chart release based on diff from the latest tag. But the latest tag may not necessarily be Helm-related which can lead to a wrong decision.

Background. I'm currently [re-working](https://github.com/grafana/k6-operator/pull/821) release procedure in k6-operator so that both the main app and Helm chart are published simultaneously, with automations. And in that case, `update-helm-repo` may see the latest tag from the operator release (like `v1.2.3`) on HEAD and decide to skip the Helm release. To avoid that, it should instead check the latest _Helm release tag_ which has a configured prefix.

I was diagnosing this case with LLM's help, and this PR is meant to prevent a likely failure on the next release with my new release procedure. The fix adds stricter guarantees:
- users of the workflow who configure the prefix will have this more precise lookup of the previous Helm tag;
- users of the workflow who don't configure the prefix aren't impacted.
