### PR TITLE
chore: Update index.yaml For New Alloy Helm Release v1.11.0

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -2,6 +2,22 @@ apiVersion: v1
 entries:
   alloy:
   - apiVersion: v2
+    appVersion: v1.18.0
+    created: "2026-07-20T16:37:13Z"
+    dependencies:
+    - condition: crds.create
+      name: crds
+      repository: ""
+      version: 0.0.0
+    description: Grafana Alloy
+    digest: 11d253b62e47beeacd89eb4283fc056962ecbf143984863c1998be13da0772dd
+    icon: https://raw.githubusercontent.com/grafana/alloy/main/docs/sources/assets/alloy_icon_orange.svg
+    name: alloy
+    type: application
+    urls:
+    - https://github.com/grafana/helm-charts/releases/download/alloy-1.11.0/alloy-1.11.0.tgz
+    version: 1.11.0
+  - apiVersion: v2
     appVersion: v1.17.1
     created: "2026-06-30T01:57:32Z"
     dependencies:


### PR DESCRIPTION
The corresponding [github action](https://github.com/grafana/alloy/actions/runs/29760295454/job/88413047327) failed that's supposed to do this automatically, so this PR bumps the change manually 