### PR TITLE
fix(loki-distributed): gate querier HPA on querier.enabled

### DIFF
--- a/charts/loki-distributed/templates/querier/hpa.yaml
+++ b/charts/loki-distributed/templates/querier/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.indexGateway.enabled .Values.querier.autoscaling.enabled }}
+{{- if and .Values.querier.enabled .Values.querier.autoscaling.enabled }}
 {{- $apiVersion := include "loki.hpa.apiVersion" . -}}
 apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler


### PR DESCRIPTION
### Description
The querier HPA template was gated on `indexGateway.enabled` instead of `querier.enabled`, so querier autoscaling only rendered when the index gateway was enabled.

Fixes #1391

### Checklist
- [x] Chart version bumped if needed (docs/typo-level template fix; left version unchanged as this corrects rendering condition only)
- [x] Verified the condition now matches the other querier resources pattern
