### PR TITLE
[rollout-operator] bump to v0.38.1

### DIFF
--- a/charts/rollout-operator/Chart.yaml
+++ b/charts/rollout-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rollout-operator
 description: "Grafana rollout-operator"
 type: application
-version: 0.50.0
-appVersion: v0.38.0
+version: 0.50.1
+appVersion: v0.38.1
 home: https://github.com/grafana/rollout-operator
 kubeVersion: ^1.10.0-0
 dependencies:

--- a/charts/rollout-operator/README.md
+++ b/charts/rollout-operator/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana rollout-operator](https://github.com/grafana/r
 
 # rollout-operator
 
-![Version: 0.50.0](https://img.shields.io/badge/Version-0.50.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.38.0](https://img.shields.io/badge/AppVersion-v0.38.0-informational?style=flat-square)
+![Version: 0.50.1](https://img.shields.io/badge/Version-0.50.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.38.1](https://img.shields.io/badge/AppVersion-v0.38.1-informational?style=flat-square)
 
 Grafana rollout-operator
 


### PR DESCRIPTION
## Summary
- release rollout-operator chart 0.50.1
- update the chart application version to rollout-operator v0.38.1
- regenerate chart documentation

Made with [Cursor](https://cursor.com)