### PR TITLE
feat: add keyless cosign to helm-repo-update.yaml

### DIFF
--- a/.github/workflows/publish-public-signing-key.yaml
+++ b/.github/workflows/publish-public-signing-key.yaml
@@ -1,0 +1,48 @@
+name: Publish public signing key
+
+# Publishes the Helm chart signing public key to the gh-pages branch as pubkey.gpg
+# (a binary/dearmored GPG keyring) so users can import it and verify chart provenance:
+#   curl https://grafana.github.io/helm-charts/pubkey.gpg | gpg --import
+# See the "Helm Provenance and Integrity" section of the README.
+on:
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # allows fetching the signing key from Vault via OIDC
+      contents: write # allows committing pubkey.gpg to the gh-pages branch
+    steps:
+      # ghcommit-action computes the file change against the checked-out branch, so we
+      # check out gh-pages at the workspace root and write pubkey.gpg there.
+      - name: Checkout gh-pages
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          ref: gh-pages
+          persist-credentials: false
+
+      - name: Fetch public signing key from Vault
+        uses: grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760 # v1.1.0
+        with:
+          repo_secrets: |
+            PUBLIC_KEY=helm-chart-signing-key:public_key
+
+      - name: Convert ASCII-armored key to binary GPG keyring
+        run: |
+          printf '%s' "${PUBLIC_KEY}" | gpg --dearmor > pubkey.gpg
+
+      # Commit via the GitHub GraphQL `createCommitOnBranch` mutation so the commit is signed
+      # by GitHub's web-flow key (shown as Verified). This matches how index.yaml is published
+      # and works with the "Require signed commits" branch protection on gh-pages.
+      - name: Publish pubkey.gpg to gh-pages
+        uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20
+        with:
+          commit_message: "Publish Helm chart public signing key (pubkey.gpg)"
+          repo: ${{ github.repository }}
+          branch: gh-pages
+          file_pattern: pubkey.gpg
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-helm-repo.yaml
+++ b/.github/workflows/update-helm-repo.yaml
@@ -291,6 +291,12 @@ jobs:
           PACKAGENAME: ${{ steps.parse-chart.outputs.packagename }}
         run: |
           helm verify --keyring "${{ runner.temp }}/secring.gpg" "${CR_PACKAGE_PATH}/${PACKAGENAME}.tgz"
+
+      # TEMPORARY (testing): stop here so a run exercises package + sign + verify without cutting a
+      # release (no tag, GitHub release, index.yaml commit, or GHCR push). Remove before merging.
+      - name: Stop before release (testing only)
+        run: |
+          echo "::notice::Stopped after verify for testing; skipping tag/release/index/GHCR. Remove this step before merging."
           exit 1
 
       - name: Create tag and check if exists on origin

--- a/.github/workflows/update-helm-repo.yaml
+++ b/.github/workflows/update-helm-repo.yaml
@@ -291,6 +291,7 @@ jobs:
           PACKAGENAME: ${{ steps.parse-chart.outputs.packagename }}
         run: |
           helm verify --keyring "${{ runner.temp }}/secring.gpg" "${CR_PACKAGE_PATH}/${PACKAGENAME}.tgz"
+          exit 1
 
       - name: Create tag and check if exists on origin
         env:

--- a/.github/workflows/update-helm-repo.yaml
+++ b/.github/workflows/update-helm-repo.yaml
@@ -296,13 +296,6 @@ jobs:
         run: |
           helm verify --keyring "${{ runner.temp }}/secring.gpg" "${CR_PACKAGE_PATH}/${PACKAGENAME}.tgz"
 
-      # TEMPORARY (testing): stop here so a run exercises package + sign + verify without cutting a
-      # release (no tag, GitHub release, index.yaml commit, or GHCR push). Remove before merging.
-      - name: Stop before release (testing only)
-        run: |
-          echo "::notice::Stopped after verify for testing; skipping tag/release/index/GHCR. Remove this step before merging."
-          exit 1
-
       - name: Create tag and check if exists on origin
         env:
           TAGNAME: ${{ steps.parse-chart.outputs.tagname }}

--- a/.github/workflows/update-helm-repo.yaml
+++ b/.github/workflows/update-helm-repo.yaml
@@ -232,14 +232,65 @@ jobs:
           tar -xzf cr.tar.gz -C "${CR_TOOL_PATH}"
           rm -f cr.tar.gz
 
+
+      - name: Determine if chart signing is enabled
+        id: signing
+        run: |
+          enabled=false
+          if [[ -f "${CR_CONFIGFILE}" ]]; then
+            enabled=$(yq '.sign // false' "${CR_CONFIGFILE}")
+          fi
+          echo "enabled=${enabled}" >> "${GITHUB_OUTPUT}"
+          echo "Chart signing enabled (from ${CR_CONFIGFILE}): ${enabled}"
+
+      - name: Fetch GPG signing key from Vault
+        if: steps.signing.outputs.enabled == 'true'
+        uses: grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760 # v1.1.0
+        
+        with:
+          common_secrets: |
+            GPG_PRIVATE_KEY=helm-chart-signing-key:private_key
+            GPG_PASSPHRASE=helm-chart-signing-key:passphrase
+            GPG_KEY_NAME=helm-chart-signing-key:key_name
+
+      - name: Configure GPG for chart signing
+        if: steps.signing.outputs.enabled == 'true'
+        env:
+          GPG_KEYRING: "${{ runner.temp }}/secring.gpg"
+          GPG_PASSPHRASE_FILE: "${{ runner.temp }}/gpg-passphrase"
+        run: |
+          mkdir -p "${HOME}/.gnupg"
+          chmod 0700 "${HOME}/.gnupg"
+          printf 'use-agent\npinentry-mode loopback\n' > "${HOME}/.gnupg/gpg.conf"
+          printf 'allow-loopback-pinentry\n' > "${HOME}/.gnupg/gpg-agent.conf"
+          gpgconf --kill gpg-agent
+          gpgconf --launch gpg-agent
+          printf '%s' "${GPG_PRIVATE_KEY}" | gpg --batch --yes --import
+          gpg --batch --yes --pinentry-mode loopback --passphrase "${GPG_PASSPHRASE}" \
+            --export-secret-keys "${GPG_KEY_NAME}" > "${GPG_KEYRING}"
+          printf '%s' "${GPG_PASSPHRASE}" > "${GPG_PASSPHRASE_FILE}"
+
       - name: Create helm package
         env:
           CHARTPATH: ${{ steps.parse-chart.outputs.chartpath }}
+          # Signing config consumed by `cr`. cr signs only when cr.yaml sets `sign: true`; when it
+          # does not these are inert (the keyring/passphrase files won't exist, cr won't read them,
+          # and CR_KEY is empty because the Vault step did not run).
+          CR_KEY: ${{ env.GPG_KEY_NAME }}
+          CR_KEYRING: "${{ runner.temp }}/secring.gpg"
+          CR_PASSPHRASE_FILE: "${{ runner.temp }}/gpg-passphrase"
         run: |
           cd source
           "${CR_TOOL_PATH}/cr" package "${CHARTPATH}" --config "${CR_CONFIGFILE}" --package-path "${CR_PACKAGE_PATH}"
           echo "Result of chart package:"
           ls -l "${CR_PACKAGE_PATH}"
+
+      - name: Verify signed package
+        if: steps.signing.outputs.enabled == 'true'
+        env:
+          PACKAGENAME: ${{ steps.parse-chart.outputs.packagename }}
+        run: |
+          helm verify --keyring "${{ runner.temp }}/secring.gpg" "${CR_PACKAGE_PATH}/${PACKAGENAME}.tgz"
 
       - name: Create tag and check if exists on origin
         env:

--- a/.github/workflows/update-helm-repo.yaml
+++ b/.github/workflows/update-helm-repo.yaml
@@ -138,6 +138,11 @@ jobs:
           app-id: ${{ env.GITHUB_APP_ID }}
           private-key: ${{ env.PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          # AUTHTOKEN only operates on the central helm-charts repository (checkout gh-pages,
+          # create the release, and push the index.yaml commit), so scope the token to that
+          # single repo with just contents:write instead of blanket installation access.
+          repositories: helm-charts
+          permission-contents: write
 
       - name: Set the correct token (Github App or PAT)
         env:
@@ -307,20 +312,30 @@ jobs:
           git tag "${TAGNAME}"
 
       - name: Make github release
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # tags/v1
-        with:
-          body: |
-            ${{ steps.parse-chart.outputs.desc }}
+        env:
+          GH_TOKEN: ${{ env.AUTHTOKEN }}
+          TAGNAME: ${{ steps.parse-chart.outputs.tagname }}
+          DESC: ${{ steps.parse-chart.outputs.desc }}
+          PACKAGENAME: ${{ steps.parse-chart.outputs.packagename }}
+        run: |
+          # The .prov provenance file only exists when chart signing is enabled; include it
+          # only when present (action-gh-release silently skipped missing files).
+          assets=( "${CR_PACKAGE_PATH}/${PACKAGENAME}.tgz" )
+          if [[ -f "${CR_PACKAGE_PATH}/${PACKAGENAME}.tgz.prov" ]]; then
+            assets+=( "${CR_PACKAGE_PATH}/${PACKAGENAME}.tgz.prov" )
+          fi
+          notes="$(cat <<EOF
+          ${DESC}
 
-            Source commit: https://github.com/${{ github.repository }}/commit/${{ github.sha }}
+          Source commit: https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}
 
-            Tag on source: https://github.com/${{ github.repository }}/releases/tag/${{ steps.parse-chart.outputs.tagname }}
-          files: |
-            ${{ env.CR_PACKAGE_PATH }}/${{ steps.parse-chart.outputs.packagename }}.tgz
-            ${{ env.CR_PACKAGE_PATH }}/${{ steps.parse-chart.outputs.packagename }}.tgz.prov
-          repository: grafana/helm-charts
-          tag_name: ${{ steps.parse-chart.outputs.tagname }}
-          token: ${{ env.AUTHTOKEN }}
+          Tag on source: https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAGNAME}
+          EOF
+          )"
+          gh release create "${TAGNAME}" "${assets[@]}" \
+            --repo grafana/helm-charts \
+            --title "${TAGNAME}" \
+            --notes "${notes}"
 
       - name: Push release tag on origin
         env:
@@ -335,7 +350,7 @@ jobs:
       # untouched. We then stage it for ghcommit-action below.
       - name: Generate helm repo index.yaml
         run: |
-          "${CR_TOOL_PATH}/cr" index --config "${CR_CONFIGFILE}" --token "${{ env.AUTHTOKEN }}" --index-path "${CR_INDEX_PATH}" --package-path "${CR_PACKAGE_PATH}"
+          "${CR_TOOL_PATH}/cr" index --config "${CR_CONFIGFILE}" --token "${AUTHTOKEN}" --index-path "${CR_INDEX_PATH}" --package-path "${CR_PACKAGE_PATH}"
           cp "${CR_INDEX_PATH}/index.yaml" index.yaml
 
       # Publish index.yaml to gh-pages via the GitHub GraphQL `createCommitOnBranch` mutation

--- a/.github/workflows/update-helm-repo.yaml
+++ b/.github/workflows/update-helm-repo.yaml
@@ -104,9 +104,10 @@ jobs:
     needs: [setup]
     runs-on: ubuntu-latest
     permissions:
-      id-token: write # allows GitHub App to generate id-token from Github's OIDC
+      id-token: write # allows GitHub App to generate id-token from Github's OIDC, and keyless cosign signing via Fulcio
       contents: write # allows GITHUB_TOKEN to push chart release, create release, and push tags to github
       packages: write # allows GITHUB_TOKEN to push package to ghcr
+      attestations: write # allows attaching SLSA build provenance to the pushed OCI chart
     env:
       # APP_ID and PRIVATE_KEY are overwritten by credentials from vault, if configured
       GITHUB_APP_ID: ${{ secrets.github_app_id }}
@@ -204,6 +205,7 @@ jobs:
           version=$(yq ".version" < ${changed}/Chart.yaml)
           echo "chartpath=${changed}" >> $GITHUB_OUTPUT
           echo "desc=${description}" >> $GITHUB_OUTPUT
+          echo "name=${name}" >> $GITHUB_OUTPUT
           if [[ -n "${HELM_TAG_PREFIX}" ]]; then
             echo "tagname=${HELM_TAG_PREFIX}-${name}-${version}" >> $GITHUB_OUTPUT
           else
@@ -371,7 +373,49 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push charts to GHCR
+        id: push
         env:
           PACKAGENAME: ${{ steps.parse-chart.outputs.packagename }}
+          CHARTNAME: ${{ steps.parse-chart.outputs.name }}
         run: |
-          helm push "${CR_PACKAGE_PATH}/${PACKAGENAME}.tgz" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/helm-charts"
+          oci_repo="ghcr.io/${GITHUB_REPOSITORY_OWNER}/helm-charts"
+          helm push "${CR_PACKAGE_PATH}/${PACKAGENAME}.tgz" "oci://${oci_repo}" 2>&1 | tee push-output.txt
+          digest=$(awk '/Digest: /{print $2}' push-output.txt)
+          if [[ -z "${digest}" ]]; then
+            echo "Could not determine the digest of the pushed chart" >&2
+            exit 1
+          fi
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          echo "image=${oci_repo}/${CHARTNAME}" >> "$GITHUB_OUTPUT"
+          echo "oci_ref=${oci_repo}/${CHARTNAME}@${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign chart with cosign (keyless)
+        env:
+          OCI_REF: ${{ steps.push.outputs.oci_ref }}
+        run: |
+          cosign sign --yes "${OCI_REF}"
+
+      - name: Generate SBOM for the chart package
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          file: ${{ env.CR_PACKAGE_PATH }}/${{ steps.parse-chart.outputs.packagename }}.tgz
+          format: spdx-json
+          output-file: ${{ github.workspace }}/sbom.spdx.json
+          upload-artifact: false
+
+      - name: Attach SBOM attestation (keyless)
+        env:
+          OCI_REF: ${{ steps.push.outputs.oci_ref }}
+          SBOM_PATH: ${{ github.workspace }}/sbom.spdx.json
+        run: |
+          cosign attest --yes --type spdxjson --predicate "${SBOM_PATH}" "${OCI_REF}"
+
+      - name: Attach SLSA build provenance attestation
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ${{ steps.push.outputs.image }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/update-helm-repo.yaml
+++ b/.github/workflows/update-helm-repo.yaml
@@ -246,9 +246,8 @@ jobs:
       - name: Fetch GPG signing key from Vault
         if: steps.signing.outputs.enabled == 'true'
         uses: grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760 # v1.1.0
-        
         with:
-          common_secrets: |
+          repo_secrets: |
             GPG_PRIVATE_KEY=helm-chart-signing-key:private_key
             GPG_PASSPHRASE=helm-chart-signing-key:passphrase
             GPG_KEY_NAME=helm-chart-signing-key:key_name

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ export CHART=grafana
 export VERSION=9.0.0
 export OCI_REF="ghcr.io/grafana/helm-charts/${CHART}:${VERSION}"
 
-export CERT_IDENTITY="^https://github.com/grafana/helm-charts/.github/workflows/update-helm-repo.yaml@.*$"
+export CERT_IDENTITY="^https://github\.com/grafana/helm-charts/\.github/workflows/update-helm-repo\.yaml@.*$"
 export CERT_ISSUER="https://token.actions.githubusercontent.com"
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,64 @@ Once your keyring is configured, pass the `--verify` flag to `helm install`,
 `helm upgrade`, `helm pull`, or `helm template` to validate a chart's signature and
 confirm its authenticity.
 
+## Verifying OCI charts with Cosign
+
+In addition to the GPG provenance described above, charts are also published as OCI
+artifacts to the GitHub Container Registry (GHCR) under `ghcr.io/grafana/helm-charts`.
+Each pushed chart is keyless-signed with [Cosign](https://docs.sigstore.dev/) using the
+release workflow's GitHub Actions identity (via Sigstore/Fulcio), and ships with two
+attestations:
+
+- an **SPDX SBOM** describing the chart package's contents, and
+- a **SLSA build provenance** statement describing how and where the chart was built.
+
+[Install Cosign](https://docs.sigstore.dev/system_config/installation/) (v2 or newer),
+then set the chart you want to verify along with the signing identity. The signatures and
+attestations are all produced by the reusable release workflow, so the keyless certificate
+identity is stable regardless of which chart triggered the release:
+
+```console
+export CHART=grafana
+export VERSION=9.0.0
+export OCI_REF="ghcr.io/grafana/helm-charts/${CHART}:${VERSION}"
+
+export CERT_IDENTITY="^https://github.com/grafana/helm-charts/.github/workflows/update-helm-repo.yaml@.*$"
+export CERT_ISSUER="https://token.actions.githubusercontent.com"
+```
+
+Verify the chart signature:
+
+```console
+cosign verify "${OCI_REF}" \
+  --certificate-identity-regexp "${CERT_IDENTITY}" \
+  --certificate-oidc-issuer "${CERT_ISSUER}"
+```
+
+Verify the SBOM attestation:
+
+```console
+cosign verify-attestation "${OCI_REF}" \
+  --type spdxjson \
+  --certificate-identity-regexp "${CERT_IDENTITY}" \
+  --certificate-oidc-issuer "${CERT_ISSUER}"
+```
+
+Verify the SLSA build provenance attestation:
+
+```console
+cosign verify-attestation "${OCI_REF}" \
+  --type slsaprovenance1 \
+  --certificate-identity-regexp "${CERT_IDENTITY}" \
+  --certificate-oidc-issuer "${CERT_ISSUER}"
+```
+
+A successful run prints the validated certificate identity and, for attestations, the
+decoded predicate. The build provenance can alternatively be verified with the GitHub CLI:
+
+```console
+gh attestation verify "oci://${OCI_REF}" --owner grafana
+```
+
 ## Contributing
 
 <!-- Keep full URL links to repo files because this README syncs from main to gh-pages.  -->

--- a/README.md
+++ b/README.md
@@ -21,6 +21,31 @@ You can then run `helm search repo grafana` to see the charts.
 <!-- Keep full URL links to repo files because this README syncs from main to gh-pages.  -->
 Chart documentation is available in [grafana directory](https://github.com/grafana/helm-charts/blob/main/charts/grafana/README.md).
 
+## Helm Provenance and Integrity
+
+Charts in this repository may be signed, allowing you to verify their integrity and
+origin. More information about how provenance works can be found in the official
+[Helm documentation](https://helm.sh/docs/topics/provenance/).
+
+A local running GPG agent is required to complete the verification process.
+
+To add the public signing key to your keyring, run:
+
+```console
+curl https://grafana.github.io/helm-charts/pubkey.gpg | gpg --import
+```
+
+Depending on your GnuPG version (2.1+ in particular), you may need to export the
+imported key so that Helm can find it:
+
+```console
+gpg --export > ~/.gnupg/pubring.gpg
+```
+
+Once your keyring is configured, pass the `--verify` flag to `helm install`,
+`helm upgrade`, `helm pull`, or `helm template` to validate a chart's signature and
+confirm its authenticity.
+
 ## Contributing
 
 <!-- Keep full URL links to repo files because this README syncs from main to gh-pages.  -->


### PR DESCRIPTION
Add support for cosign, SBMO and SLSA to the `update-helm-repo.yaml` action. This means anyone using the action also automatically gets keyless cosign support for the actions pushed the the OCI registry (GHCR in our case).