### PR TITLE
[update-helm-repo] scope GitHub App token to fix zizmor github-app findings

### DIFF
--- a/.github/workflows/update-helm-repo.yaml
+++ b/.github/workflows/update-helm-repo.yaml
@@ -138,6 +138,8 @@ jobs:
           app-id: ${{ env.GITHUB_APP_ID }}
           private-key: ${{ env.PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: helm-charts
+          permission-contents: write
 
       - name: Set the correct token (Github App or PAT)
         env:


### PR DESCRIPTION
## What

Scopes the `actions/create-github-app-token@v2` step in `update-helm-repo.yaml` down to just the `helm-charts` repository and `contents: write` permission.

```yaml
          repositories: helm-charts
          permission-contents: write
```

## Why

CI zizmor raised two high-severity `github-app` findings on this step:

1. **Blanket repository access** — `owner:` was set with no `repositories:` scope, so the token could access every repo in the app installation.
2. **Blanket permissions** — no `permission-*` inputs, so the token inherited all installation permissions.

## Verification

Traced every use of the resulting `AUTHTOKEN`; all target `grafana/helm-charts` and the strongest permission needed is `contents: write`:

| Use | Target | Needs |
|-----|--------|-------|
| Checkout `gh-pages` | grafana/helm-charts | contents:read |
| GitHub release | grafana/helm-charts | contents:write |
| `cr index --token` | grafana/helm-charts | contents:read |
| Publish index.yaml via `createCommitOnBranch` | grafana/helm-charts | contents:write |

The GHCR push uses `secrets.GITHUB_TOKEN` and the source tag push uses the default checkout credentials — neither relies on this app token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)