### PR TITLE
Sign release workflow index updates

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,11 +20,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
@@ -39,14 +34,57 @@ jobs:
           helm repo add hashicorp https://helm.releases.hashicorp.com
           helm repo add minio-new https://charts.min.io
 
+      # skip_upload only skips the action's built-in `cr index --push` step (see cr.sh
+      # in helm/chart-releaser-action); packages are still uploaded as GitHub releases.
+      # The built-in index push creates an unsigned commit on gh-pages, which the
+      # repository ruleset ("Commits must have verified signatures") rejects. Instead,
+      # we regenerate index.yaml below and publish it via the GitHub API, so the commit
+      # is signed by GitHub's web-flow key. This mirrors what update-helm-repo.yaml
+      # (the reusable workflow used by charts living in other repos) already does.
+      # See https://github.com/helm/chart-releaser/issues/625 for upstream tracking.
       - name: Run chart-releaser
+        id: chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
           charts_dir: charts
           config: cr.yaml
+          skip_upload: "true"
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: "true"
+
+      # Merge the freshly uploaded packages into the gh-pages index.yaml. cr writes the
+      # merged file to .cr-index/index.yaml only when the index actually changed; we
+      # stage it at the workspace root for ghcommit-action below.
+      - name: Generate updated index.yaml
+        id: generate-index
+        if: steps.chart-releaser.outputs.changed_charts != ''
+        run: |
+          mkdir -p .cr-index
+          cr index --config cr.yaml -o "${GITHUB_REPOSITORY_OWNER}" -r "${GITHUB_REPOSITORY#*/}" --index-path .cr-index --package-path .cr-release-packages
+          if [[ -f .cr-index/index.yaml ]]; then
+            cp .cr-index/index.yaml index.yaml
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Index is already up to date; nothing to publish"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      # Publish index.yaml to gh-pages via the GitHub GraphQL `createCommitOnBranch`
+      # mutation so the commit is signed by GitHub's web-flow key (shown as Verified),
+      # satisfying the gh-pages ruleset.
+      - name: Publish index.yaml to gh-pages
+        if: steps.generate-index.outputs.changed == 'true'
+        uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20
+        with:
+          commit_message: "Update index.yaml"
+          repo: ${{ github.repository }}
+          branch: gh-pages
+          file_pattern: index.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to GHCR
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0


### PR DESCRIPTION
## Summary

- Skip chart-releaser-action's built-in `cr index --push`, which creates an unsigned commit rejected by the `gh-pages` signed-commits ruleset.
- Regenerate `index.yaml` with `cr index` and publish it with `planetscale/ghcommit-action`, matching the signed commit approach used by `update-helm-repo.yaml`.
- Keep package upload behavior unchanged; only the index publishing path changes.

Made with [Cursor](https://cursor.com)