### PR TITLE
fix: correct shared workflow action tag comments

### DIFF
--- a/.github/workflows/publish-public-signing-key.yaml
+++ b/.github/workflows/publish-public-signing-key.yaml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Fetch public signing key from Vault
-        uses: grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760 # v1.1.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760 # get-vault-secrets-v1.1.0
         with:
           repo_secrets: |
             PUBLIC_KEY=helm-chart-signing-key:public_key

--- a/.github/workflows/update-helm-repo.yaml
+++ b/.github/workflows/update-helm-repo.yaml
@@ -124,7 +124,7 @@ jobs:
       - name: Retrieve GitHub App credentials from Vault
         if: inputs.github_app == '' && env.VAULT_REPO_SECRET_NAME != ''
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760 # v1.1.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760 # get-vault-secrets-v1.1.0
         with:
           repo_secrets: |
             GITHUB_APP_ID=${{ env.VAULT_REPO_SECRET_NAME }}:app-id
@@ -250,7 +250,7 @@ jobs:
 
       - name: Fetch GPG signing key from Vault
         if: steps.signing.outputs.enabled == 'true'
-        uses: grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760 # v1.1.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760 # get-vault-secrets-v1.1.0
         with:
           repo_secrets: |
             GPG_PRIVATE_KEY=helm-chart-signing-key:private_key


### PR DESCRIPTION
## What changed

Update three `get-vault-secrets` comments to the actual historical tag `get-vault-secrets-v1.1.0`.

## Why

The bare version comments omit the shared-workflows monorepo component name, preventing Renovate from identifying the correct tag namespace and causing lookup failures. This repository uses the historical hyphenated release tag; the pinned SHA was verified against that exact tag.

## Validation

- Verified `get-vault-secrets-v1.1.0` resolves to the pinned SHA.
- `actionlint` on changed workflows (pre-existing shellcheck diagnostics excluded)
- `git diff --check`

Related to grafana/shared-workflows#2255
