### PR TITLE
[loki-stack] Revise deprecation notice in README.md

### DIFF
--- a/charts/loki-stack/README.md
+++ b/charts/loki-stack/README.md
@@ -2,7 +2,7 @@
 
 **This chart is deprecated and will no longer receive updates or support.**
 
-Please consider using the [loki](https://github.com/grafana/loki/tree/main/production/helm/loki)
+Please consider using the Community maintained [Loki](https://github.com/grafana-community/helm-charts/tree/main/charts/loki)
 chart instead, which provides comprehensive features and ongoing maintenance.
 
 # Loki-Stack Helm Chart


### PR DESCRIPTION
Updated deprecation notice to refer to the community maintained Loki chart.

This update was prompted by https://github.com/grafana/loki/issues/23964.