### PR TITLE
[rollout-operator] render serviceMonitor.labels on ServiceMonitor

### DIFF
--- a/charts/rollout-operator/Chart.yaml
+++ b/charts/rollout-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-operator
 description: "Grafana rollout-operator"
 type: application
-version: 0.50.1
+version: 0.50.2
 appVersion: v0.38.1
 home: https://github.com/grafana/rollout-operator
 kubeVersion: ^1.10.0-0

--- a/charts/rollout-operator/templates/servicemonitor.yaml
+++ b/charts/rollout-operator/templates/servicemonitor.yaml
@@ -8,6 +8,9 @@ metadata:
   {{- end }}
   labels:
     {{- include "rollout-operator.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.serviceMonitor.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
## What this PR does

The rollout-operator chart documents a `serviceMonitor.labels` value (`values.yaml` and `README.md`, "Additional ServiceMonitor labels"), but the ServiceMonitor template never rendered it — so any labels set there were silently ignored.

This merges `serviceMonitor.labels` into the ServiceMonitor `metadata.labels` block, following the same `{{- with ... }}` / `toYaml | nindent` pattern already used for `serviceMonitor.annotations`. User-provided labels render last so they can extend (or override) the common chart labels.

This is commonly needed so the Prometheus Operator's `serviceMonitorSelector` (e.g. `release: kube-prometheus-stack`) can discover the ServiceMonitor.

## Changes
- `templates/servicemonitor.yaml`: render `serviceMonitor.labels` in `metadata.labels`
- `Chart.yaml`: bump chart version `0.50.1` → `0.50.2` (patch, bug fix)

## Verification
```
helm template test charts/rollout-operator \
  --set serviceMonitor.enabled=true \
  --set serviceMonitor.labels.release=kube-prometheus-stack \
  --show-only templates/servicemonitor.yaml
```
Output now contains `release: kube-prometheus-stack` in `metadata.labels`. The default (no labels set) still renders cleanly.
